### PR TITLE
925 datasets auto approval

### DIFF
--- a/backend/dataall/modules/dataset_sharing/services/share_object_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_object_service.py
@@ -247,7 +247,6 @@ class ShareObjectService:
             session.add(approve_share_task)
 
         Worker.queue(engine=context.db_engine, task_ids=[approve_share_task.taskUri])
-        print('Hurray!')
         return share
 
     @staticmethod

--- a/backend/dataall/modules/dataset_sharing/services/share_object_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_object_service.py
@@ -195,6 +195,17 @@ class ShareObjectService:
                 share=share
             ).notify_share_object_submission(email_id=context.username)
 
+            # if parent dataset has auto-approve flag, we trigger the next transition to approved state
+            if dataset.autoApprovalEnabled:
+                ResourcePolicy.attach_resource_policy(
+                    session=session,
+                    group=share.groupUri,
+                    permissions=SHARE_OBJECT_APPROVER,
+                    resource_uri=share.shareUri,
+                    resource_type=ShareObject.__name__,
+                )
+                share = cls.approve_share_object(uri=share.shareUri)
+
             return share
 
     @classmethod
@@ -236,7 +247,7 @@ class ShareObjectService:
             session.add(approve_share_task)
 
         Worker.queue(engine=context.db_engine, task_ids=[approve_share_task.taskUri])
-
+        print('Hurray!')
         return share
 
     @staticmethod

--- a/backend/dataall/modules/datasets/api/dataset/input_types.py
+++ b/backend/dataall/modules/datasets/api/dataset/input_types.py
@@ -39,6 +39,7 @@ ModifyDatasetInput = gql.InputType(
         gql.Argument('confidentiality', gql.Ref('ConfidentialityClassification')),
         gql.Argument(name='stewards', type=gql.String),
         gql.Argument('KmsAlias', gql.NonNullableType(gql.String)),
+        gql.Argument(name='autoApprovalEnabled', type=gql.Boolean)
     ],
 )
 
@@ -104,5 +105,7 @@ ImportDatasetInput = gql.InputType(
         ),
         gql.Argument('confidentiality', gql.Ref('ConfidentialityClassification')),
         gql.Argument(name='stewards', type=gql.String),
+        gql.Argument(name='autoApprovalEnabled', type=gql.Boolean)
+
     ],
 )

--- a/backend/dataall/modules/datasets/api/dataset/input_types.py
+++ b/backend/dataall/modules/datasets/api/dataset/input_types.py
@@ -21,6 +21,7 @@ NewDatasetInput = gql.InputType(
         ),
         gql.Argument('confidentiality', gql.Ref('ConfidentialityClassification')),
         gql.Argument(name='stewards', type=gql.String),
+        gql.Argument(name='autoApprovalEnabled', type=gql.Boolean)
     ],
 )
 

--- a/backend/dataall/modules/datasets/api/dataset/types.py
+++ b/backend/dataall/modules/datasets/api/dataset/types.py
@@ -150,6 +150,7 @@ Dataset = gql.ObjectType(
             type=gql.Boolean,
         ),
         gql.Field(name='stack', type=gql.Ref('Stack'), resolver=get_dataset_stack),
+        gql.Field(name='autoApprovalEnabled', type=gql.Boolean),
     ],
 )
 

--- a/backend/dataall/modules/datasets/services/dataset_service.py
+++ b/backend/dataall/modules/datasets/services/dataset_service.py
@@ -132,6 +132,7 @@ class DatasetService:
                     resource_uri=dataset.datasetUri,
                     resource_type=Dataset.__name__,
                 )
