### PR TITLE
Gh-1081 - Email notification metadata

### DIFF
--- a/backend/dataall/base/aws/ses.py
+++ b/backend/dataall/base/aws/ses.py
@@ -29,7 +29,7 @@ class Ses:
                 'ToAddresses': toList,
             }
             body_dict = {
-                'Text': {
+                'Html': {
                     'Data': message,
                     'Charset': 'UTF-8'
                 }

--- a/backend/dataall/modules/dataset_sharing/services/share_notification_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_notification_service.py
@@ -42,7 +42,10 @@ class ShareNotificationService:
         self.notification_target_users = self._get_share_object_targeted_users()
 
     def notify_share_object_submission(self, email_id: str):
-        msg = f'User {email_id} SUBMITTED share request for dataset {self.dataset.label} for principal {self.share.principalId} \n\n Please visit Data.all Share link - {os.environ.get("domain_url")}"/shares/{self.share.shareUri}'
+        share_link_text = ''
+        if os.environ.get("frontend_domain_url"):
+            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
+        msg = f'User {email_id} SUBMITTED share request for dataset {self.dataset.label} for principal {self.share.principalId}' + share_link_text
         subject = f'Data.all | Share Request Submitted for {self.dataset.label}'
 
         notifications = self._register_notifications(
@@ -52,7 +55,10 @@ class ShareNotificationService:
         return notifications
 
     def notify_share_object_approval(self, email_id: str):
-        msg = f'User {email_id} APPROVED share request for dataset {self.dataset.label} for principal {self.share.principalId}'
+        share_link_text = ''
+        if os.environ.get("frontend_domain_url"):
+            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
+        msg = f'User {email_id} APPROVED share request for dataset {self.dataset.label} for principal {self.share.principalId}' + share_link_text
         subject = f'Data.all | Share Request Approved for {self.dataset.label}'
 
         notifications = self._register_notifications(
@@ -62,14 +68,17 @@ class ShareNotificationService:
         return notifications
 
     def notify_share_object_rejection(self, email_id: str):
+        share_link_text = ''
+        if os.environ.get("frontend_domain_url"):
+            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
         if self.share.status == ShareObjectStatus.Rejected.value:
-            msg = f'User {email_id} REJECTED share request for dataset {self.dataset.label} for principal {self.share.principalId}'
+            msg = f'User {email_id} REJECTED share request for dataset {self.dataset.label} for principal {self.share.principalId}' + share_link_text
             subject = f'Data.all | Share Request Rejected for {self.dataset.label}'
         elif self.share.status == ShareObjectStatus.Revoked.value:
-            msg = f'User {email_id} REVOKED share request for dataset {self.dataset.label} for principal {self.share.principalId}'
+            msg = f'User {email_id} REVOKED share request for dataset {self.dataset.label} for principal {self.share.principalId}' + share_link_text
             subject = f'Data.all | Share Request Revoked for {self.dataset.label}'
         else:
-            msg = f'User {email_id} REJECTED/REVOKED share request for dataset {self.dataset.label} for principal {self.share.principalId}'
+            msg = f'User {email_id} REJECTED/REVOKED share request for dataset {self.dataset.label} for principal {self.share.principalId}' + share_link_text
             subject = f'Data.all | Share Request Rejected / Revoked for {self.dataset.label}'
 
         notifications = self._register_notifications(

--- a/backend/dataall/modules/dataset_sharing/services/share_notification_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_notification_service.py
@@ -44,7 +44,7 @@ class ShareNotificationService:
     def notify_share_object_submission(self, email_id: str):
         share_link_text = ''
         if os.environ.get("frontend_domain_url"):
-            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
+            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/console/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
         msg = f'User {email_id} SUBMITTED share request for dataset {self.dataset.label} for principal {self.share.principalId}' + share_link_text
         subject = f'Data.all | Share Request Submitted for {self.dataset.label}'
 
@@ -57,7 +57,7 @@ class ShareNotificationService:
     def notify_share_object_approval(self, email_id: str):
         share_link_text = ''
         if os.environ.get("frontend_domain_url"):
-            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
+            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/console/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
         msg = f'User {email_id} APPROVED share request for dataset {self.dataset.label} for principal {self.share.principalId}' + share_link_text
         subject = f'Data.all | Share Request Approved for {self.dataset.label}'
 
@@ -70,7 +70,7 @@ class ShareNotificationService:
     def notify_share_object_rejection(self, email_id: str):
         share_link_text = ''
         if os.environ.get("frontend_domain_url"):
-            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
+            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/console/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
         if self.share.status == ShareObjectStatus.Rejected.value:
             msg = f'User {email_id} REJECTED share request for dataset {self.dataset.label} for principal {self.share.principalId}' + share_link_text
             subject = f'Data.all | Share Request Rejected for {self.dataset.label}'

--- a/backend/dataall/modules/dataset_sharing/services/share_notification_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_notification_service.py
@@ -1,5 +1,7 @@
 import logging
 import enum
+import os
+
 from dataall.base.config import config
 from dataall.core.tasks.db.task_models import Task
 from dataall.core.tasks.service_handlers import Worker
@@ -40,7 +42,7 @@ class ShareNotificationService:
         self.notification_target_users = self._get_share_object_targeted_users()
 
     def notify_share_object_submission(self, email_id: str):
-        msg = f'User {email_id} SUBMITTED share request for dataset {self.dataset.label} for principal {self.share.principalId}'
+        msg = f'User {email_id} SUBMITTED share request for dataset {self.dataset.label} for principal {self.share.principalId} \n\n Please visit Data.all Share link - {os.environ.get("domain_url")}"/shares/{self.share.shareUri}'
         subject = f'Data.all | Share Request Submitted for {self.dataset.label}'
 
         notifications = self._register_notifications(

--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -189,6 +189,7 @@ class BackendStack(Stack):
             email_notification_sender_email_id=email_sender,
             email_custom_domain = ses_stack.ses_identity.email_identity_name if ses_stack != None else None,
             ses_configuration_set = ses_stack.configuration_set.configuration_set_name if ses_stack != None else None,
+            custom_domain=custom_domain,
             custom_auth=custom_auth,
             **kwargs,
         )


### PR DESCRIPTION
### Feature or Bugfix
- Feature


### Detail

- Adds weblink to the Share UI page corresponding to the share request

Email notification received after this change - 
<img width="1317" alt="image" src="https://github.com/data-dot-all/dataall/assets/71188245/ebc85003-32b7-4668-a74a-a5e96bc383a7">


### Relates
- https://github.com/data-dot-all/dataall/issues/1081

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? No 
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization? Yes
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms? yes
  - Are you logging failed auth attempts? N/A
- Are you using or adding any cryptographic features? No
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users? No
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
