### PR TITLE
Edit local deploy command to include UID

### DIFF
--- a/pages/deploy/deploy_locally.md
+++ b/pages/deploy/deploy_locally.md
@@ -33,8 +33,10 @@ You can check the ports assigned to each container in the `docker-compose.yaml` 
 
 ```bash
 cd dataall
-docker-compose up
+export UID && docker-compose up
 ```
+
+**Note:** We export `UID` to ensure the docker user created to run the container has the correct permissions to read from the mounted file systems for the locally deployed data.all.
 
 ![dockercompose](../img/docker_compose.png#zoom#shadow)
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Documentation

### Detail
- Update the local deploy instructions to reflect the latest changes to include `export UID`


### Relates
- https://github.com/data-dot-all/dataall/pull/968

### Security
N/A
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
