### PR TITLE
Fix: worksheet UI improvements - fix Team and list Environments of Team

### DIFF
--- a/backend/dataall/core/environment/api/input_types.py
+++ b/backend/dataall/core/environment/api/input_types.py
@@ -76,6 +76,7 @@ EnvironmentFilter = gql.InputType(
         gql.Argument('displayArchived', gql.Boolean),
         gql.Argument('roles', gql.ArrayType(gql.Ref('EnvironmentPermission'))),
         gql.Argument('quicksight', gql.Boolean),
+        gql.Argument('SamlGroupName', gql.String),
         gql.Argument('sort', gql.ArrayType(EnvironmentSortCriteria)),
         gql.Argument('pageSize', gql.Integer),
     ],

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -541,9 +541,7 @@ class EnvironmentService:
                 )
             )
         if filter and filter.get('SamlGroupName') and filter.get('SamlGroupName') in groups:
-            query = query.filter(
-                EnvironmentGroup.groupUri == filter.get('SamlGroupName')
-            )
+            query = query.filter(EnvironmentGroup.groupUri == filter.get('SamlGroupName'))
         return query
 
     @staticmethod

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -517,8 +517,6 @@ class EnvironmentService:
 
     @staticmethod
     def query_user_environments(session, username, groups, filter) -> Query:
-        if filter and filter.get('SamlGroupName') and filter.get('SamlGroupName') in groups:
-            groups = [filter.get('SamlGroupName')]
         query = (
             session.query(Environment)
             .outerjoin(
@@ -541,6 +539,10 @@ class EnvironmentService:
                     Environment.tags.contains(f'{{{term}}}'),
                     Environment.region.ilike('%' + term + '%'),
                 )
+            )
+        if filter and filter.get('SamlGroupName') and filter.get('SamlGroupName') in groups:
+            query = query.filter(
+                EnvironmentGroup.groupUri == filter.get('SamlGroupName')
             )
         return query
 

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -517,7 +517,7 @@ class EnvironmentService:
 
     @staticmethod
     def query_user_environments(session, username, groups, filter) -> Query:
