### PR TITLE
update auth-at-edge semantic version to latest 2.1.5

### DIFF
--- a/deploy/stacks/auth_at_edge.py
+++ b/deploy/stacks/auth_at_edge.py
@@ -23,7 +23,7 @@ class AuthAtEdge(pyNestedClass):
             f'{resource_prefix}-{envname}-authatedge',
             location={
                 'applicationId': 'arn:aws:serverlessrepo:us-east-1:520945424137:applications/cloudfront-authorization-at-edge',
-                'semanticVersion': '2.0.4',
+                'semanticVersion': '2.1.5',
             },
             parameters={
                 'UserPoolArn': userpool_arn,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Custom resources created by the [cloudfront-authorization-at-edge](https://github.com/aws-samples/cloudfront-authorization-at-edge/blob/master/example-serverless-app-reuse/README.md) application used in data.all use node12 for the version of the application previously used (2.0.4). By upgrading to the latest version (2.1.5) the Lambda custom resources used also use node14 at runtime.

After upgrading the semantic version, I performed the following tests:

- [X] upgrade a pre-existing deployment (Lambdas node12) and check that the runtime has been updated to node14. See screenshot below.
- [X] open userguide (where auth at edge is used) in pre-existing deployment
- [X] execute GraphQL APIs in pre-existing deployment
- [X] execute ES APIs in pre-existing deployment

![image](https://github.com/awslabs/aws-dataall/assets/71252798/4d50a8fb-0084-48ee-adb8-d11b20dd6b4a)

- [X] deploy data.all from scratch and check that the Lambdas deployed use node14
- [X] open userguide (where auth at edge is used) in new deployment
- [X] execute GraphQL APIs in new deployment
- [X] execute ES APIs in new deployment

![image](https://github.com/awslabs/aws-dataall/assets/71252798/341124bd-c4c7-4a94-b53b-e451306e2653)

### Relates
- #479 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
