### PR TITLE
Update Cognito WAF Rules for Auth@Edge

### DIFF
--- a/deploy/stacks/waf_rules.py
+++ b/deploy/stacks/waf_rules.py
@@ -90,24 +90,6 @@ def get_waf_rules(envname, name, custom_waf_rules=None, ip_set_regional=None):
     priority += 1
     waf_rules.append(
         wafv2.CfnWebACL.RuleProperty(
-            name='AWS-AWSManagedRulesCommonRuleSet',
-            statement=wafv2.CfnWebACL.StatementProperty(
-                managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
-                    vendor_name='AWS', name='AWSManagedRulesCommonRuleSet'
-                )
-            ),
-            visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
-                sampled_requests_enabled=True,
-                cloud_watch_metrics_enabled=True,
-                metric_name='AWS-AWSManagedRulesCommonRuleSet',
-            ),
-            priority=priority,
-            override_action=wafv2.CfnWebACL.OverrideActionProperty(none={}),
-        )
-    )
-    priority += 1
-    waf_rules.append(
-        wafv2.CfnWebACL.RuleProperty(
             name='AWS-AWSManagedRulesKnownBadInputsRuleSet',
             statement=wafv2.CfnWebACL.StatementProperty(
                 managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
@@ -123,42 +105,61 @@ def get_waf_rules(envname, name, custom_waf_rules=None, ip_set_regional=None):
             override_action=wafv2.CfnWebACL.OverrideActionProperty(none={}),
         )
     )
-    priority += 1
-    waf_rules.append(
-        wafv2.CfnWebACL.RuleProperty(
-            name='AWS-AWSManagedRulesLinuxRuleSet',
-            statement=wafv2.CfnWebACL.StatementProperty(
-                managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
-                    vendor_name='AWS', name='AWSManagedRulesLinuxRuleSet'
-                )
-            ),
-            visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
-                sampled_requests_enabled=True,
-                cloud_watch_metrics_enabled=True,
-                metric_name='AWS-AWSManagedRulesLinuxRuleSet',
-            ),
-            priority=priority,
-            override_action=wafv2.CfnWebACL.OverrideActionProperty(none={}),
+    if name != "Cognito":
+        priority += 1
+        waf_rules.append(
+            wafv2.CfnWebACL.RuleProperty(
+                name='AWS-AWSManagedRulesCommonRuleSet',
+                statement=wafv2.CfnWebACL.StatementProperty(
+                    managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
+                        vendor_name='AWS', name='AWSManagedRulesCommonRuleSet'
+                    )
+                ),
+                visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                    sampled_requests_enabled=True,
+                    cloud_watch_metrics_enabled=True,
+                    metric_name='AWS-AWSManagedRulesCommonRuleSet',
+                ),
+                priority=priority,
+                override_action=wafv2.CfnWebACL.OverrideActionProperty(none={}),
+            )
         )
-    )
-    priority += 1
-    waf_rules.append(
-        wafv2.CfnWebACL.RuleProperty(
-            name='AWS-AWSManagedRulesSQLiRuleSet',
-            statement=wafv2.CfnWebACL.StatementProperty(
-                managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
-                    vendor_name='AWS', name='AWSManagedRulesSQLiRuleSet'
-                )
-            ),
-            visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
-                sampled_requests_enabled=True,
-                cloud_watch_metrics_enabled=True,
-                metric_name='AWS-AWSManagedRulesSQLiRuleSet',
-            ),
-            priority=priority,
-            override_action=wafv2.CfnWebACL.OverrideActionProperty(none={}),
+        priority += 1
+        waf_rules.append(
+            wafv2.CfnWebACL.RuleProperty(
+                name='AWS-AWSManagedRulesLinuxRuleSet',
+                statement=wafv2.CfnWebACL.StatementProperty(
+                    managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
+                        vendor_name='AWS', name='AWSManagedRulesLinuxRuleSet'
+                    )
+                ),
+                visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                    sampled_requests_enabled=True,
+                    cloud_watch_metrics_enabled=True,
+                    metric_name='AWS-AWSManagedRulesLinuxRuleSet',
+                ),
+                priority=priority,
+                override_action=wafv2.CfnWebACL.OverrideActionProperty(none={}),
+            )
         )
-    )
+        priority += 1
+        waf_rules.append(
+            wafv2.CfnWebACL.RuleProperty(
+                name='AWS-AWSManagedRulesSQLiRuleSet',
+                statement=wafv2.CfnWebACL.StatementProperty(
+                    managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
+                        vendor_name='AWS', name='AWSManagedRulesSQLiRuleSet'
+                    )
+                ),
+                visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                    sampled_requests_enabled=True,
+                    cloud_watch_metrics_enabled=True,
+                    metric_name='AWS-AWSManagedRulesSQLiRuleSet',
+                ),
+                priority=priority,
+                override_action=wafv2.CfnWebACL.OverrideActionProperty(none={}),
+            )
+        )
     if name != "Cloudfront":
         priority += 1
         waf_rules.append(


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- Need to remove a managed rule set from WAF associated with Cognito User Pool because it is blocking the request and preventing Userguide from loading
  - Root cause is NoUserAgentHeader check coming from `AWSManagedRulesCommonRuleSet`
  - This PR Removes `AWSManagedRulesCommonRuleSet` along with other unnecessary managed rules set for Cognito User Pool, including `AWSManagedRulesSQLiRuleSet` and `AWSManagedRulesLinuxRuleSet`

  - NOTE: The above managed rule sets still are assigned to BOTH the Cloudfront Distributions (if `internet_facing=True`) AND the API GW Endpoint


### Relates
- N/A

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
