### PR TITLE
unused import protected from ruff

### DIFF
--- a/backend/dataall/core/environment/cdk/pivot_role_stack.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_stack.py
@@ -4,6 +4,13 @@ from constructs import Construct
 from aws_cdk import Duration, aws_iam as iam, NestedStack
 from dataall.base.utils.iam_policy_utils import split_policy_statements_in_chunks
 
+# disable ruff-format, because this unused imports are important
+# pivot_role_core_policies is used to fill PivotRoleStatementSet subclasses (line 31)
+# fmt: off
+from dataall.core.environment.cdk import pivot_role_core_policies
+# fmt: on
+# enable ruff-format back
+
 logger = logging.getLogger(__name__)
 
 

--- a/backend/dataall/core/environment/cdk/pivot_role_stack.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_stack.py
@@ -4,13 +4,6 @@ from constructs import Construct
 from aws_cdk import Duration, aws_iam as iam, NestedStack
 from dataall.base.utils.iam_policy_utils import split_policy_statements_in_chunks
 
-# disable ruff-format, because this unused imports are important
-# pivot_role_core_policies is used to fill PivotRoleStatementSet subclasses (line 31)
-# fmt: off
-from dataall.core.environment.cdk import pivot_role_core_policies
-# fmt: on
-# enable ruff-format back
-
 logger = logging.getLogger(__name__)
 
 
@@ -59,6 +52,13 @@ class PivotRoleStatementSet(object):
         :return: list
         """
         raise NotImplementedError('PivotRoleStatementSet subclasses need to implement the get_statements class method')
+
+
+# IT IS HERE TO AVOID CIRCULAR IMPORT
+# disable ruff-format, because this unused imports are important
+# pivot_role_core_policies is used to fill PivotRoleStatementSet subclasses (line 31)
+# ruff: noqa: E402
+from dataall.core.environment.cdk import pivot_role_core_policies
 
 
 class PivotRole(NestedStack):

--- a/backend/dataall/modules/dataset_sharing/api/resolvers.py
+++ b/backend/dataall/modules/dataset_sharing/api/resolvers.py
@@ -255,7 +255,9 @@ def resolve_shared_database_name(context: Context, source):
         return None
     old_shared_db_name = (source.GlueDatabaseName + '_shared_' + source.shareUri)[:254]
     with context.engine.scoped_session() as session:
-        share = ShareObjectService.get_share_object_in_environment(uri=source.targetEnvironmentUri, shareUri=source.shareUri)
+        share = ShareObjectService.get_share_object_in_environment(
+            uri=source.targetEnvironmentUri, shareUri=source.shareUri
+        )
         env = EnvironmentService.get_environment_by_uri(session, share.environmentUri)
         database = GlueClient(
             account_id=env.AwsAccountId, database=old_shared_db_name, region=env.region


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
ruff removed unused import from `dataall/backend/dataall/core/environment/cdk/pivot_role_stack.py`
But it was secretly used in line 31:   classes imported from that file are the subclasses of `PivotRoleStatementSet`,
they are crucial for right permissions for pivot role.

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
- Does this PR introduce any functionality or component that requires authorization? N/A
- Are you using or adding any cryptographic features? N/A
- Are you introducing any new policies/roles/users? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
