### PR TITLE
Fix EnvUri to check GET_ENV permission for worksheet

### DIFF
--- a/backend/dataall/modules/dataset_sharing/api/resolvers.py
+++ b/backend/dataall/modules/dataset_sharing/api/resolvers.py
@@ -255,7 +255,7 @@ def resolve_shared_database_name(context: Context, source):
         return None
     old_shared_db_name = (source.GlueDatabaseName + '_shared_' + source.shareUri)[:254]
     with context.engine.scoped_session() as session:
-        share = ShareObjectService.get_share_object_in_environment(uri=source.environmentUri, shareUri=source.shareUri)
+        share = ShareObjectService.get_share_object_in_environment(uri=source.targetEnvironmentUri, shareUri=source.shareUri)
         env = EnvironmentService.get_environment_by_uri(session, share.environmentUri)
         database = GlueClient(
             account_id=env.AwsAccountId, database=old_shared_db_name, region=env.region

--- a/backend/dataall/modules/dataset_sharing/api/types.py
+++ b/backend/dataall/modules/dataset_sharing/api/types.py
@@ -199,6 +199,7 @@ EnvironmentPublishedItem = gql.ObjectType(
         gql.Field(name='itemAccess', type=gql.NonNullableType(gql.String)),
         gql.Field(name='itemType', type=gql.NonNullableType(gql.String)),
         gql.Field(name='environmentUri', type=gql.NonNullableType(gql.String)),
+        gql.Field(name='targetEnvironmentUri', type=gql.NonNullableType(gql.String)),
         gql.Field(name='principalId', type=gql.NonNullableType(gql.String)),
         gql.Field(name='environmentName', type=gql.NonNullableType(gql.String)),
         gql.Field(name='organizationUri', type=gql.NonNullableType(gql.String)),

--- a/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
+++ b/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
@@ -1070,6 +1070,7 @@ class ShareObjectRepository:
                 ShareObject.created.label('created'),
                 ShareObject.principalId.label('principalId'),
                 ShareObject.principalType.label('principalType'),
+                ShareObject.environmentUri.label('targetEnvironmentUri'),
                 ShareObjectItem.itemType.label('itemType'),
                 ShareObjectItem.GlueDatabaseName.label('GlueDatabaseName'),
                 ShareObjectItem.GlueTableName.label('GlueTableName'),


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- For Worksheets... Check `GET_ENVIRONMENT` permissions on the environment selected in the worksheet dropdown (i.e. the share's requestor environment) - NOT the environment of the dataset
  - Specifically for shared Datasets queried in the `searchEnvironmentDataItems` query

### Relates
- https://github.com/data-dot-all/dataall/issues/1124

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? No
  - Is the input sanitized? N/A
  - What precautions are you taking before deserializing the data you consume? N/A
  - Is injection prevented by parametrizing queries? N/A
  - Have you ensured no `eval` or similar functions are used? Yes
- Does this PR introduce any functionality or component that requires authorization? No
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms? N/A
  - Are you logging failed auth attempts? N/A
- Are you using or adding any cryptographic features? No
  - Do you use a standard proven implementations? Yes
  - Are the used keys controlled by the customer? Where are they stored? N/A
- Are you introducing any new policies/roles/users? No
  - Have you used the least-privilege principle? How? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
