### PR TITLE
adding update consumption role capability

### DIFF
--- a/backend/dataall/core/environment/api/input_types.py
+++ b/backend/dataall/core/environment/api/input_types.py
@@ -118,3 +118,11 @@ ConsumptionRoleFilter = gql.InputType(
         gql.Argument(name='groupUri', type=gql.String),
     ],
 )
+
+UpdateConsumptionRoleInput = gql.InputType(
+    name='UpdateConsumptionRoleInput',
+    arguments=[
+        gql.Argument('consumptionRoleName', gql.String),
+        gql.Argument('groupUri', gql.String),
+    ],
+)

--- a/backend/dataall/core/environment/api/mutations.py
+++ b/backend/dataall/core/environment/api/mutations.py
@@ -5,7 +5,8 @@ from dataall.core.environment.api.input_types import (
     NewEnvironmentInput,
     EnableDataSubscriptionsInput,
     InviteGroupOnEnvironmentInput,
-    AddConsumptionRoleToEnvironmentInput
+    AddConsumptionRoleToEnvironmentInput,
+    UpdateConsumptionRoleInput,
 )
 from dataall.core.environment.api.resolvers import *
 
@@ -109,4 +110,15 @@ DisableDataSubscriptions = gql.MutationField(
     ],
     resolver=disable_subscriptions,
     type=gql.Boolean,
+)
+
+updateConsumptionRole = gql.MutationField(
+    name='updateConsumptionRole',
+    args=[
+        gql.Argument('environmentUri', type=gql.NonNullableType(gql.String)),
+        gql.Argument('consumptionRoleUri', type=gql.NonNullableType(gql.String)),
+        gql.Argument('input', type=UpdateConsumptionRoleInput),
+    ],
+    type=gql.Ref('ConsumptionRole'),
+    resolver=update_consumption_role,
 )