-        if filter and filter.get('SamlGroupName'):
+        if filter and filter.get('SamlGroupName') and filter.get('SamlGroupName') in groups:
             groups = [filter.get('SamlGroupName')]
         query = (
             session.query(Environment)

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -517,6 +517,8 @@ class EnvironmentService:
 
     @staticmethod
     def query_user_environments(session, username, groups, filter) -> Query:
+        if filter and filter.get('SamlGroupName'):
+            groups = [filter.get('SamlGroupName')]
         query = (
             session.query(Environment)
             .outerjoin(

--- a/backend/dataall/modules/datasets/db/dataset_table_repositories.py
+++ b/backend/dataall/modules/datasets/db/dataset_table_repositories.py
@@ -7,6 +7,7 @@ from sqlalchemy.sql import and_
 from dataall.base.db import exceptions
 from dataall.modules.dataset_sharing.db.share_object_models import ShareObjectItem, ShareObject
 from dataall.modules.dataset_sharing.db.share_object_repositories import ShareItemSM
+from dataall.modules.dataset_sharing.services.dataset_sharing_enums import PrincipalType
 from dataall.modules.datasets_base.db.dataset_models import DatasetTableColumn, DatasetTable, Dataset
 from dataall.base.utils import json_utils
 
@@ -66,6 +67,8 @@ class DatasetTableRepository:
                     ShareObject.datasetUri == dataset_uri,  # for this dataset
                     ShareObject.environmentUri == environment_uri,  # for this environment
                     ShareObjectItem.status.in_(share_item_shared_states),
+                    ShareObject.principalType
+                    != PrincipalType.ConsumptionRole.value,  # Exclude Consumption roles shares
                     or_(
                         ShareObject.owner == username,
                         ShareObject.principalId.in_(groups),

--- a/frontend/src/modules/Worksheets/views/WorksheetView.js
+++ b/frontend/src/modules/Worksheets/views/WorksheetView.js
@@ -90,11 +90,6 @@ const WorksheetView = () => {
 
   const fetchEnvironments = useCallback(
     async (group) => {
-      /* eslint-disable no-console */
-      console.log('Calling fetch environment...');
-      console.log(worksheet);
-      console.log(group);
-      /* eslint-enable no-console */
       setLoadingEnvs(true);
       const response = await client.query(
         listValidEnvironments({

--- a/frontend/src/modules/Worksheets/views/WorksheetView.js
+++ b/frontend/src/modules/Worksheets/views/WorksheetView.js
@@ -159,14 +159,17 @@ const WorksheetView = () => {
             value: d.datasetUri,
             label: d.sharedGlueDatabaseName,
             GlueDatabaseName: d.sharedGlueDatabaseName,
-            environmentUri: d.environmentUri
+            environmentUri: d.environmentUri,
+            principalId: d.principalId
           }));
         // Remove duplicates based on GlueDatabaseName
         sharedWithDatabases = sharedWithDatabases.filter(
           (database, index, self) =>
             index ===
             self.findIndex(
-              (d) => d.GlueDatabaseName === database.GlueDatabaseName
+              (d) =>
+                d.GlueDatabaseName === database.GlueDatabaseName &&
+                d.principalId === team
             )
         );
       }

--- a/frontend/src/modules/Worksheets/views/WorksheetView.js
+++ b/frontend/src/modules/Worksheets/views/WorksheetView.js
@@ -33,7 +33,6 @@ import {
   getSharedDatasetTables,
   listDatasetTableColumns,
   listDatasetsOwnedByEnvGroup,
-  listEnvironmentGroups,
   listValidEnvironments,
   searchEnvironmentDataItems,
   useClient
@@ -57,7 +56,6 @@ const WorksheetView = () => {
   const client = useClient();
   const { enqueueSnackbar } = useSnackbar();
   const [environmentOptions, setEnvironmentOptions] = useState([]);
-  const [groupOptions, setGroupOptions] = useState([]);
   const [worksheet, setWorksheet] = useState({ worksheetUri: '' });
   const [results, setResults] = useState({ rows: [], fields: [] });
   const [loading, setLoading] = useState(true);
@@ -65,7 +63,6 @@ const WorksheetView = () => {
     " select 'A' as dim, 23 as nb\n union \n select 'B' as dim, 43 as nb "
   );
   const [currentEnv, setCurrentEnv] = useState();
-  const [currentTeam, setCurrentTeam] = useState();
   const [loadingEnvs, setLoadingEnvs] = useState(false);
   const [loadingDatabases, setLoadingDatabases] = useState(false);
   const [databaseOptions, setDatabaseOptions] = useState([]);
@@ -109,29 +106,6 @@ const WorksheetView = () => {
     }
     setLoadingEnvs(false);
   }, [client, dispatch]);
-
-  const fetchGroups = async (environmentUri) => {
-    try {
-      const response = await client.query(
-        listEnvironmentGroups({
-          filter: Defaults.selectListFilter,
-          environmentUri
-        })
-      );
-      if (!response.errors) {
-        setGroupOptions(
-          response.data.listEnvironmentGroups.nodes.map((g) => ({
-            value: g.groupUri,
-            label: g.groupUri
-          }))
-        );
-      } else {
-        dispatch({ type: SET_ERROR, error: response.errors[0].message });
-      }
-    } catch (e) {
-      dispatch({ type: SET_ERROR, error: e.message });
-    }
-  };
 
   const fetchDatabases = useCallback(
     async (environment, team) => {
@@ -369,22 +343,9 @@ const WorksheetView = () => {
     setSelectedTable('');
     setDatabaseOptions([]);
     setTableOptions([]);
-    setCurrentTeam('');
     setCurrentEnv(event.target.value);
-    fetchGroups(event.target.value.environmentUri).catch((e) =>
-      dispatch({ type: SET_ERROR, error: e.message })
-    );
-  }
-
-  function handleTeamChange(event) {
-    setColumns([]);
-    setSelectedDatabase('');
-    setSelectedTable('');
-    setDatabaseOptions([]);
-    setTableOptions([]);
-    setCurrentTeam(event.target.value);
-    fetchDatabases(currentEnv, event.target.value).catch((e) =>
-      dispatch({ type: SET_ERROR, error: e.message })
+    fetchDatabases(event.target.value, worksheet.SamlAdminGroupName).catch(
+      (e) => dispatch({ type: SET_ERROR, error: e.message })
     );
   }
 
@@ -474,31 +435,13 @@ const WorksheetView = () => {
                 </Box>
                 <Box sx={{ p: 2, mt: 2 }}>
                   <TextField
+                    disabled
                     fullWidth
                     label="Team"
                     name="team"
-                    onChange={(event) => {
-                      handleTeamChange(event);
-                    }}
-                    select
-                    value={currentTeam}
+                    value={worksheet ? worksheet.SamlAdminGroupName : ''}
                     variant="outlined"
-                    InputProps={{
-                      endAdornment: (
-                        <>
-                          {loadingEnvs ? (
-                            <CircularProgress color="inherit" size={20} />
-                          ) : null}
-                        </>
-                      )
-                    }}
-                  >
-                    {groupOptions.map((group) => (
-                      <MenuItem key={group.value} value={group.value}>
-                        {group.label}
-                      </MenuItem>
-                    ))}
-                  </TextField>
+                  />
                 </Box>
                 <Box sx={{ p: 2 }}>
                   <TextField


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Detail
- Make Team static when opening a Worksheet. It is the same Team that the one that owns the Worksheet
- Modify ListEnvironments to show only the environments for this user AND TEAM
- Fix one bug on shared databases being visible for all teams of an environment
- todo: open 2 issues for the issues found to be fixed on a separate PR

### Testing
Testing scenario:
- Environment 1: TeamA and TeamB added to environment
- Environment 2: TeamA and TeamB added to environment. TeamA creates consumption role CRA
- Dataset created 1: Env1-TeamA
- Dataset imported 1: Env1-TeamA
- Dataset imported with central catalog: Env1-TeamA ---> shared with Env1-TeamB
- Dataset created2: Env2-TeamA ---> shared with Env1-TeamA and Env1-CRA

Worksheet owned by TeamA
- [X] UI can Select Env1 or Env2
- [X] When selecting env1: UI shows OWNED CREATED database without duplicates
- [X] When selecting env1: UI shows OWNED IMPORTED database without duplicates
- [X] When selecting env1: UI shows OWNED IMPORTED CENTRAL CATALOG database without duplicates --> 🔴  The listing of tables is correct, but the query fails `Insufficient permissions to execute the query. Insufficient Lake Formation permission(s) on rl_imported_central_sse_c3`
- [X] When selecting env1: UI shows SHARED database without duplicates  🔴  it shows 1 single database for the 2 shares (TeamA and CR_A). Each share requested a different table. In the drop-down it shows both tables which is incorrect, but, querying the table shared with CR_A fails `TABLE_NOT_FOUND: line 1:15: Table  'awsdatacatalog.dataall_lcreated_a2_l7pm61ii_shared.books_raw' does not exist` ---> FIXED!
- [X] When selecting env2: UI shows OWNED database in env2
- [X] UI can change from environment, database... without glitches - databases and tables are cleaned up

Worksheet owned by TeamB

- [X] When selecting env1: UI shows SHARED IMPORTED CENTRAL CATALOG database without duplicates 🔴  Error: it shows the SHARED database with TeamA!! --> FIXED!
- [X] When selecting env2: UI shows no databases
- [X] UI can change from environment, database... without glitches

### Issues found:
- Insufficient Lake Formation permissions when running Query for OWNED IMPORTED CENTRAL CATALOG database
- When there are consumption roles the shared database shows all tables shared (the ones with team IAM roles and the ones with CR) when it should only show the ones for the team IAM roles. The issue is that now we have a single Glue shared database and we are getting the tables from Glue, which means we get all the shared tables. The issue is in `getSharedDatasetTables` --> Fixed
- Showing Shared databases with other teams --> Fixed


### Relates
- #984 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/). `N/A`

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
