### PR TITLE
modify ash on workflow - in PRs and push to main

### DIFF
--- a/.github/workflows/ash.yml
+++ b/.github/workflows/ash.yml
@@ -2,6 +2,15 @@ name: ASH
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - release/*
+      - main-v2
+      - v2m*
 
 permissions:
   contents: read


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
Modify ash github workflow to run on pushes to `main` and on PRs to selected branches
Ash stands for automated-security-helper and it is a tool owned by AWS that runs multiple security open-source frameworks, including checkov

### Relates
- #881 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).
`n/a` this feature actually increases security as it adds more tests for Git actions

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