+
             if environment.SamlGroupName != dataset.SamlAdminGroupName:
                 ResourcePolicy.attach_resource_policy(
                     session=session,

--- a/backend/dataall/modules/datasets_base/db/dataset_models.py
+++ b/backend/dataall/modules/datasets_base/db/dataset_models.py
@@ -138,6 +138,8 @@ class Dataset(Resource, Base):
     importedAdminRole = Column(Boolean, default=False)
     imported = Column(Boolean, default=False)
 
+    autoApprovalEnabled = Column(Boolean, default=False)
+
     @classmethod
     def uri(cls):
         return cls.datasetUri

--- a/backend/dataall/modules/datasets_base/db/dataset_repositories.py
+++ b/backend/dataall/modules/datasets_base/db/dataset_repositories.py
@@ -50,6 +50,7 @@ class DatasetRepository(EnvironmentResource):
             stewards=data.get('stewards')
             if data.get('stewards')
             else data['SamlAdminGroupName'],
+            autoApprovalEnabled=data.get('autoApprovalEnabled', False),
         )
         cls._set_dataset_aws_resources(dataset, data, env)
         cls._set_import_data(dataset, data)
@@ -177,7 +178,7 @@ class DatasetRepository(EnvironmentResource):
         ).to_dict()
 
     @staticmethod
