### PR TITLE
Fix: Added check and reapply for attaching S3 IAM policy

### DIFF
--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -833,6 +833,14 @@ class EnvironmentService:
         ).first()
 
     @staticmethod
+    def get_consumption_role(session, uri) -> Query:
+        return session.query(ConsumptionRole).filter(
+            and_(
+                ConsumptionRole.consumptionRoleUri == uri,
+            )
+        ).first()
+
+    @staticmethod
     def query_environment_networks(session, uri, filter) -> Query:
         query = session.query(Vpc).filter(
             Vpc.environmentUri == uri,

--- a/tests/modules/datasets/tasks/test_s3_access_point_share_manager.py
+++ b/tests/modules/datasets/tasks/test_s3_access_point_share_manager.py
@@ -345,6 +345,10 @@ def test_grant_target_role_access_policy_test_empty_policy(
         "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists",
         return_value=True
     )
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
 
     expected_policy = {
         "Version": "2012-10-17",
@@ -415,6 +419,10 @@ def test_grant_target_role_access_policy_existing_policy_bucket_not_included(
         "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists",
         return_value=True
     )
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
 
     iam_update_role_policy_mock = mocker.patch(
         "dataall.base.aws.iam.IAM.update_managed_policy_default_version",
@@ -461,6 +469,11 @@ def test_grant_target_role_access_policy_existing_policy_bucket_included(
 
     mocker.patch(
         "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists",
+        return_value=True
+    )
+
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
         return_value=True
     )
 
@@ -958,6 +971,11 @@ def test_delete_target_role_access_policy_no_remaining_statement(
         return_value=True
     )
 
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
+
     iam_update_role_policy_mock = mocker.patch(
         "dataall.base.aws.iam.IAM.update_managed_policy_default_version",
         return_value=None,
@@ -1055,6 +1073,11 @@ def test_delete_target_role_access_policy_with_remaining_statement(
 
     mocker.patch(
         "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists",
+        return_value=True
+    )
+
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
         return_value=True
     )
 
@@ -1267,6 +1290,12 @@ def test_check_target_role_access_policy(
     mocker.patch(
         "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists",
         return_value=True)
+
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
+
     iam_get_policy_mock = mocker.patch("dataall.base.aws.iam.IAM.get_managed_policy_default_version",
                                        return_value=('v1', target_dataset_access_control_policy))
 
@@ -1293,6 +1322,12 @@ def test_check_target_role_access_policy_existing_policy_bucket_and_key_not_incl
     mocker.patch(
         "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists",
         return_value=True)
+
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
+
     # Gets policy with other S3 and KMS
     iam_get_policy_mock = mocker.patch("dataall.base.aws.iam.IAM.get_managed_policy_default_version", return_value=('v1', target_dataset_access_control_policy))
 
@@ -1318,6 +1353,11 @@ def test_check_target_role_access_policy_test_no_policy(
         return_value=False
     )
 
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
+
     kms_client = mock_kms_client(mocker)
     kms_client().get_key_id.return_value = "kms-key"
 
@@ -1325,6 +1365,32 @@ def test_check_target_role_access_policy_test_no_policy(
     share_manager.check_target_role_access_policy()
     # Then
     assert len(share_manager.folder_errors) == 1
+
+
+def test_check_target_role_access_policy_test_policy_not_attached(
+    mocker,
+    share_manager
+):
+
+    # Given
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists",
+        return_value=True
+    )
+    # Policy is not attached
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=False
+    )
+
+    kms_client = mock_kms_client(mocker)
+    kms_client().get_key_id.return_value = "kms-key"
+
+    # When
+    share_manager.check_target_role_access_policy()
+    # Then
+    assert len(share_manager.folder_errors) == 1
+
 
 def test_check_access_point_and_policy(
     mocker,

--- a/tests/modules/datasets/tasks/test_s3_bucket_share_manager.py
+++ b/tests/modules/datasets/tasks/test_s3_bucket_share_manager.py
@@ -490,6 +490,10 @@ def test_grant_s3_iam_access_with_no_policy(
     share_policy_service_mock_2 = mocker.patch(
         "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.attach_policy",
         return_value=True)
+    share_policy_service_mock_3 = mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=False
+    )
     iam_update_role_policy_mock_1 = mocker.patch("dataall.base.aws.iam.IAM.get_managed_policy_default_version", return_value=('v1',empty_policy_document))
     iam_update_role_policy_mock_2 = mocker.patch("dataall.base.aws.iam.IAM.update_managed_policy_default_version",
                                                  return_value=None)
@@ -498,6 +502,7 @@ def test_grant_s3_iam_access_with_no_policy(
     # Assert IAM and service calls called
     share_policy_service_mock_1.assert_called_once()
     share_policy_service_mock_2.assert_called()
+    share_policy_service_mock_3.assert_called_once()
     iam_update_role_policy_mock_1.assert_called_once()
     iam_update_role_policy_mock_2.assert_called_once()
 

--- a/tests/modules/datasets/tasks/test_s3_bucket_share_manager.py
+++ b/tests/modules/datasets/tasks/test_s3_bucket_share_manager.py
@@ -469,7 +469,6 @@ def test_grant_s3_iam_access_with_no_policy(
     # Check if the get and update_role_policy func are called and policy statements are added
 
     mocker.patch("dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists", return_value=False)
-
     kms_client = mock_kms_client(mocker)
     kms_client().get_key_id.return_value = "kms-key"
 
@@ -498,7 +497,7 @@ def test_grant_s3_iam_access_with_no_policy(
 
     # Assert IAM and service calls called
     share_policy_service_mock_1.assert_called_once()
-    share_policy_service_mock_2.assert_called_once()
+    share_policy_service_mock_2.assert_called()
     iam_update_role_policy_mock_1.assert_called_once()
     iam_update_role_policy_mock_2.assert_called_once()
 
@@ -530,7 +529,10 @@ def test_grant_s3_iam_access_with_empty_policy(
     # Check if the get and update_role_policy func are called and policy statements are added
 
     mocker.patch("dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists", return_value=True)
-
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
     kms_client = mock_kms_client(mocker)
     kms_client().get_key_id.return_value = "kms-key"
 
@@ -610,7 +612,10 @@ def test_grant_s3_iam_access_with_policy_and_target_resources_not_present(
     }
 
     mocker.patch("dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists", return_value=True)
-
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
     s3_index = SharePolicyService._get_statement_by_sid(policy=policy, sid=f"{IAM_S3_BUCKETS_STATEMENT_SID}S3")
     kms_index = SharePolicyService._get_statement_by_sid(policy=policy, sid=f"{IAM_S3_BUCKETS_STATEMENT_SID}KMS")
 
@@ -681,7 +686,10 @@ def test_grant_s3_iam_access_with_complete_policy_present(
     }
 
     mocker.patch("dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists", return_value=True)
-
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
     kms_client = mock_kms_client(mocker)
     kms_client().get_key_id.return_value = "kms-key"
 
@@ -1087,6 +1095,10 @@ def test_delete_target_role_access_policy_no_resource_of_datasets_s3_bucket(
     }
 
     mocker.patch("dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists", return_value=True)
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
 
     kms_client = mock_kms_client(mocker)
     kms_client().get_key_id.return_value = "kms-key"
@@ -1161,6 +1173,10 @@ def test_delete_target_role_access_policy_with_multiple_s3_buckets_in_policy(
     }
 
     mocker.patch("dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists", return_value=True)
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
 
     iam_update_role_policy_mock_1 = mocker.patch("dataall.base.aws.iam.IAM.get_managed_policy_default_version", return_value=('v1',iam_policy))
     iam_update_role_policy_mock_2 = mocker.patch("dataall.base.aws.iam.IAM.update_managed_policy_default_version",
@@ -1236,6 +1252,10 @@ def test_delete_target_role_access_policy_with_one_s3_bucket_and_one_kms_resourc
     }
 
     mocker.patch("dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists", return_value=True)
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
 
     kms_client = mock_kms_client(mocker)
     kms_client().get_key_id.return_value = "kms-key"
@@ -1559,6 +1579,10 @@ def test_check_s3_iam_access(
         ]
     }
     mocker.patch("dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists", return_value=True)
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True
+    )
     # Gets policy with S3 and KMS
     iam_update_role_policy_mock_1 = mocker.patch("dataall.base.aws.iam.IAM.get_managed_policy_default_version", return_value=('v1', policy))
 
@@ -1592,6 +1616,31 @@ def test_check_s3_iam_access_no_policy(
     assert(len(share2_manager.bucket_errors)) == 1
     assert "IAM Policy Target Resource" in share2_manager.bucket_errors[0]
 
+def test_check_s3_iam_access_policy_not_attached(
+        mocker,
+        dataset2,
+        share2_manager
+):
+    # Given
+    # There is not existing IAM policy in the requesters account for the dataset's S3bucket
+    # Check if the update_role_policy func is called and policy statements are added
+
+    # When policy does not exist
+    iam_update_role_policy_mock_1 = mocker.patch("dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists", return_value=True)
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=False
+    )
+
+    kms_client = mock_kms_client(mocker)
+    kms_client().get_key_id.return_value = "kms-key"
+    # When
+    share2_manager.check_s3_iam_access()
+    # Then
+    iam_update_role_policy_mock_1.assert_called_once()
+    assert(len(share2_manager.bucket_errors)) == 1
+    assert "IAM Policy attached Target Resource" in share2_manager.bucket_errors[0]
+
 def test_check_s3_iam_access_missing_policy_statement(
         mocker,
         dataset2,
@@ -1617,6 +1666,9 @@ def test_check_s3_iam_access_missing_policy_statement(
         ]
     }
     mocker.patch("dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists", return_value=True)
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True)
     # Gets policy with other S3 and KMS
     iam_update_role_policy_mock_1 = mocker.patch("dataall.base.aws.iam.IAM.get_managed_policy_default_version", return_value=('v1', policy))
 
@@ -1665,6 +1717,9 @@ def test_check_s3_iam_access_missing_target_resource(
         ]
     }
     mocker.patch("dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_exists", return_value=True)
+    mocker.patch(
+        "dataall.modules.dataset_sharing.services.managed_share_policy_service.SharePolicyService.check_if_policy_attached",
+        return_value=True)
     # Gets policy with other S3 and KMS
     iam_update_role_policy_mock_1 = mocker.patch("dataall.base.aws.iam.IAM.get_managed_policy_default_version", return_value=('v1', policy))
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
For S3 bucket shares and for S3 access point shares (folder sharing)
- In share-verify workflow add a check to verify the managed policy for shares is attached to the target role. Log the error and raise an unhealthy status
- In share-approve workflow add a check to verify the managed policy for shares is attached to the target role and attach the policy if the requester is a Group or a data.all Managed Consumption role

### Relates
- #1062 
- #1068 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
