### PR TITLE
[GH-993] - Removing AWS Manged Lake Formation Service Linked Role from Pivot Role Nested Stack

### DIFF
--- a/backend/dataall/core/environment/cdk/pivot_role_stack.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_stack.py
@@ -77,11 +77,6 @@ class PivotRole(NestedStack):
             external_id=config['externalId'],
         )
 
-        # Data.All IAM Lake Formation service role creation
-        self.lf_service_role = iam.CfnServiceLinkedRole(
-            self, 'LakeFormationSLR', aws_service_name='lakeformation.amazonaws.com'
-        )
-
     def create_pivot_role(self, principal_id: str, external_id: str) -> iam.Role:
         """
         Creates an IAM Role that will enable data.all to interact with this Data Account


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail

- Updating code to remove `AWSServiceRoleForLakeFormationDataAccess` role which is created in the pivot role nested stack 

### Testing

1. Deployed code and checked all the environment are in proper state and that this role is removed from AWS account - ✅ 
2. Imported a dataset ( with and without KMS key ) ✅ 
3. Created a dataset ✅ 
4. Created shares for both type of datasets ✅ 
5. Onboarded another environment successfully ✅ 

### Relates
- https://github.com/data-dot-all/dataall/issues/993

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization? N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users? Removing Role
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
