### PR TITLE
Fixes for email notifications not sending share link in the body

### DIFF
--- a/backend/dataall/modules/dataset_sharing/services/share_notification_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_notification_service.py
@@ -43,38 +43,36 @@ class ShareNotificationService:
 
     def notify_share_object_submission(self, email_id: str):
         share_link_text = ''
-        if os.environ.get('frontend_domain_url'):
-            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/console/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
+        if os.environ.get("frontend_domain_url"):
+            share_link_text = f'<br><br> Please visit data.all <a href="{os.environ.get("frontend_domain_url")}/console/shares/{self.share.shareUri}">share link </a> to take action or view more details'
         msg = f'User {email_id} SUBMITTED share request for dataset {self.dataset.label} for principal {self.share.principalId}'
         subject = f'Data.all | Share Request Submitted for {self.dataset.label}'
         email_notification_msg = msg + share_link_text
 
         notifications = self._register_notifications(
-            notification_type=DataSharingNotificationType.SHARE_OBJECT_SUBMITTED.value, msg=msg
-        )
+            notification_type=DataSharingNotificationType.SHARE_OBJECT_SUBMITTED.value, msg=msg)
 
         self._create_notification_task(subject=subject, msg=email_notification_msg)
         return notifications
 
     def notify_share_object_approval(self, email_id: str):
         share_link_text = ''
-        if os.environ.get('frontend_domain_url'):
-            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/console/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
+        if os.environ.get("frontend_domain_url"):
+            share_link_text = f'<br><br> Please visit data.all <a href="{os.environ.get("frontend_domain_url")}/console/shares/{self.share.shareUri}">share link </a> to take action or view more details'
         msg = f'User {email_id} APPROVED share request for dataset {self.dataset.label} for principal {self.share.principalId}'
         subject = f'Data.all | Share Request Approved for {self.dataset.label}'
         email_notification_msg = msg + share_link_text
 
         notifications = self._register_notifications(
-            notification_type=DataSharingNotificationType.SHARE_OBJECT_APPROVED.value, msg=msg
-        )
+            notification_type=DataSharingNotificationType.SHARE_OBJECT_APPROVED.value, msg=msg)
 
         self._create_notification_task(subject=subject, msg=email_notification_msg)
         return notifications
 
     def notify_share_object_rejection(self, email_id: str):
         share_link_text = ''
-        if os.environ.get('frontend_domain_url'):
-            share_link_text = f'<br><br> Please visit Data.all <a href="{os.environ.get("frontend_domain_url")}"/console/shares/{self.share.shareUri}">Share link </a> to take action or view more details'
+        if os.environ.get("frontend_domain_url"):
+            share_link_text = f'<br><br> Please visit data.all <a href="{os.environ.get("frontend_domain_url")}/console/shares/{self.share.shareUri}">share link </a> to take action or view more details'
         if self.share.status == ShareObjectStatus.Rejected.value:
             msg = f'User {email_id} REJECTED share request for dataset {self.dataset.label} for principal {self.share.principalId}'
             subject = f'Data.all | Share Request Rejected for {self.dataset.label}'
@@ -87,8 +85,7 @@ class ShareNotificationService:
         email_notification_msg = msg + share_link_text
 
         notifications = self._register_notifications(
-            notification_type=DataSharingNotificationType.SHARE_OBJECT_REJECTED.value, msg=msg
-        )
+            notification_type=DataSharingNotificationType.SHARE_OBJECT_REJECTED.value, msg=msg)
 
         self._create_notification_task(subject=subject, msg=email_notification_msg)
         return notifications
@@ -97,8 +94,7 @@ class ShareNotificationService:
         msg = f'New data (at {s3_prefix}) is available from dataset {self.dataset.datasetUri} shared by owner {self.dataset.owner}'
 
         notifications = self._register_notifications(
-            notification_type=DataSharingNotificationType.DATASET_VERSION.value, msg=msg
-        )
+            notification_type=DataSharingNotificationType.DATASET_VERSION.value, msg=msg)
         return notifications
 
     def _get_share_object_targeted_users(self):
@@ -118,7 +114,7 @@ class ShareNotificationService:
         """
         notifications = []
         for recipient in self.notification_target_users:
-            log.info(f'Creating notification for {recipient}, msg {msg}')
+            log.info(f"Creating notification for {recipient}, msg {msg}")
             notifications.append(
                 NotificationRepository.create_notification(
                     session=self.session,
@@ -148,8 +144,8 @@ class ShareNotificationService:
                     notification_recipient_groups_list = [self.dataset.SamlAdminGroupName, self.dataset.stewards]
                     notification_recipient_email_ids = []
 
-                    if share_notification_config_type == 'email':
-                        if params.get('group_notifications', False) == True:
+                    if share_notification_config_type == "email":
+                        if params.get("group_notifications", False) == True:
                             notification_recipient_groups_list.append(self.share.groupUri)
                         else:
                             notification_recipient_email_ids = [self.share.owner]
@@ -162,7 +158,7 @@ class ShareNotificationService:
                                 'subject': subject,
                                 'message': msg,
                                 'recipientGroupsList': notification_recipient_groups_list,
-                                'recipientEmailList': notification_recipient_email_ids,
+                                'recipientEmailList': notification_recipient_email_ids
                             },
                         )
                         self.session.add(notification_task)

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -94,7 +94,6 @@ class LambdaApiStack(pyNestedClass):
         # Check if custom domain exists and if it exists email notifications could be enabled. Create a env variable which stores the domain url. This is used for sending data.all share weblinks in the email notifications.
         if custom_domain and custom_domain.get('hosted_zone_name', None):
             api_handler_env['frontend_domain_url'] = f'https://{custom_domain.get("hosted_zone_name", None)}'
-        api_handler_role = self.create_function_role(envname, resource_prefix, 'graphql', pivot_role_name)
         if custom_auth:
             api_handler_env['custom_auth'] = custom_auth.get('provider', None)
         self.api_handler = _lambda.DockerImageFunction(
@@ -102,7 +101,7 @@ class LambdaApiStack(pyNestedClass):
             'LambdaGraphQL',
             function_name=f'{resource_prefix}-{envname}-graphql',
             description='dataall graphql function',
-            role=api_handler_role,
+            role=self.create_function_role(envname, resource_prefix, 'graphql', pivot_role_name),
             code=_lambda.DockerImageCode.from_ecr(
                 repository=ecr_repository, tag=image_tag, cmd=['api_handler.handler']
             ),


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Correcting place where the environment variable containing frontend URL is defined. Earlier it was in the AWSWorker lambda env but it is needed in the graphQL lambda
- Removing " which was causing issues when clicking on email address. Also lowercased words. 

### Relates
- https://github.com/data-dot-all/dataall/issues/1142

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization? N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users? N/A
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
