### PR TITLE
Fix verify share table items and access point share no bucket policy

### DIFF
--- a/backend/dataall/modules/dataset_sharing/services/share_managers/s3_access_point_share_manager.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_managers/s3_access_point_share_manager.py
@@ -126,7 +126,6 @@ class S3AccessPointShareManager:
         """
         logger.info(f"Manage Bucket policy for {self.bucket_name}")
 
-        s3_client = S3Client(self.source_account_id, self.source_environment.region)
         bucket_policy = self.get_bucket_policy_or_default()
         counter = count()
         statements = {item.get("Sid", next(counter)): item for item in bucket_policy.get("Statement", {})}

--- a/backend/dataall/modules/dataset_sharing/services/share_processors/lakeformation_process_share.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_processors/lakeformation_process_share.py
@@ -287,6 +287,7 @@ class ProcessLakeFormationShare(LFShareManager):
             log.info("No tables to verify. Skipping...")
         else:
             try:
+                self.initialize_clients()
                 self.check_pivot_role_permissions_to_source_database()
                 self.check_shared_database_in_target()
                 self.check_pivot_role_permissions_to_shared_database()

--- a/tests/modules/datasets/tasks/test_s3_access_point_share_manager.py
+++ b/tests/modules/datasets/tasks/test_s3_access_point_share_manager.py
@@ -251,9 +251,9 @@ def test_manage_bucket_policy_no_policy(
 ):
 
     # Given
-    bucket_policy = base_bucket_policy
+    # bucket_policy = base_bucket_policy
     s3_client = mock_s3_client(mocker)
-    s3_client().get_bucket_policy.return_value = json.dumps(bucket_policy)
+    s3_client().get_bucket_policy.return_value = None
 
     mocker.patch(
         "dataall.base.aws.sts.SessionHelper.get_delegation_role_arn",
@@ -291,6 +291,16 @@ def test_manage_bucket_policy_existing_policy(
     # Given
     bucket_policy = admin_ap_delegation_bucket_policy
     s3_client = mock_s3_client(mocker)
+
+    mocker.patch(
+        "dataall.base.aws.sts.SessionHelper.get_delegation_role_arn",
+        return_value="arn:role",
+    )
+
+    mocker.patch(
+        "dataall.base.aws.sts.SessionHelper.get_role_ids",
+        return_value=[1, 2, 3],
+    )
 
     s3_client().get_bucket_policy.return_value = json.dumps(bucket_policy)
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Verify Share throws errors on verifying table shares since introducing the new way to `initialize_clients()` for LF Shares when determining the source Glue DB
  - This PR includes the `initialize_client()` call before starting to verify the table share item
  - This PR fixes verify share checks on table shares where the glue DB is hosted in a separate catalog account

- When processing a folder item share - it will fail if there is no pre-existing bucket policy on the S3 bucket
  - This PR adds checks similar to how we handle with bucket sharing method `get_bucket_policy_or_default()`

### Relates
- N/A

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
