### PR TITLE
Delete tables from data.all when they are deleted in Glue

### DIFF
--- a/backend/dataall/api/Objects/Dataset/resolvers.py
+++ b/backend/dataall/api/Objects/Dataset/resolvers.py
@@ -305,6 +305,9 @@ def sync_tables(context: Context, source, datasetUri: str = None):
         indexers.upsert_dataset_tables(
             session=session, es=context.es, datasetUri=dataset.datasetUri
         )
+        indexers.remove_deleted_tables(
+            session=session, es=context.es, datasetUri=dataset.datasetUri
+        )
         return Dataset.paginated_dataset_tables(
             session=session,
             username=context.username,

--- a/backend/dataall/db/api/dataset.py
+++ b/backend/dataall/db/api/dataset.py
@@ -287,7 +287,12 @@ class Dataset:
     ) -> dict:
         query = (
             session.query(models.DatasetTable)
-            .filter(models.DatasetTable.datasetUri == uri)
+            .filter(
+                and_(
+                    models.DatasetTable.datasetUri == uri,
+                    models.DatasetTable.LastGlueTableStatus != 'Deleted',
+                )
+            )
             .order_by(models.DatasetTable.created.desc())
         )
         if data and data.get('term'):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
This PR deletes tables in data.all (hide them in data.all console and delete them from the opensearch cluster) when if they are deleted in Glue

### Relates
https://github.com/awslabs/aws-dataall/issues/81

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
