### PR TITLE
Remove unused packages: jinja2, deprecated

### DIFF
--- a/backend/dataall/base/cdkproxy/requirements.txt
+++ b/backend/dataall/base/cdkproxy/requirements.txt
@@ -11,7 +11,7 @@ PyYAML==6.0
 requests==2.31.0
 tabulate==0.8.9
 uvicorn==0.15.0
-jinja2==3.1.2
+jinja2==3.1.3
 werkzeug==3.0.1
 constructs>=10.0.0,<11.0.0
 git-remote-codecommit==1.16

--- a/backend/dataall/base/cdkproxy/requirements.txt
+++ b/backend/dataall/base/cdkproxy/requirements.txt
@@ -11,9 +11,7 @@ PyYAML==6.0
 requests==2.31.0
 tabulate==0.8.9
 uvicorn==0.15.0
-jinja2==3.1.3
 werkzeug==3.0.1
 constructs>=10.0.0,<11.0.0
 git-remote-codecommit==1.16
 aws-ddk-core==1.3.0
-deprecated==1.2.13

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,4 +15,3 @@ requests==2.31.0
 requests_aws4auth==1.1.1
 sqlalchemy==1.3.24
 starlette==0.27.0
-deprecated==1.2.13

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,4 +4,3 @@ pytest-cov==3.0.0
 pytest-mock==3.6.1
 pytest-dependency==0.5.1
 werkzeug==3.0.1
-deprecated==1.2.13


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Remove unused jinja2 ---> it was used in an old version of data pipelines
- Remove unused deprecated --> it was used during development of v2

### Relates

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
