### PR TITLE
 Dataset Description on shares UI page

### DIFF
--- a/backend/dataall/modules/dataset_sharing/api/resolvers.py
+++ b/backend/dataall/modules/dataset_sharing/api/resolvers.py
@@ -126,6 +126,7 @@ def resolve_dataset(context: Context, source: ShareObject, **kwargs):
                 'AwsAccountId': env.AwsAccountId if env else 'NotFound',
                 'region': env.region if env else 'NotFound',
                 'exists': True if ds else False,
+                'description' : ds.description
             }
 
 

--- a/backend/dataall/modules/dataset_sharing/api/types.py
+++ b/backend/dataall/modules/dataset_sharing/api/types.py
@@ -99,6 +99,7 @@ DatasetLink = gql.ObjectType(
         gql.Field(name='AwsAccountId', type=gql.String),
         gql.Field(name='region', type=gql.String),
         gql.Field(name='exists', type=gql.Boolean),
+        gql.Field(name='description', type=gql.String),
     ],
 )
 

--- a/frontend/src/design/components/ObjectBrief.js
+++ b/frontend/src/design/components/ObjectBrief.js
@@ -116,7 +116,11 @@ export const ObjectBrief = (props) => {
           <Typography color="textSecondary" variant="subtitle2">
             Description
           </Typography>
-          <Typography color="textPrimary" variant="subtitle2">
+          <Typography
+            color="textPrimary"
+            variant="subtitle2"
+            style={{ whiteSpace: 'pre-line' }}
+          >
             {description}
           </Typography>
         </Box>

--- a/frontend/src/modules/Shares/services/getShareObject.js
+++ b/frontend/src/modules/Shares/services/getShareObject.js
@@ -56,6 +56,7 @@ export const getShareObject = ({ shareUri, filter }) => ({
           AwsAccountId
           region
           exists
+          description
         }
       }
     }

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -742,7 +742,7 @@ const ShareView = () => {
                         sx={{ wordBreak: 'break-word' }}
                         style={{ whiteSpace: 'pre-line' }}
                       >
-                        {share.dataset.description}
+                        {share.dataset.description.trim().length != 0 ? share.dataset.description : 'No dataset description'}
                       </Typography>
                     </Box>
                   </CardContent>

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -742,7 +742,9 @@ const ShareView = () => {
                         sx={{ wordBreak: 'break-word' }}
                         style={{ whiteSpace: 'pre-line' }}
                       >
-                        {share.dataset.description.trim().length != 0 ? share.dataset.description : 'No dataset description'}
+                        {share.dataset.description.trim().length !== 0
+                          ? share.dataset.description
+                          : 'No dataset description'}
                       </Typography>
                     </Box>
                   </CardContent>

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -731,6 +731,26 @@ const ShareView = () => {
               <Box sx={{ mb: 3 }}>
                 <Card {...share}>
                   <Box>
+                    <CardHeader title="Dataset Description" />
+                    <Divider />
+                  </Box>
+                  <CardContent>
+                    <Box sx={{ mt: 1 }}>
+                      <Typography
+                        color="textPrimary"
+                        variant="subtitle2"
+                        sx={{ wordBreak: 'break-word' }}
+                        style={{ whiteSpace: 'pre-line' }}
+                      >
+                        {share.dataset.description}
+                      </Typography>
+                    </Box>
+                  </CardContent>
+                </Card>
+              </Box>
+              <Box sx={{ mb: 3 }}>
+                <Card {...share}>
+                  <Box>
                     <CardHeader title="Share Object Comments" />
                     <Divider />
                   </Box>


### PR DESCRIPTION
### Feature or Bugfix
- Feature


### Detail

As described by the problem in this GH issue - https://github.com/data-dot-all/dataall/issues/1025 . This will add dataset description on the shares UI page. 

### Testing 

1. Created a share for a dataset 
2. Shares Page now contains the dataset description in the  UI 

### Relates
- https://github.com/data-dot-all/dataall/issues/1025

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? No
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization? No
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? No
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored? No
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
