### PR TITLE
Add share_reapply task - ON DEMAND for data.all admins

### DIFF
--- a/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
+++ b/backend/dataall/modules/dataset_sharing/db/share_object_repositories.py
@@ -730,6 +730,24 @@ class ShareObjectRepository:
         )
 
     @staticmethod
+    def update_share_item_health_status_batch(
+        session,
+        share_uri: str,
+        old_status: str,
+        new_status: str,
+    ) -> bool:
+        (
+            session.query(ShareObjectItem)
+            .filter(and_(ShareObjectItem.shareUri == share_uri, ShareObjectItem.healthStatus == old_status))
+            .update(
+                {
+                    ShareObjectItem.healthStatus: new_status,
+                }
+            )
+        )
+        return True
+
+    @staticmethod
     def update_share_item_status_batch(
         session,
         share_uri: str,

--- a/backend/dataall/modules/dataset_sharing/tasks/share_reapplier_task.py
+++ b/backend/dataall/modules/dataset_sharing/tasks/share_reapplier_task.py
@@ -14,7 +14,7 @@ if not root.hasHandlers():
 log = logging.getLogger(__name__)
 
 
-def verify_shares(engine):
+def reapply_shares(engine):
     """
     A method used by the scheduled ECS Task to re-apply_share() on all data.all active shares
     """
@@ -41,4 +41,4 @@ def verify_shares(engine):
 if __name__ == '__main__':
     ENVNAME = os.environ.get('envname', 'local')
     ENGINE = get_engine(envname=ENVNAME)
-    verify_shares(engine=ENGINE)
+    reapply_shares(engine=ENGINE)

--- a/backend/dataall/modules/dataset_sharing/tasks/share_reapplier_task.py
+++ b/backend/dataall/modules/dataset_sharing/tasks/share_reapplier_task.py
@@ -1,0 +1,38 @@
+import logging
+import os
+import sys
+from dataall.modules.dataset_sharing.api.types import ShareObject
+from dataall.modules.dataset_sharing.db.share_object_repositories import ShareObjectRepository
+from dataall.modules.dataset_sharing.services.dataset_sharing_enums import ShareItemStatus
+from dataall.modules.dataset_sharing.services.data_sharing_service import DataSharingService
+from dataall.base.db import get_engine
+
+root = logging.getLogger()
+root.setLevel(logging.INFO)
+if not root.hasHandlers():
+    root.addHandler(logging.StreamHandler(sys.stdout))
+log = logging.getLogger(__name__)
+
+
+def verify_shares(engine):
+    """
+    A method used by the scheduled ECS Task to re-apply_share() on all data.all active shares
+    """
+    with engine.scoped_session() as session:
+        processed_share_objects = []
+        all_share_objects: [ShareObject] = ShareObjectRepository.list_all_active_share_objects(session)
+        log.info(f'Found {len(all_share_objects)} share objects ')
+        share_object: ShareObject
+        for share_object in all_share_objects:
+            log.info(
+                f'Re-applying Share Items for Share Object with Requestor: {share_object.principalId} on Target Dataset: {share_object.datasetUri}'
+            )
+            processed_share_objects.append(share_object.shareUri)
+            DataSharingService.reapply_share(engine, share_uri=share_object.shareUri)
+        return processed_share_objects
+
+
+if __name__ == '__main__':
+    ENVNAME = os.environ.get('envname', 'local')
+    ENGINE = get_engine(envname=ENVNAME)
+    verify_shares(engine=ENGINE)

--- a/backend/dataall/modules/dataset_sharing/tasks/share_reapplier_task.py
+++ b/backend/dataall/modules/dataset_sharing/tasks/share_reapplier_task.py
@@ -3,7 +3,7 @@ import os
 import sys
 from dataall.modules.dataset_sharing.api.types import ShareObject
 from dataall.modules.dataset_sharing.db.share_object_repositories import ShareObjectRepository
-from dataall.modules.dataset_sharing.services.dataset_sharing_enums import ShareItemStatus
+from dataall.modules.dataset_sharing.services.dataset_sharing_enums import ShareItemHealthStatus
 from dataall.modules.dataset_sharing.services.data_sharing_service import DataSharingService
 from dataall.base.db import get_engine
 
@@ -28,6 +28,12 @@ def verify_shares(engine):
                 f'Re-applying Share Items for Share Object with Requestor: {share_object.principalId} on Target Dataset: {share_object.datasetUri}'
             )
             processed_share_objects.append(share_object.shareUri)
+            ShareObjectRepository.update_share_item_health_status_batch(
+                session=session,
+                share_uri=share_object.shareUri,
+                old_status=ShareItemHealthStatus.Unhealthy.value,
+                new_status=ShareItemHealthStatus.PendingReApply.value,
+            )
             DataSharingService.reapply_share(engine, share_uri=share_object.shareUri)
         return processed_share_objects
 

--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -176,6 +176,7 @@ class ContainerStack(pyNestedClass):
         self.add_subscription_task()
         self.add_share_management_task()
         self.add_share_verifier_task()
+        self.add_share_reapplier_task()
 
     @run_if(['modules.datasets.active', 'modules.dashboards.active'])
     def add_catalog_indexer_task(self):


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
Implements https://github.com/data-dot-all/dataall/issues/1150
- Add **on-demand** ECS task to reapply shares
- It goes through ALL active shares, if there are unhealthy items, it reapplies the share

As explained in the issue description, this task is a resource of data.all admins that can run it on-demand using ECS commands or directly in the AWS console. We could extend how it is used:
- By triggering it in the `share-verifier` task daily. We can add a one-liner that triggers the share-reapplier task at the end of the share-verifier task.
- By adding functionalities in the UI that allow users to trigger this task

### Testing
Deploying in AWS:
- [X] CICD pipeline runs successfully and creates new on-demand ECS task definition `share-reapplier`
- [X] We can run the ECS task `share-reapplier` from the AWS console
- [X] Checking the logs of the ECS task `share-reapplier` without any unhealthy share succeeds
- [X] Checking the logs of the ECS task `share-reapplier` with unhealthy shares succeeds - reapplies the unhealthy shares

### Relates
- #1150 
- #1064 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
