### PR TITLE
Replace dataall prefix by resourcePrefix in data pipeline creation

### DIFF
--- a/backend/dataall/modules/datapipelines/cdk/datapipelines_cdk_pipeline.py
+++ b/backend/dataall/modules/datapipelines/cdk/datapipelines_cdk_pipeline.py
@@ -67,7 +67,7 @@ class CDKPipelineStack:
                     )
                 )
                 CDKPipelineStack.write_ddk_json_multienvironment(path=os.path.join(self.code_dir_path, self.pipeline.repo), output_file="ddk.json", pipeline_environment=self.pipeline_environment, development_environments=self.development_environments, pipeline_name=self.pipeline.name)
-                CDKPipelineStack.write_ddk_app_multienvironment(path=os.path.join(self.code_dir_path, self.pipeline.repo), output_file="app.py", pipeline=self.pipeline, development_environments=self.development_environments)
+                CDKPipelineStack.write_ddk_app_multienvironment(path=os.path.join(self.code_dir_path, self.pipeline.repo), output_file="app.py", pipeline=self.pipeline, development_environments=self.development_environments, pipeline_environment=self.pipeline_environment)
 
                 logger.info(f"Pipeline Repo {self.pipeline.repo} Exists...Handling Update")
                 update_cmds = [
@@ -94,7 +94,7 @@ class CDKPipelineStack:
                 raise Exception
         except Exception as e:
             self.initialize_repo()
-            CDKPipelineStack.write_ddk_app_multienvironment(path=os.path.join(self.code_dir_path, self.pipeline.repo), output_file="app.py", pipeline=self.pipeline, development_environments=self.development_environments)
+            CDKPipelineStack.write_ddk_app_multienvironment(path=os.path.join(self.code_dir_path, self.pipeline.repo), output_file="app.py", pipeline=self.pipeline, development_environments=self.development_environments, pipeline_environment=self.pipeline_environment)
             CDKPipelineStack.write_ddk_json_multienvironment(path=os.path.join(self.code_dir_path, self.pipeline.repo), output_file="ddk.json", pipeline_environment=self.pipeline_environment, development_environments=self.development_environments, pipeline_name=self.pipeline.name)
             self.git_push_repo()
 
@@ -157,7 +157,7 @@ class CDKPipelineStack:
             print(json, file=text_file)
 
     @staticmethod
-    def write_ddk_app_multienvironment(path, output_file, pipeline, development_environments):
+    def write_ddk_app_multienvironment(path, output_file, pipeline, development_environments, pipeline_environment):
         header = f"""
 # !/usr/bin/env python3
 
@@ -177,7 +177,7 @@ class ApplicationStage(cdk.Stage):
         super().__init__(scope, f"dataall-{{environment_id.title()}}", **kwargs)
         DataallPipelineStack(self, "{pipeline.name}-DataallPipelineStack", environment_id)
 
-id = f"dataall-cdkpipeline-{pipeline.DataPipelineUri}"
+id = f"{pipeline_environment.resourcePrefix}-cdkpipeline-{pipeline.DataPipelineUri}"
 cicd_pipeline = (
     ddk.CICDPipelineStack(
         app,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- fix name reference that was using hardcoded "dataall" and instead use environment resource prefix. Solves: #666 

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
