### PR TITLE
Allow ListEnv to get associated org information

### DIFF
--- a/backend/dataall/core/environment/api/resolvers.py
+++ b/backend/dataall/core/environment/api/resolvers.py
@@ -28,7 +28,7 @@ from dataall.base.utils.naming_convention import (
     NamingConventionService,
     NamingConventionPattern,
 )
-from dataall.core.organizations.api.resolvers import Context, exceptions, get_organization
+from dataall.core.organizations.api.resolvers import Context, exceptions, get_organization_simplified
 
 log = logging.getLogger()
 
@@ -337,7 +337,7 @@ def list_environment_networks(context: Context, source, environmentUri=None, fil
 
 
 def get_parent_organization(context: Context, source, **kwargs):
-    org = get_organization(context, source, organizationUri=source.organizationUri)
+    org = get_organization_simplified(context, source, organizationUri=source.organizationUri)
     return org
 
 

--- a/backend/dataall/core/environment/api/types.py
+++ b/backend/dataall/core/environment/api/types.py
@@ -82,7 +82,7 @@ Environment = gql.ObjectType(
         gql.Field(name='datasets', type=gql.String),
         gql.Field(
             name='organization',
-            type=gql.Ref('Organization'),
+            type=gql.Ref('OrganizationSimplified'),
             resolver=get_parent_organization,
         ),
         gql.Field(
@@ -138,7 +138,7 @@ EnvironmentSimplified = gql.ObjectType(
         gql.Field(name='region', type=gql.String),
         gql.Field(
             name='organization',
-            type=gql.Ref('Organization'),
+            type=gql.Ref('OrganizationSimplified'),
             resolver=get_parent_organization,
         ),
         gql.Field(

--- a/backend/dataall/core/organizations/api/resolvers.py
+++ b/backend/dataall/core/organizations/api/resolvers.py
@@ -25,6 +25,8 @@ def update_organization(context, source, organizationUri=None, input=None):
 def get_organization(context: Context, source, organizationUri=None):
     return OrganizationService.get_organization(uri=organizationUri)
 
+def get_organization_simplified(context: Context, source, organizationUri=None):
+    return OrganizationService.get_organization_simplified(uri=organizationUri)
 
 def list_organizations(context: Context, source, filter=None):
     if not filter:

--- a/backend/dataall/core/organizations/api/types.py
+++ b/backend/dataall/core/organizations/api/types.py
@@ -51,3 +51,12 @@ OrganizationSearchResult = gql.ObjectType(
         gql.Field(name='nodes', type=gql.ArrayType(Organization)),
     ],
 )
+
+OrganizationSimplified = gql.ObjectType(
+    name='OrganizationSimplified',
+    fields=[
+        gql.Field(name='organizationUri', type=gql.ID),
+        gql.Field(name='label', type=gql.String),
+        gql.Field(name='name', type=gql.String)
+    ],
+)

--- a/backend/dataall/core/organizations/services/organization_service.py
+++ b/backend/dataall/core/organizations/services/organization_service.py
@@ -93,6 +93,12 @@ class OrganizationService:
             return OrganizationRepository.get_organization_by_uri(session=session, uri=uri)
 
     @staticmethod
+    def get_organization_simplified(uri):
+        context = get_context()
+        with context.db_engine.scoped_session() as session:
+            return OrganizationRepository.get_organization_by_uri(session=session, uri=uri)
+
+    @staticmethod
     def list_organizations(filter):
         context = get_context()
         with context.db_engine.scoped_session() as session:


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix (TBD)

### Detail
- If a group is invited to an environment but is not invited to an organization then the invited group is unable to perform any actions that involve the `listEnvironments` or `listValidEnvironments` queries 
  - Includes listing environments in data.all console on Environments Tab
  - Includes creating new resources like Datasets, Notebooks, etc.
  - Includes selecting Environments on Worksheets
- This is because the user receives Unauthorized exception on GET_ORGANIZATION permission for the parent org

- This PR creates a new child resolver to get high-level parent org information (orgUri, name, label) about the associated environment without the permissions check on GET_ORGANIZATION
  - Defines new `OrganizationSimplified` type and new `get_organization_simplified` method


### Relates


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
