### PR TITLE
WAF rule parameters in cdk.json + Documantation

### DIFF
--- a/backend/dataall/modules/datasets/indexers/location_indexer.py
+++ b/backend/dataall/modules/datasets/indexers/location_indexer.py
@@ -1,4 +1,5 @@
 """Indexes DatasetStorageLocation in OpenSearch"""
+
 import re
 
 from dataall.core.environment.services.environment_service import EnvironmentService

--- a/backend/dataall/modules/datasets/indexers/table_indexer.py
+++ b/backend/dataall/modules/datasets/indexers/table_indexer.py
@@ -1,4 +1,5 @@
 """Indexes DatasetTable in OpenSearch"""
+
 import re
 
 from dataall.core.environment.services.environment_service import EnvironmentService

--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -55,6 +55,7 @@ class BackendStack(Stack):
         reauth_config=None,
         cognito_user_session_timeout_inmins=43200,
         custom_auth=None,
+        custom_waf_rules=None,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -123,6 +124,7 @@ class BackendStack(Stack):
                 enable_cw_rum=enable_cw_rum,
                 vpc=vpc,
                 cognito_user_session_timeout_inmins=cognito_user_session_timeout_inmins,
+                custom_waf_rules=custom_waf_rules,
                 **kwargs,
             )
         else:
@@ -191,6 +193,7 @@ class BackendStack(Stack):
             ses_configuration_set=ses_stack.configuration_set.configuration_set_name if ses_stack is not None else None,
             custom_domain=custom_domain,
             custom_auth=custom_auth,
+            custom_waf_rules=custom_waf_rules,
             **kwargs,
         )
 

--- a/deploy/stacks/backend_stage.py
+++ b/deploy/stacks/backend_stage.py
@@ -35,6 +35,7 @@ class BackendStage(Stage):
         reauth_config=None,
         cognito_user_session_timeout_inmins=43200,
         custom_auth=None,
+        custom_waf_rules=None,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -67,6 +68,7 @@ class BackendStage(Stage):
             reauth_config=reauth_config,
             cognito_user_session_timeout_inmins=cognito_user_session_timeout_inmins,
             custom_auth=custom_auth,
+            custom_waf_rules=custom_waf_rules,
             **kwargs,
         )
 

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -631,7 +631,7 @@ class PipelineStack(Stack):
                 reauth_config=target_env.get('reauth_config', None),
                 cognito_user_session_timeout_inmins=target_env.get('cognito_user_session_timeout_inmins', 43200),
                 custom_auth=target_env.get('custom_auth', None),
-                custom_waf_rules=target_env.get('custom_waf_rules', False),
+                custom_waf_rules=target_env.get('custom_waf_rules', None),
             )
         )
         return backend_stage
@@ -708,7 +708,7 @@ class PipelineStack(Stack):
                 tooling_account_id=self.account,
                 custom_domain=target_env.get('custom_domain'),
                 custom_auth=target_env.get('custom_auth', None),
-                custom_waf_rules=target_env.get('custom_waf_rules', False),
+                custom_waf_rules=target_env.get('custom_waf_rules', None),
             )
         )
         front_stage_actions = (

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -631,6 +631,7 @@ class PipelineStack(Stack):
                 reauth_config=target_env.get('reauth_config', None),
                 cognito_user_session_timeout_inmins=target_env.get('cognito_user_session_timeout_inmins', 43200),
                 custom_auth=target_env.get('custom_auth', None),
+                custom_waf_rules=target_env.get('custom_waf_rules', False),
             )
         )
         return backend_stage
@@ -707,6 +708,7 @@ class PipelineStack(Stack):
                 tooling_account_id=self.account,
                 custom_domain=target_env.get('custom_domain'),
                 custom_auth=target_env.get('custom_auth', None),
+                custom_waf_rules=target_env.get('custom_waf_rules', False),
             )
         )
         front_stage_actions = (

--- a/documentation/userguide/docs/security.md
+++ b/documentation/userguide/docs/security.md
@@ -35,3 +35,39 @@ Any user data transmitted over the internet is SSL-encrypted over HTTPS.
 ### **Authentication**
 The data.all authentication process is based SAML 2.0–based login. data.all can also integrate into organizations’
 existing SAML 2.0–based SSO authentication systems.
+
+### **AWS Web Application Firewall (WAF)**
+Data.all supports the opportunity to add custom rules to AWS WAF. These rules are set in `cdk.json` at the root level of the repository.
+As a custom rules (property `custom_waf_rules`) customer can set two allow lists:
+* The Geo match allow-list (property `allowed_geo_list`) is an array of two-character country codes that you want to match against. 
+If this property is specified, WAF will block web requests from all other countries, otherwise requests from all countries will be allowed.
+* The IP match allow-list (property `allowed_ip_list`) is used to specify zero or more IP addresses or blocks of IP addresses. 
+If this property is specified, WAF will block web requests from all other IP addresses, otherwise requests from all IP addresses will be allowed.
+
+Example of custom WAF rules setting:
+```json
+{
+  "app": "python ./deploy/app.py",
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": false,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": false,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": false,
+    "@aws-cdk/core:stackRelativeExports": false,
+    "tooling_region": "eu-west-1",
+    "custom_waf_rules": {
+      "allowed_geo_list": [ "US", "CN" ],
+      "allowed_ip_list":  ["192.0.2.44/32", "192.0.2.0/24", "192.0.0.0/16"] 
+    },
+    "DeploymentEnvironments": [
+        {
+            "envname": "dev",
+            "account": "000000000000",
+            "region": "eu-west-1",
+            "enable_pivot_role_auto_create": true,
+            "enable_opensearch_serverless": true
+        }
+    ]
+  }
+}
+```
+

--- a/documentation/userguide/docs/security.md
+++ b/documentation/userguide/docs/security.md
@@ -54,17 +54,22 @@ Example of custom WAF rules setting:
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": false,
     "@aws-cdk/core:stackRelativeExports": false,
     "tooling_region": "eu-west-1",
-    "custom_waf_rules": {
-      "allowed_geo_list": [ "US", "CN" ],
-      "allowed_ip_list":  ["192.0.2.44/32", "192.0.2.0/24", "192.0.0.0/16"] 
-    },
     "DeploymentEnvironments": [
         {
             "envname": "dev",
             "account": "000000000000",
             "region": "eu-west-1",
-            "enable_pivot_role_auto_create": true,
-            "enable_opensearch_serverless": true
+            "custom_waf_rules": {
+                "allowed_geo_list": [
+                  "US",
+                  "CN"
+                ],
+                "allowed_ip_list": [
+                  "192.0.2.44/32",
+                  "192.0.2.0/24",
+                  "192.0.0.0/16"
+                ]
+              }
         }
     ]
   }


### PR DESCRIPTION
### Feature or Bugfix
- Feature


### Detail
- custom_waf_rules property can be added in cdk.json and parsed by pipeline
- documentation is updated

### Relates
- [Add custom_waf_rules in cdk.json and in instructions #995](https://github.com/data-dot-all/dataall/issues/995)

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
- Does this PR introduce any functionality or component that requires authorization? N/A
- Are you using or adding any cryptographic features? N/A
- Are you introducing any new policies/roles/users? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
