### PR TITLE
Add validation of AWS account and region in environment creation

### DIFF
--- a/backend/dataall/base/db/exceptions.py
+++ b/backend/dataall/base/db/exceptions.py
@@ -54,7 +54,7 @@ class InvalidInput(Exception):
         self.param_name = param_name
         self.param_value = param_value
         self.message = f"""
-                    An error occurred (InvalidInput): f'{param_name} value {param_value} must be {constraint}'
+                    An error occurred (InvalidInput): '{param_name} value {param_value} must be {constraint}'
         """
 
     def __str__(self):

--- a/backend/dataall/core/environment/db/environment_repositories.py
+++ b/backend/dataall/core/environment/db/environment_repositories.py
@@ -57,3 +57,15 @@ class EnvironmentRepository:
                 Environment.SamlGroupName == group,
             )
         ).count()
+
+    @staticmethod
+    def find_environment_by_account_region(session, account_id, region):
+        environment: Environment = session.query(Environment).filter(
+            and_(
+                Environment.AwsAccountId == account_id,
+                Environment.region == region
+            )
+        ).first()
+        if not environment:
+            return None
+        return environment

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -41,7 +41,7 @@ class EnvironmentService:
     @has_resource_permission(permissions.LINK_ENVIRONMENT)
     def create_environment(session, uri, data=None):
         context = get_context()
-        EnvironmentService._validate_creation_params(data, uri)
+        EnvironmentService._validate_creation_params(data, uri, session)
         organization = OrganizationRepository.get_organization_by_uri(session, uri)
         env = Environment(
             organizationUri=data.get('organizationUri'),
@@ -129,7 +129,7 @@ class EnvironmentService:
         return env
 
     @staticmethod
-    def _validate_creation_params(data, uri):
+    def _validate_creation_params(data, uri, session):
         if not uri:
             raise exceptions.RequiredParameter('organizationUri')
         if not data:
@@ -143,7 +143,7 @@ class EnvironmentService:
         if not data.get('region'):
             raise exceptions.RequiredParameter('region')
         EnvironmentService._validate_resource_prefix(data)
-        EnvironmentService._validate_account_region(data)
+        EnvironmentService._validate_account_region(data, session)
 
     @staticmethod
     def _validate_resource_prefix(data):
@@ -157,8 +157,8 @@ class EnvironmentService:
             )
 
     @staticmethod
