### PR TITLE
Fixing issue 949: validate consumer roles

### DIFF
--- a/backend/dataall/base/aws/iam.py
+++ b/backend/dataall/base/aws/iam.py
@@ -20,6 +20,7 @@ class IAM:
             response = iamcli.get_role(
                 RoleName=role_arn.split("/")[-1]
             )
+            assert response['Role']['Arn'] == role_arn, "Arn doesn't match the role name. Check Arn and try again."
         except Exception as e:
             log.error(
                 f'Failed to get role {role_arn} due to: {e}'


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix


### Detail
Check if role ARN matches the role name (boto3 get_role works by name, not by arn)

### Relates

https://github.com/data-dot-all/dataall/issues/949

### Security

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?N/A
  - Are you logging failed auth attempts?N/A
- Are you using or adding any cryptographic features?N/A
  - Do you use a standard proven implementations?N/A
  - Are the used keys controlled by the customer? Where are they stored?N/A
- Are you introducing any new policies/roles/users?N/A
  - Have you used the least-privilege principle? How?N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
