### PR TITLE
Restricting Team/User Access to Worksheets

### DIFF
--- a/backend/dataall/modules/datasets/cdk/env_role_dataset_glue_policy.py
+++ b/backend/dataall/modules/datasets/cdk/env_role_dataset_glue_policy.py
@@ -10,9 +10,6 @@ class DatasetGlueCatalogServicePolicy(ServicePolicy):
     """
 
     def get_statements(self, group_permissions, **kwargs):
-        if CREATE_DATASET not in group_permissions:
-            return []
-
         statements = [
             iam.PolicyStatement(
                 # sid="GlueLFReadData",

--- a/backend/dataall/modules/datasets/indexers/location_indexer.py
+++ b/backend/dataall/modules/datasets/indexers/location_indexer.py
@@ -1,4 +1,5 @@
 """Indexes DatasetStorageLocation in OpenSearch"""
+
 import re
 
 from dataall.core.environment.services.environment_service import EnvironmentService

--- a/backend/dataall/modules/datasets/indexers/table_indexer.py
+++ b/backend/dataall/modules/datasets/indexers/table_indexer.py
@@ -1,4 +1,5 @@
 """Indexes DatasetTable in OpenSearch"""
+
 import re
 
 from dataall.core.environment.services.environment_service import EnvironmentService


### PR DESCRIPTION
### Feature or Bugfix

- Bugfix


### Detail
Glue-permissions were added to the team's env role only if the role had CREATE_DATASET permissions. But `glue-permissions are about the get-operations, so i removed that if, so the required permissions are added to the team's env role regardless of CREATE_DATASET 


### Relates
- [945](https://github.com/data-dot-all/dataall/issues/945)

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
- Does this PR introduce any functionality or component that requires authorization? N/A
- Are you using or adding any cryptographic features? N/A
- Are you introducing any new policies/roles/users? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