-    def _validate_account_region(data):
-        environment = EnvironmentRepository.find_environment_by_account_region(account_id=data.get('AwsAccountId'), region=data.get('region'))
+    def _validate_account_region(data, session):
+        environment = EnvironmentRepository.find_environment_by_account_region(session=session, account_id=data.get('AwsAccountId'), region=data.get('region'))
         if environment:
             raise exceptions.InvalidInput(
                 'AwsAccount/region',

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -160,7 +160,6 @@ class EnvironmentService:
     def _validate_account_region(data, session):
         environment = EnvironmentRepository.find_environment_by_account_region(session=session, account_id=data.get('AwsAccountId'), region=data.get('region'))
         if environment:
-            #  An error occurred (InvalidInput): f'AwsAccount/region value 081212569412/eu-west-1 must be An environment for AwsAccount/region already exists'
             raise exceptions.InvalidInput(
                 'AwsAccount/region',
                 f"{data.get('AwsAccountId')}/{data.get('region')}",

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -138,7 +138,12 @@ class EnvironmentService:
             raise exceptions.RequiredParameter('label')
         if not data.get('SamlGroupName'):
             raise exceptions.RequiredParameter('group')
+        if not data.get('AwsAccountId'):
+            raise exceptions.RequiredParameter('AwsAccountId')
+        if not data.get('region'):
+            raise exceptions.RequiredParameter('region')
         EnvironmentService._validate_resource_prefix(data)
+        EnvironmentService._validate_account_region(data)
 
     @staticmethod
     def _validate_resource_prefix(data):
@@ -149,6 +154,16 @@ class EnvironmentService:
                 'resourcePrefix',
                 data.get('resourcePrefix'),
                 'must match the pattern ^[a-z-]+$',
+            )
+
+    @staticmethod
+    def _validate_account_region(data):
+        environment = EnvironmentRepository.find_environment_by_account_region(account_id=data.get('AwsAccountId'), region=data.get('region'))
+        if environment:
+            raise exceptions.InvalidInput(
+                'AwsAccount/region',
+                f"{data.get('AwsAccountId')}/{data.get('region')}",
+                'An environment for AwsAccount/region already exists',
             )
 
     @staticmethod

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -160,10 +160,11 @@ class EnvironmentService:
     def _validate_account_region(data, session):
         environment = EnvironmentRepository.find_environment_by_account_region(session=session, account_id=data.get('AwsAccountId'), region=data.get('region'))
         if environment:
+            #  An error occurred (InvalidInput): f'AwsAccount/region value 081212569412/eu-west-1 must be An environment for AwsAccount/region already exists'
             raise exceptions.InvalidInput(
                 'AwsAccount/region',
                 f"{data.get('AwsAccountId')}/{data.get('region')}",
-                'An environment for AwsAccount/region already exists',
+                f"unique. An environment for {data.get('AwsAccountId')}/{data.get('region')} already exists",
             )
 
     @staticmethod

--- a/tests/core/environments/test_environment.py
+++ b/tests/core/environments/test_environment.py
@@ -621,7 +621,7 @@ def test_group_invitation(db, client, env_fixture, org_fixture, group2, user, gr
 
 
 def test_archive_env(client, org_fixture, env, group, group2):
-    env_fixture = env(org_fixture, 'dev-delete', 'alice', 'testadmins', '111111111111', 'eu-west-1')
+    env_fixture = env(org_fixture, 'dev-delete', 'alice', 'testadmins', '111111111111', 'eu-west-2')
     response = client.query(
         """
         mutation deleteEnvironment($environmentUri:String!, $deleteFromAWS:Boolean!){
@@ -637,7 +637,7 @@ def test_archive_env(client, org_fixture, env, group, group2):
     assert response.data.deleteEnvironment
 
 
-def test_create_environment(db, client, org_fixture, env_fixture, user, group):
+def test_create_environment(db, client, org_fixture, user, group):
     response = client.query(
         """mutation CreateEnv($input:NewEnvironmentInput){
             createEnvironment(input:$input){
@@ -668,11 +668,11 @@ def test_create_environment(db, client, org_fixture, env_fixture, user, group):
         input={
             'label': f'dev',
             'description': f'test',
-            'EnvironmentDefaultIAMRoleArn': f'arn:aws:iam::{env_fixture.AwsAccountId}:role/myOwnIamRole',
+            'EnvironmentDefaultIAMRoleArn': 'arn:aws:iam::444444444444:role/myOwnIamRole',
             'organizationUri': org_fixture.organizationUri,
-            'AwsAccountId': env_fixture.AwsAccountId,
+            'AwsAccountId': '444444444444',
             'tags': ['a', 'b', 'c'],
-            'region': f'{env_fixture.region}',
+            'region': 'eu-west-1',
             'SamlGroupName': group.name,
             'resourcePrefix': 'customer-prefix',
         },

--- a/tests/core/environments/test_environment.py
+++ b/tests/core/environments/test_environment.py
@@ -32,6 +32,41 @@ def get_env(client, env_fixture, group):
         groups=[group.name],
     )
 
+def test_create_environment_invalid_account_region(client, org_fixture, env_fixture, group):
+    response = client.query(
+        """mutation CreateEnv($input:NewEnvironmentInput){
+                createEnvironment(input:$input){
+                    organization{
+                        organizationUri
+                    }
+                    environmentUri
+                    label
+                    AwsAccountId
+                    SamlGroupName
+                    region
+                    name
+                    owner
+                    parameters {
+                        key
+                        value
+                    }
+                }
+            }""",
+            username='alice',
+            groups=[group.name],
+            input={
+                'label': 'invalid',
+                'description': 'invalid environment',
+                'organizationUri': org_fixture.organizationUri,
+                'AwsAccountId': env_fixture.AwsAccountId,
+                'tags': ['a', 'b', 'c'],
+                'region': env_fixture.region,
+                'SamlGroupName': group.name,
+                'parameters': [{'key': k, 'value': v} for k, v in {"dashboardsEnabled": "true"}.items()]
+            },
+        )
+    assert 'InvalidInput' in response.errors[0].message
+
 
 def test_get_environment(client, org_fixture, env_fixture, group):
     response = get_env(client, env_fixture, group)

--- a/tests/core/organizations/test_organization.py
+++ b/tests/core/organizations/test_organization.py
@@ -18,7 +18,7 @@ def org2(org, user2, group2, tenant):
 
 @pytest.fixture(scope='module', autouse=True)
 def env_dev(env, org2, user2, group2, tenant):
-    env2 = env(org2, 'dev', user2.username, group2.name, '222222222222', 'eu-west-1', 'description')
+    env2 = env(org2, 'dev', user2.username, group2.name, '333333333333', 'eu-west-1', 'description')
     yield env2
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Added validation in environment creation. In this PR we add a check that raise an exception if an environment is created using the same AWS account and region as other environment.

### Relates
- #779 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
