### PR TITLE
Fix issue in SageMaker Create permissions

### DIFF
--- a/backend/dataall/modules/notebooks/cdk/env_role_notebook_policy.py
+++ b/backend/dataall/modules/notebooks/cdk/env_role_notebook_policy.py
@@ -119,7 +119,10 @@ class SagemakernotebookPolicy(ServicePolicy):
             iam.PolicyStatement(
                 # sid="SageMakerDenyCreateDomainsUsers",
                 effect=iam.Effect.DENY,
-                actions=['sagemaker:Create*'],
+                actions=[
+                    'sagemaker:CreateDomain',
+                    'sagemaker:CreateUserProfile',
+                ],
                 resources=[
                     f'arn:aws:sagemaker:{self.region}:{self.account}:domain/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:user-profile/*/*',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Define Create permissions in environment role policy to deny only user and domain creation in SageMaker

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