-    def update_dataset_activity(session, dataset, username) :
+    def update_dataset_activity(session, dataset, username):
         activity = Activity(
             action='dataset:update',
             label='dataset:update',

--- a/backend/migrations/versions/f6cd4ba7dd8d__dataset_autoapproval_field.py
+++ b/backend/migrations/versions/f6cd4ba7dd8d__dataset_autoapproval_field.py
@@ -1,0 +1,23 @@
+"""_dataset_autoapproval_field
+
+Revision ID: f6cd4ba7dd8d
+Revises: 71a5f5de322f
+Create Date: 2024-01-16 13:49:29.527312
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'f6cd4ba7dd8d'
+down_revision = '71a5f5de322f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('dataset', sa.Column('autoApprovalEnabled', sa.Boolean(), default=False))
+
+
+def downgrade():
+    op.drop_column('dataset', 'autoApprovalEnabled')

--- a/frontend/src/modules/Datasets/components/DatasetGovernance.js
+++ b/frontend/src/modules/Datasets/components/DatasetGovernance.js
@@ -40,6 +40,16 @@ export const DatasetGovernance = (props) => {
       </CardContent>
       <CardContent>
         <Typography color="textSecondary" variant="subtitle2">
+          Auto-Approval
+        </Typography>
+        <Box sx={{ mt: 1 }}>
+          <Label color="primary">
+            {dataset.autoApprovalEnabled ? 'Enabled' : 'Disabled'}
+          </Label>
+        </Box>
+      </CardContent>
+      <CardContent>
+        <Typography color="textSecondary" variant="subtitle2">
           Classification
         </Typography>
         <Box sx={{ mt: 1 }}>

--- a/frontend/src/modules/Datasets/views/DatasetCreateForm.js
+++ b/frontend/src/modules/Datasets/views/DatasetCreateForm.js
@@ -14,6 +14,7 @@ import {
   Grid,
   Link,
   MenuItem,
+  Switch,
   TextField,
   Typography
 } from '@mui/material';
@@ -53,6 +54,7 @@ const DatasetCreateForm = (props) => {
     'Official',
     'Secret'
   ]);
+
 
   const topicsData = Topics.map((t) => ({ label: t, value: t }));
 
@@ -106,6 +108,10 @@ const DatasetCreateForm = (props) => {
     }
   }, [client, fetchEnvironments, dispatch]);
 
+  function  test(x){
+    console.log(x);
+  }
+
   async function submit(values, setStatus, setSubmitting, setErrors) {
     try {
       const response = await client.mutate(
@@ -119,7 +125,8 @@ const DatasetCreateForm = (props) => {
           tags: values.tags,
           description: values.description,
           topics: values.topics ? values.topics.map((t) => t.value) : [],
-          confidentiality: values.confidentiality
+          confidentiality: values.confidentiality,
+          autoApprovalEnabled: values.autoApprovalEnabled
         })
       );
       if (!response.errors) {
@@ -214,7 +221,8 @@ const DatasetCreateForm = (props) => {
                 confidentiality: '',
                 SamlGroupName: '',
                 tags: [],
-                topics: []
+                topics: [],
+                autoApprovalEnabled: false
               }}
               validationSchema={Yup.object().shape({
                 label: Yup.string()
@@ -230,7 +238,9 @@ const DatasetCreateForm = (props) => {
                 stewards: Yup.string().max(255).nullable(),
                 confidentiality: Yup.string()
                   .max(255)
-                  .required('*Confidentiality is required')
+                  .required('*Confidentiality is required'),
+                autoApprovalEnabled: Yup.boolean()
+                  .required('*AutoApproval property is required'),
               })}
               onSubmit={async (
                 values,
@@ -263,7 +273,6 @@ const DatasetCreateForm = (props) => {
                             name="label"
                             onBlur={handleBlur}
                             onChange={handleChange}
-                            value={values.label}
                             variant="outlined"
                           />
                         </CardContent>
@@ -300,7 +309,7 @@ const DatasetCreateForm = (props) => {
                           )}
                         </CardContent>
                       </Card>
-                      <Card sx={{ mt: 3 }}>
+                      <Card sx={{ mt: 4 }}>
                         <CardHeader title="Classification" />
                         <CardContent>
                           <TextField
@@ -367,6 +376,26 @@ const DatasetCreateForm = (props) => {
                               }}
                             />
                           </Box>
+                        </CardContent>
+                        <CardContent>
+                          <TextField
+                            fullWidth
+                            label="Auto Approval"
+                            name="autoApprovalEnabled"
+                            onChange={handleChange}
+                            select
+                            value={values.autoApprovalEnabled}
+                            variant="outlined"
+                          >
+
+                              <MenuItem key={'Enabled'} value={true}>
+                                Enabled
+                              </MenuItem>
+                            <MenuItem key={'Enabled'} value={false}>
+                              Disabled
+                            </MenuItem>
+
+                          </TextField>
                         </CardContent>
                       </Card>
                     </Grid>

--- a/frontend/src/modules/Datasets/views/DatasetCreateForm.js
+++ b/frontend/src/modules/Datasets/views/DatasetCreateForm.js
@@ -14,7 +14,6 @@ import {
   Grid,
   Link,
   MenuItem,
-  Switch,
   TextField,
   Typography
 } from '@mui/material';
@@ -54,7 +53,6 @@ const DatasetCreateForm = (props) => {
     'Official',
     'Secret'
   ]);
-
 
   const topicsData = Topics.map((t) => ({ label: t, value: t }));
 
@@ -107,10 +105,6 @@ const DatasetCreateForm = (props) => {
       );
     }
   }, [client, fetchEnvironments, dispatch]);
-
-  function  test(x){
-    console.log(x);
-  }
 
   async function submit(values, setStatus, setSubmitting, setErrors) {
     try {
@@ -239,8 +233,9 @@ const DatasetCreateForm = (props) => {
                 confidentiality: Yup.string()
                   .max(255)
                   .required('*Confidentiality is required'),
-                autoApprovalEnabled: Yup.boolean()
-                  .required('*AutoApproval property is required'),
+                autoApprovalEnabled: Yup.boolean().required(
+                  '*AutoApproval property is required'
+                )
               })}
               onSubmit={async (
                 values,
@@ -387,14 +382,12 @@ const DatasetCreateForm = (props) => {
                             value={values.autoApprovalEnabled}
                             variant="outlined"
                           >
-
-                              <MenuItem key={'Enabled'} value={true}>
-                                Enabled
-                              </MenuItem>
+                            <MenuItem key={'Enabled'} value={true}>
+                              Enabled
+                            </MenuItem>
                             <MenuItem key={'Enabled'} value={false}>
                               Disabled
                             </MenuItem>
-
                           </TextField>
                         </CardContent>
                       </Card>

--- a/frontend/src/modules/Datasets/views/DatasetEditForm.js
+++ b/frontend/src/modules/Datasets/views/DatasetEditForm.js
@@ -155,7 +155,9 @@ const DatasetEditForm = (props) => {
               ? values.terms.nodes.map((t) => t.nodeUri)
               : values.terms.map((t) => t.nodeUri),
             confidentiality: values.confidentiality,
-            KmsAlias: values.KmsAlias
+            KmsAlias: values.KmsAlias,
+            autoApprovalEnabled: values.autoApprovalEnabled
+
           }
         })
       );
@@ -261,7 +263,9 @@ const DatasetEditForm = (props) => {
                 terms: dataset.terms || [],
                 stewards: dataset.stewards,
                 confidentiality: dataset.confidentiality,
-                KmsAlias: dataset.KmsAlias
+                KmsAlias: dataset.KmsAlias,
+                autoApprovalEnabled: dataset.autoApprovalEnabled
+
               }}
               validationSchema={Yup.object().shape({
                 label: Yup.string()
@@ -273,7 +277,9 @@ const DatasetEditForm = (props) => {
                 tags: Yup.array().min(1).required('*Tags are required'),
                 confidentiality: Yup.string().required(
                   '*Confidentiality is required'
-                )
+                ),
+                autoApprovalEnabled: Yup.boolean()
+                  .required('*AutoApproval property is required'),
               })}
               onSubmit={async (
                 values,
@@ -452,6 +458,26 @@ const DatasetEditForm = (props) => {
                               }}
                             />
                           </Box>
+                        </CardContent>
+                        <CardContent>
+                          <TextField
+                            fullWidth
+                            label="Auto Approval"
+                            name="autoApprovalEnabled"
+                            onChange={handleChange}
+                            select
+                            value={values.autoApprovalEnabled}
+                            variant="outlined"
+                          >
+
+                            <MenuItem key={'Enabled'} value={true}>
+                              Enabled
+                            </MenuItem>
+                            <MenuItem key={'Enabled'} value={false}>
+                              Disabled
+                            </MenuItem>
+
+                          </TextField>
                         </CardContent>
                       </Card>
                     </Grid>

--- a/frontend/src/modules/Datasets/views/DatasetEditForm.js
+++ b/frontend/src/modules/Datasets/views/DatasetEditForm.js
@@ -157,7 +157,6 @@ const DatasetEditForm = (props) => {
             confidentiality: values.confidentiality,
             KmsAlias: values.KmsAlias,
             autoApprovalEnabled: values.autoApprovalEnabled
-
           }
         })
       );
@@ -265,7 +264,6 @@ const DatasetEditForm = (props) => {
                 confidentiality: dataset.confidentiality,
                 KmsAlias: dataset.KmsAlias,
                 autoApprovalEnabled: dataset.autoApprovalEnabled
-
               }}
               validationSchema={Yup.object().shape({
                 label: Yup.string()
@@ -278,8 +276,9 @@ const DatasetEditForm = (props) => {
                 confidentiality: Yup.string().required(
                   '*Confidentiality is required'
                 ),
-                autoApprovalEnabled: Yup.boolean()
-                  .required('*AutoApproval property is required'),
+                autoApprovalEnabled: Yup.boolean().required(
+                  '*AutoApproval property is required'
+                )
               })}
               onSubmit={async (
                 values,
@@ -469,14 +468,12 @@ const DatasetEditForm = (props) => {
                             value={values.autoApprovalEnabled}
                             variant="outlined"
                           >
-
                             <MenuItem key={'Enabled'} value={true}>
                               Enabled
                             </MenuItem>
                             <MenuItem key={'Enabled'} value={false}>
                               Disabled
                             </MenuItem>
-
                           </TextField>
                         </CardContent>
                       </Card>

--- a/frontend/src/modules/Datasets/views/DatasetImportForm.js
+++ b/frontend/src/modules/Datasets/views/DatasetImportForm.js
@@ -224,7 +224,7 @@ const DatasetImportForm = (props) => {
                 bucketName: '',
                 KmsKeyAlias: '',
                 confidentiality: '',
-                autoApprovalEnabled: false,
+                autoApprovalEnabled: false
               }}
               validationSchema={Yup.object().shape({
                 label: Yup.string()
@@ -245,8 +245,9 @@ const DatasetImportForm = (props) => {
                 confidentiality: Yup.string()
                   .max(255)
                   .required('*Confidentiality is required'),
-                autoApprovalEnabled: Yup.boolean()
-                  .required('*AutoApproval property is required'),
+                autoApprovalEnabled: Yup.boolean().required(
+                  '*AutoApproval property is required'
+                )
               })}
               onSubmit={async (
                 values,
@@ -394,14 +395,12 @@ const DatasetImportForm = (props) => {
                             value={values.autoApprovalEnabled}
                             variant="outlined"
                           >
-
                             <MenuItem key={'Enabled'} value={true}>
                               Enabled
                             </MenuItem>
                             <MenuItem key={'Enabled'} value={false}>
                               Disabled
                             </MenuItem>
-
                           </TextField>
                         </CardContent>
                       </Card>

--- a/frontend/src/modules/Datasets/views/DatasetImportForm.js
+++ b/frontend/src/modules/Datasets/views/DatasetImportForm.js
@@ -122,7 +122,8 @@ const DatasetImportForm = (props) => {
           KmsKeyAlias: values.KmsKeyAlias,
           glueDatabaseName: values.glueDatabaseName,
           stewards: values.stewards,
-          confidentiality: values.confidentiality
+          confidentiality: values.confidentiality,
+          autoApprovalEnabled: values.autoApprovalEnabled
         })
       );
       if (!response.errors) {
@@ -222,7 +223,8 @@ const DatasetImportForm = (props) => {
                 glueDatabaseName: '',
                 bucketName: '',
                 KmsKeyAlias: '',
-                confidentiality: ''
+                confidentiality: '',
+                autoApprovalEnabled: false,
               }}
               validationSchema={Yup.object().shape({
                 label: Yup.string()
@@ -242,7 +244,9 @@ const DatasetImportForm = (props) => {
                   .required('*S3 bucket name is required'),
                 confidentiality: Yup.string()
                   .max(255)
-                  .required('*Confidentiality is required')
+                  .required('*Confidentiality is required'),
+                autoApprovalEnabled: Yup.boolean()
+                  .required('*AutoApproval property is required'),
               })}
               onSubmit={async (
                 values,
@@ -379,6 +383,26 @@ const DatasetImportForm = (props) => {
                               }}
                             />
                           </Box>
+                        </CardContent>
+                        <CardContent>
+                          <TextField
+                            fullWidth
+                            label="Auto Approval"
+                            name="autoApprovalEnabled"
+                            onChange={handleChange}
+                            select
+                            value={values.autoApprovalEnabled}
+                            variant="outlined"
+                          >
+
+                            <MenuItem key={'Enabled'} value={true}>
+                              Enabled
+                            </MenuItem>
+                            <MenuItem key={'Enabled'} value={false}>
+                              Disabled
+                            </MenuItem>
+
+                          </TextField>
                         </CardContent>
                       </Card>
                     </Grid>

--- a/frontend/src/services/graphql/Datasets/getDataset.js
+++ b/frontend/src/services/graphql/Datasets/getDataset.js
@@ -41,6 +41,7 @@ export const getDataset = (datasetUri) => ({
         topics
         language
         confidentiality
+        autoApprovalEnabled
         organization {
           organizationUri
           label

--- a/tests/modules/datasets/conftest.py
+++ b/tests/modules/datasets/conftest.py
@@ -45,7 +45,8 @@ def dataset(client, patch_es, patch_dataset_methods):
         name: str,
         owner: str,
         group: str,
-        confidentiality: str = None
+        confidentiality: str = None,
+        autoApprovalEnabled: bool = False
     ) -> Dataset:
         key = f'{org.organizationUri}-{env.environmentUri}-{name}-{group}'
         if cache.get(key):
@@ -95,6 +96,7 @@ def dataset(client, patch_es, patch_dataset_methods):
                     topics
                     language
                     confidentiality
+                    autoApprovalEnabled
                     organization{
                         organizationUri
                         label
@@ -149,7 +151,8 @@ def dataset(client, patch_es, patch_dataset_methods):
                 'environmentUri': env.environmentUri,
                 'SamlAdminGroupName': group or random_group(),
                 'organizationUri': org.organizationUri,
-                'confidentiality': confidentiality or ConfidentialityClassification.Unclassified.value
+                'confidentiality': confidentiality or ConfidentialityClassification.Unclassified.value,
+                'autoApprovalEnabled': autoApprovalEnabled
 
             },
         )
@@ -267,7 +270,8 @@ def dataset_model(db):
     def factory(
         organization: Organization,
         environment: Environment,
-        label: str
+        label: str,
+        autoApprovalEnabled: bool = False
     ) -> Dataset:
         with db.scoped_session() as session:
             dataset = Dataset(
@@ -286,6 +290,7 @@ def dataset_model(db):
                 region=environment.region,
                 IAMDatasetAdminUserArn=f"arn:aws:iam::{environment.AwsAccountId}:user/dataset",
                 IAMDatasetAdminRoleArn=f"arn:aws:iam::{environment.AwsAccountId}:role/dataset",
+                autoApprovalEnabled = autoApprovalEnabled
             )
             session.add(dataset)
             session.commit()

--- a/tests/modules/datasets/tasks/conftest.py
+++ b/tests/modules/datasets/tasks/conftest.py
@@ -13,7 +13,8 @@ def create_dataset(db):
         organization: Organization,
         environment: Environment,
         label: str,
-        imported: bool = False
+        imported: bool = False,
+        autoApprovalEnabled: bool = False,
     ) -> Dataset:
         with db.scoped_session() as session:
             dataset = Dataset(
@@ -32,7 +33,8 @@ def create_dataset(db):
                 IAMDatasetAdminUserArn=f"arn:aws:iam::{environment.AwsAccountId}:user/dataset",
                 IAMDatasetAdminRoleArn=f"arn:aws:iam::{environment.AwsAccountId}:role/dataset",
                 imported=imported,
-                importedKmsKey=imported
+                importedKmsKey=imported,
+                autoApprovalEnabled=autoApprovalEnabled,
             )
             session.add(dataset)
             session.commit()

--- a/tests/modules/datasets/test_share.py
+++ b/tests/modules/datasets/test_share.py
@@ -133,6 +133,34 @@ def env2group(environment_group: typing.Callable, env2, user2, group2) -> Enviro
     )
 
 
+
+@pytest.fixture(scope='module')
+def dataset3(
+        dataset_model: typing.Callable, org2: Organization, env2: Environment
+) -> Dataset:
+    yield dataset_model(
+        organization=org2,
+        environment=env2,
+        label="datasettoshare3",
+        autoApprovalEnabled=True
+    )
+
+
+@pytest.fixture(scope='module')
+def tables3(table, dataset3):
+    for i in range(1, 100):
+        table(dataset3, name=random_table_name(), username=dataset3.owner)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def table3(table: typing.Callable, dataset3: Dataset) -> DatasetTable:
+    yield table(
+        dataset=dataset3,
+        name="table3",
+        username='bob'
+    )
+
+
 @pytest.fixture(scope='function')
 def share1_draft(
         db,
@@ -196,6 +224,28 @@ def share1_draft(
         shareUri=share1.shareUri
     )
 
+@pytest.fixture(scope='function')
+def share_autoapprove_draft(
+        db,
+        client,
+        user2,
+        group2,
+        share: typing.Callable,
+        dataset3: Dataset,
+        env2: Environment,
+        env2group: EnvironmentGroup,
+) -> ShareObject:
+    share1 = share(
+        dataset=dataset3,
+        environment=env2,
+        env_group=env2group,
+        owner=user2.username,
+        status=ShareObjectStatus.Draft.value
+    )
+
+    yield share1
+
+
 
 @pytest.fixture(scope='function')
 def share1_item_pa(
@@ -207,6 +257,20 @@ def share1_item_pa(
     yield share_item(
         share=share1_draft,
         table=table1,
+        status=ShareItemStatus.PendingApproval.value
+    )
+
+
+@pytest.fixture(scope='function')
+def share_autoapprove_item_pa(
+        share_item: typing.Callable,
+        share_autoapprove_draft: ShareObject,
+        table3: DatasetTable
+) -> ShareObjectItem:
+    # Cleaned up with share1_draft
+    yield share_item(
+        share=share_autoapprove_draft,
+        table=table3,
         status=ShareItemStatus.PendingApproval.value
     )
 
@@ -1194,6 +1258,53 @@ def test_submit_share_request(
     shareItem = get_share_object_response.data.getShareObject.get("items").nodes[0]
     status = shareItem['status']
     assert status == ShareItemStatus.PendingApproval.name
+
+
+def test_submit_share_request_with_auto_approval(
+        client, user2, group2, share_autoapprove_draft, share_autoapprove_item_pa,
+):
+    # Given
+    # Existing share object in status Draft (-> fixture share1_draft)
+    # with existing share item in status Pending Approval (-> fixture share1_item_pa)
+    get_share_object_response = get_share_object(
+        client=client,
+        user=user2,
+        group=group2,
+        shareUri=share_autoapprove_draft.shareUri,
+        filter={"isShared": True}
+    )
+
+    assert get_share_object_response.data.getShareObject.status == ShareObjectStatus.Draft.value
+
+    shareItem = get_share_object_response.data.getShareObject.get("items").nodes[0]
+    assert shareItem.shareItemUri == share_autoapprove_item_pa.shareItemUri
+    assert shareItem.status == ShareItemStatus.PendingApproval.value
+    assert get_share_object_response.data.getShareObject.get("items").count == 1
+
+    # When
+    # Submit share object
+    submit_share_object_response = submit_share_object(
+        client=client,
+        user=user2,
+        group=group2,
+        shareUri=share_autoapprove_draft.shareUri
+    )
+
+    # Then share object status is changed to Submitted
+    assert submit_share_object_response.data.submitShareObject.status == ShareObjectStatus.Approved.name
+    assert submit_share_object_response.data.submitShareObject.userRoleForShareObject == 'ApproversAndRequesters'
+
+    # and share item status stays in PendingApproval
+    get_share_object_response = get_share_object(
+        client=client,
+        user=user2,
+        group=group2,
+        shareUri=share_autoapprove_draft.shareUri,
+        filter={"isShared": True}
+    )
+    shareItem = get_share_object_response.data.getShareObject.get("items").nodes[0]
+    status = shareItem['status']
+    assert status == ShareItemStatus.Share_Approved.name
 
 
 def test_update_share_reject_purpose(client, share2_submitted, user, group):


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature


### Detail
- AutoApprove property was added to UI and API
- If it is True, then the sharing request is approved right after submission

### Relates
https://github.com/data-dot-all/dataall/issues/925

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? Yes
  - Is the input sanitized? No
  - What precautions are you taking before deserializing the data you consume? Default deserialiser is used
  - Is injection prevented by parametrizing queries? YES
  - Have you ensured no `eval` or similar functions are used? N/A
- Does this PR introduce any functionality or component that requires authorization? No
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? No
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users? No
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
