### PR TITLE
Update starlette version and dependecies to avoid ReDoS

### DIFF
--- a/backend/dataall/base/cdkproxy/requirements.txt
+++ b/backend/dataall/base/cdkproxy/requirements.txt
@@ -4,8 +4,8 @@ boto3-stubs==1.24.85
 botocore==1.27.85
 cdk-nag==2.7.2
 constructs==10.0.73
-starlette==0.27.0
-fastapi == 0.95.2
+starlette==0.36.3
+fastapi == 0.109.2
 Flask==2.3.2
 PyYAML==6.0
 requests==2.31.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,8 +1,8 @@
-ariadne==0.17.0
+ariadne==0.22.0
 aws-xray-sdk==2.4.3
 boto3==1.26.95
 botocore==1.29.95
-fastapi == 0.95.2
+fastapi == 0.109.2
 Flask==2.3.2
 flask-cors==3.0.10
 nanoid==2.0.0
@@ -14,4 +14,4 @@ PyYAML==6.0
 requests==2.31.0
 requests_aws4auth==1.1.1
 sqlalchemy==1.3.24
-starlette==0.27.0
+starlette==0.36.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-ariadne==0.22.0
+ariadne==0.17.0
 aws-xray-sdk==2.4.3
 boto3==1.26.95
 botocore==1.29.95


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Vulnerability found in `starlette` using `python-multipart`. Fixed in starlette > 0.32.0 ([version releases](https://github.com/encode/starlette/releases))

### Relates

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
