### PR TITLE
Fix: Added lakeformation in trust policy of dataset role

### DIFF
--- a/backend/dataall/modules/datasets/cdk/dataset_stack.py
+++ b/backend/dataall/modules/datasets/cdk/dataset_stack.py
@@ -382,6 +382,7 @@ class DatasetStack(Stack):
                     f'arn:aws:iam::{dataset.AwsAccountId}:role/{self.pivot_role_name}'
                 ),
                 iam.ServicePrincipal('glue.amazonaws.com'),
+                iam.ServicePrincipal('lakeformation.amazonaws.com'),
             ),
         )
         dataset_admin_policy.attach_to_role(dataset_admin_role)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Added missing LakeFormation assume role permissions to dataset role. This permissions are needed to delegate data access to Lake Formation because we register the data location with the dataset role.

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
