### PR TITLE
Fix created dataset naming convention

### DIFF
--- a/backend/dataall/modules/datasets/services/dataset_service.py
+++ b/backend/dataall/modules/datasets/services/dataset_service.py
@@ -113,6 +113,7 @@ class DatasetService:
                 session=session,
                 env=environment,
                 dataset=dataset,
+                data=data
             )
 
             DatasetBucketRepository.create_dataset_bucket(session, dataset, data)

--- a/backend/dataall/modules/datasets_base/db/dataset_repositories.py
+++ b/backend/dataall/modules/datasets_base/db/dataset_repositories.py
@@ -80,10 +80,10 @@ class DatasetRepository(EnvironmentResource):
         organization = OrganizationRepository.get_organization_by_uri(
             session, env.organizationUri
         )
-
-        cls._set_dataset_aws_resources(dataset, data, env)
         session.add(dataset)
         session.commit()
+
+        cls._set_dataset_aws_resources(dataset, data, env)
 
         activity = Activity(
             action='dataset:create',

--- a/backend/dataall/modules/datasets_base/db/dataset_repositories.py
+++ b/backend/dataall/modules/datasets_base/db/dataset_repositories.py
@@ -115,7 +115,8 @@ class DatasetRepository(EnvironmentResource):
         ).build_compliant_name()
         dataset.GlueDatabaseName = data.get('glueDatabaseName') or glue_db_name
 
-        dataset.KmsAlias = bucket_name
+        if not dataset.imported:
+            dataset.KmsAlias = bucket_name
 
         iam_role_name = NamingConventionService(
             target_uri=dataset.datasetUri,

--- a/backend/dataall/modules/datasets_base/db/dataset_repositories.py
+++ b/backend/dataall/modules/datasets_base/db/dataset_repositories.py
@@ -33,7 +33,7 @@ class DatasetRepository(EnvironmentResource):
             AwsAccountId=env.AwsAccountId,
             SamlAdminGroupName=data['SamlAdminGroupName'],
             region=env.region,
-            S3BucketName='undefined',
+            S3BucketName=data.get('bucketName', 'undefined'),
             GlueDatabaseName='undefined',
             IAMDatasetAdminRoleArn='undefined',
             IAMDatasetAdminUserArn='undefined',
@@ -52,7 +52,7 @@ class DatasetRepository(EnvironmentResource):
             else data['SamlAdminGroupName'],
             autoApprovalEnabled=data.get('autoApprovalEnabled', False),
         )
-        cls._set_dataset_aws_resources(dataset, data, env)
+
         cls._set_import_data(dataset, data)
         return dataset
 
@@ -75,12 +75,13 @@ class DatasetRepository(EnvironmentResource):
             .count()
         )
 
-    @staticmethod
-    def create_dataset(session, env: Environment, dataset: Dataset):
+    @classmethod
+    def create_dataset(cls, session, env: Environment, dataset: Dataset, data: dict):
         organization = OrganizationRepository.get_organization_by_uri(
             session, env.organizationUri
         )
 
+        cls._set_dataset_aws_resources(dataset, data, env)
         session.add(dataset)
         session.commit()
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- Before we were creating naming convention for s3 buckets, kms keys, etc. for newly create datasets without using the `targetUri` because we were referencing the Dataset object before it was added to the RDS Table and thus before the datasetUri is created


### Relates
- N/A

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