--- a/backend/dataall/core/environment/api/resolvers.py
+++ b/backend/dataall/core/environment/api/resolvers.py
@@ -222,6 +222,17 @@ def remove_consumption_role(context: Context, source, environmentUri=None, consu
     return status
 
 
+def update_consumption_role(context: Context, source, environmentUri=None, consumptionRoleUri=None, input={}):
+    with context.engine.scoped_session() as session:
+        status = EnvironmentService.update_consumption_role(
+            session=session,
+            uri=consumptionRoleUri,
+            env_uri=environmentUri,
+            input=input,
+        )
+    return status
+
+
 def list_environment_invited_groups(
     context: Context, source, environmentUri=None, filter=None
 ):

--- a/backend/dataall/core/environment/api/resolvers.py
+++ b/backend/dataall/core/environment/api/resolvers.py
@@ -224,13 +224,13 @@ def remove_consumption_role(context: Context, source, environmentUri=None, consu
 
 def update_consumption_role(context: Context, source, environmentUri=None, consumptionRoleUri=None, input={}):
     with context.engine.scoped_session() as session:
-        status = EnvironmentService.update_consumption_role(
+        consumption_role = EnvironmentService.update_consumption_role(
             session=session,
             uri=consumptionRoleUri,
             env_uri=environmentUri,
             input=input,
         )
-    return status
+    return consumption_role
 
 
 def list_environment_invited_groups(

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -463,6 +463,12 @@ class EnvironmentService:
     @has_tenant_permission(permissions.MANAGE_ENVIRONMENTS)
     @has_resource_permission(permissions.REMOVE_ENVIRONMENT_CONSUMPTION_ROLE)
     def update_consumption_role(session, uri, env_uri, input):
+        if not input:
+            raise exceptions.RequiredParameter('input')
+        if not input.get('groupUri'):
+            raise exceptions.RequiredParameter('groupUri')
+        if not input.get('consumptionRoleName'):
+            raise exceptions.RequiredParameter('consumptionRoleName')
         role_query = session.query(ConsumptionRole).filter(
             (
                 and_(

--- a/backend/dataall/core/permissions/db/resource_policy_repositories.py
+++ b/backend/dataall/core/permissions/db/resource_policy_repositories.py
@@ -123,6 +123,29 @@ class ResourcePolicy:
         return resource_policy
 
     @staticmethod
+    def update_resource_policy(
+            session,
+            resource_uri: str,
+            resource_type: str,
+            old_group: str,
+            new_group: str,
+            new_permissions: [str]
+    ) -> models.ResourcePolicy:
+        ResourcePolicy.delete_resource_policy(
+            session=session,
+            group=old_group,
+            resource_uri=resource_uri,
+            resource_type=resource_type,
+        )
+        return ResourcePolicy.attach_resource_policy(
+            session=session,
+            group=new_group,
+            resource_uri=resource_uri,
+            permissions=new_permissions,
+            resource_type=resource_type,
+        )
+
+    @staticmethod
     def attach_resource_policy(
         session,
         group: str,

--- a/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
@@ -15,9 +15,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import * as Yup from 'yup';
 import { SET_ERROR, useDispatch } from 'globalErrors';
-import { useClient } from 'services';
+import { useClient, useFetchGroups } from 'services';
 import { addConsumptionRoleToEnvironment } from '../services';
-import { useFetchGroups } from '../../../utils/api';
 
 export const EnvironmentRoleAddForm = (props) => {
   const { environment, onClose, open, reloadRoles, ...other } = props;

--- a/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
@@ -12,53 +12,18 @@ import {
 import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import * as Yup from 'yup';
-import { Defaults } from 'design';
 import { SET_ERROR, useDispatch } from 'globalErrors';
-import { listEnvironmentGroups, useClient } from 'services';
+import { useClient } from 'services';
 import { addConsumptionRoleToEnvironment } from '../services';
+import { useFetchGroups } from '../../../utils/api';
+
 export const EnvironmentRoleAddForm = (props) => {
   const { environment, onClose, open, reloadRoles, ...other } = props;
   const { enqueueSnackbar } = useSnackbar();
   const dispatch = useDispatch();
   const client = useClient();
-  const [loadingGroups, setLoadingGroups] = useState(true);
-  const [groupOptions, setGroupOptions] = useState([]);
-
-  const fetchGroups = async (environmentUri) => {
-    try {
-      setLoadingGroups(true);
-      const response = await client.query(
-        listEnvironmentGroups({
-          filter: Defaults.selectListFilter,
-          environmentUri
-        })
-      );
-      if (!response.errors) {
-        setGroupOptions(
-          response.data.listEnvironmentGroups.nodes.map((g) => ({
-            value: g.groupUri,
-            label: g.groupUri
-          }))
-        );
-      } else {
-        dispatch({ type: SET_ERROR, error: response.errors[0].message });
-      }
-    } catch (e) {
-      dispatch({ type: SET_ERROR, error: e.message });
-    } finally {
-      setLoadingGroups(false);
-    }
-  };
-
-  useEffect(() => {
-    if (client && environment) {
-      fetchGroups(environment.environmentUri).catch((e) =>
-        dispatch({ type: SET_ERROR, error: e.message })
-      );
-    }
-  }, [client, environment, dispatch]);
 
   async function submit(values, setStatus, setSubmitting, setErrors) {
     try {
@@ -97,6 +62,8 @@ export const EnvironmentRoleAddForm = (props) => {
       dispatch({ type: SET_ERROR, error: err.message });
     }
   }
+
+  let { groupOptions, loadingGroups } = useFetchGroups(environment);
 
   if (!environment) {
     return null;

--- a/frontend/src/modules/Environments/components/EnvironmentTeams.js
+++ b/frontend/src/modules/Environments/components/EnvironmentTeams.js
@@ -41,7 +41,8 @@ import {
   SearchIcon
 } from 'design';
 import { SET_ERROR, useDispatch } from 'globalErrors';
-import { useClient } from 'services';
+import { isFeatureEnabled } from 'utils';
+import { useClient, useFetchGroups } from 'services';
 import {
   generateEnvironmentAccessToken,
   getEnvironmentAssumeRoleUrl,
@@ -54,9 +55,7 @@ import {
 import { EnvironmentRoleAddForm } from './EnvironmentRoleAddForm';
 import { EnvironmentTeamInviteEditForm } from './EnvironmentTeamInviteEditForm';
 import { EnvironmentTeamInviteForm } from './EnvironmentTeamInviteForm';
-import { isFeatureEnabled } from '../../../utils';
 import { DataGrid, GridActionsCellItem, GridRowModes } from '@mui/x-data-grid';
-import { useFetchGroups } from '../../../utils/api';
 
 function TeamRow({ team, environment, fetchItems }) {
   const client = useClient();
@@ -436,7 +435,7 @@ export const EnvironmentTeams = ({ environment }) => {
     });
   };
 
-  const processRowUpdate = async (newRow, oldRow) => {
+  const processRowUpdate = async (newRow) => {
     await updateConsumptionRoleHandler(newRow);
     return newRow;
   };

--- a/frontend/src/modules/Environments/components/EnvironmentTeams.js
+++ b/frontend/src/modules/Environments/components/EnvironmentTeams.js
@@ -407,7 +407,7 @@ export const EnvironmentTeams = ({ environment }) => {
     }
   };
 
-  const [rowModesModel, setRowModesModel] = React.useState({});
+  const [rowModesModel, setRowModesModel] = useState({});
 
   const handleRowEditStart = (params, event) => {
     event.defaultMuiPrevented = true;

--- a/frontend/src/modules/Environments/services/index.js
+++ b/frontend/src/modules/Environments/services/index.js
@@ -22,3 +22,4 @@ export * from './removeConsumptionRole';
 export * from './removeGroup';
 export * from './updateEnvironment';
 export * from './updateGroupEnvironmentPermissions';
+export * from './updateConsumptionRole';

--- a/frontend/src/modules/Environments/services/updateConsumptionRole.js
+++ b/frontend/src/modules/Environments/services/updateConsumptionRole.js
@@ -1,0 +1,33 @@
+import { gql } from 'apollo-boost';
+
+export const updateConsumptionRole = ({
+  environmentUri,
+  consumptionRoleUri,
+  input
+}) => ({
+  variables: {
+    environmentUri,
+    consumptionRoleUri,
+    input
+  },
+  mutation: gql`
+    mutation updateConsumptionRole(
+      $environmentUri: String!
+      $consumptionRoleUri: String!
+      $input: UpdateConsumptionRoleInput!
+    ) {
+      updateConsumptionRole(
+        environmentUri: $environmentUri
+        consumptionRoleUri: $consumptionRoleUri
+        input: $input
+      ) {
+        consumptionRoleUri
+        consumptionRoleName
+        environmentUri
+        groupUri
+        IAMRoleName
+        IAMRoleArn
+      }
+    }
+  `
+});

--- a/frontend/src/services/hooks/index.js
+++ b/frontend/src/services/hooks/index.js
@@ -1,2 +1,3 @@
 export * from './useClient';
 export * from './useGroups';
+export * from './useFetchGroups';

--- a/frontend/src/services/hooks/useFetchGroups.js
+++ b/frontend/src/services/hooks/useFetchGroups.js
@@ -1,7 +1,7 @@
-import { listEnvironmentGroups, useClient } from '../services';
+import { listEnvironmentGroups, useClient } from 'services';
 import { useEffect, useState } from 'react';
-import { SET_ERROR, useDispatch } from '../globalErrors';
-import { Defaults } from '../design';
+import { SET_ERROR, useDispatch } from 'globalErrors';
+import { Defaults } from 'design';
 
 // TODO DRY fetchGroup usages using this func
 export const useFetchGroups = (environment) => {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,0 +1,50 @@
+import { listEnvironmentGroups, useClient } from '../services';
+import { useEffect, useState } from 'react';
+import { SET_ERROR, useDispatch } from '../globalErrors';
+import { Defaults } from '../design';
+
+// TODO DRY fetchGroup usages using this func
+export const useFetchGroups = (environment) => {
+  const client = useClient();
+  const [loadingGroups, setLoadingGroups] = useState(true);
+  const [groupOptions, setGroupOptions] = useState([]);
+  const dispatch = useDispatch();
+  const fetchGroups = async (environmentUri) => {
+    try {
+      setLoadingGroups(true);
+      const response = await client.query(
+        listEnvironmentGroups({
+          filter: Defaults.selectListFilter,
+          environmentUri
+        })
+      );
+      if (!response.errors) {
+        setGroupOptions(
+          response.data.listEnvironmentGroups.nodes.map((g) => ({
+            value: g.groupUri,
+            label: g.groupUri
+          }))
+        );
+      } else {
+        dispatch({ type: SET_ERROR, error: response.errors[0].message });
+      }
+    } catch (e) {
+      dispatch({ type: SET_ERROR, error: e.message });
+    } finally {
+      setLoadingGroups(false);
+    }
+  };
+
+  useEffect(() => {
+    if (client && environment) {
+      fetchGroups(environment.environmentUri).catch((e) =>
+        dispatch({
+          type: SET_ERROR,
+          error: e.message
+        })
+      );
+    }
+  }, [client, environment, dispatch]);
+
+  return { groupOptions, loadingGroups };
+};

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,6 +196,11 @@ def mock_aws_client(module_mocker):
         session_helper
     )
 
+    module_mocker.patch(
+        'dataall.base.aws.sts.SessionHelper',
+        session_helper
+    )
+
     session_helper.get_session.return_value = session
     session_helper.remote_session.return_value = session
     session.client.return_value = aws_client

--- a/tests/core/environments/conftest.py
+++ b/tests/core/environments/conftest.py
@@ -1,0 +1,39 @@
+import uuid
+
+from tests.core.permissions.test_permission import *
+
+
+@pytest.fixture
+def consumption_role(mock_aws_client, client, org_fixture, env_fixture, user, group, db):
+    test_arn = f'arn:aws:sts::111111111111:assumed-role/Test/{str(uuid.uuid4())[:8]}'
+    mock_aws_client.get_role.return_value = {'Role': {'Arn': test_arn}}
+    query = """
+        mutation addConsumptionRoleToEnvironment(
+            $input:AddConsumptionRoleToEnvironmentInput
+        ){
+            addConsumptionRoleToEnvironment(
+                input:$input
+            ){
+                consumptionRoleUri
+                consumptionRoleName
+                environmentUri
+                groupUri
+                IAMRoleName
+                IAMRoleArn
+            }
+        }
+    """
+    response = client.query(
+        query,
+        username=user,
+        groups=[group.name],
+        environmentUri=env_fixture.environmentUri,
+        input={
+            'consumptionRoleName': str(uuid.uuid4())[:8],
+            'groupUri': str(uuid.uuid4())[:8],
+            'IAMRoleArn': test_arn,
+            'environmentUri': env_fixture.environmentUri
+        },
+    )
+    assert not response.errors
+    return response


### PR DESCRIPTION
### Feature or Bugfix

- Feature


### Detail
- Add capability to update consumption role owner and name
- Setting the paradigm to use [DataGrid (with edit/CRUD ops)](https://v5.mui.com/x/react-data-grid/editing/#full-featured-crud-component) instead of Table

### Relates
- Resolves #870 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

### Testing

Tested with multiple accounts and roles
* Locally
* AWS account
* Added unit-tests
  * Mocked the entire `sts` client as the tests were sending request to AWS

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
