### PR TITLE
Bug fix - 948 | Added else if condition to get tables into InSync state

### DIFF
--- a/backend/dataall/modules/datasets/db/dataset_table_repositories.py
+++ b/backend/dataall/modules/datasets/db/dataset_table_repositories.py
@@ -93,7 +93,12 @@ class DatasetTableRepository:
             if existing_table.GlueTableName not in [t['Name'] for t in glue_tables]:
                 existing_table.LastGlueTableStatus = 'Deleted'
                 logger.info(
-                    f'Table {existing_table.GlueTableName} status set to Deleted from Glue.'
+                    f'Existing Table {existing_table.GlueTableName} status set to Deleted from Glue'
+                )
+            elif existing_table.GlueTableName in [t['Name'] for t in glue_tables] and existing_table.LastGlueTableStatus == 'Deleted':
+                existing_table.LastGlueTableStatus = 'InSync'
+                logger.info(
+                    f'Updating Existing Table {existing_table.GlueTableName} status set to InSync from Deleted after found in Glue'
                 )
 
     @staticmethod


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail

- Added else if condition for getting the glue tables which exist on the AWS account and also present in RDS dataset tables set the `LastGlueTableStatus` to `InSync`. 

### Testing 

1. Created a dataset with tables
2. Marked the dataset tables `LastGlueTableStatus` to `Deleted`.
3. Checked if the table are now NOT displayed. 
4. Deployed data.all with this fix
5. Now the dataset tables are present on the UI. 

### Relates

- https://github.com/data-dot-all/dataall/issues/979

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization? No
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms? 
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? No
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users? No
  - Have you used the least-privilege principle? How? 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
