### PR TITLE
Add high throughput ssm on prod_sizing

### DIFF
--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -92,6 +92,7 @@ class BackendStack(Stack):
             enable_pivot_role_auto_create=enable_pivot_role_auto_create,
             pivot_role_name=self.pivot_role_name,
             reauth_apis=reauth_config.get('reauth_apis', None) if reauth_config else None,
+            prod_sizing=prod_sizing,
             **kwargs,
         )
         if enable_cw_canaries:

--- a/deploy/stacks/param_store_stack.py
+++ b/deploy/stacks/param_store_stack.py
@@ -26,6 +26,7 @@ class ParamStoreStack(pyNestedClass):
         enable_pivot_role_auto_create=False,
         pivot_role_name='dataallPivotRole',
         reauth_apis=None,
+        prod_sizing=False,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -131,23 +132,23 @@ class ParamStoreStack(pyNestedClass):
             string_value=str(json.dumps(deploy_config.get_dataall_version())),
             description='Deployed data all version',
         )
-
-        cr.AwsCustomResource(
-            self, 
-            "SSMParamSettingHighThroughput",
-            on_update=cr.AwsSdkCall(
-                service="SSM",
-                action="UpdateServiceSettingCommand",
-                parameters={
-                    "SettingId": "/ssm/parameter-store/high-throughput-enabled",
-                    "SettingValue": "true"
-                },
-                physical_resource_id=cr.PhysicalResourceId.from_response(f"ssm-high-throughput-{self.account}-{self.region}")
-            ),
-            policy=cr.AwsCustomResourcePolicy.from_sdk_calls(
-                resources=[f"arn:aws:ssm:{self.region}:{self.account}:servicesetting/ssm/parameter-store/high-throughput-enabled"]
+        if prod_sizing:
+            cr.AwsCustomResource(
+                self, 
+                "SSMParamSettingHighThroughput",
+                on_update=cr.AwsSdkCall(
+                    service="SSM",
+                    action="UpdateServiceSettingCommand",
+                    parameters={
+                        "SettingId": "/ssm/parameter-store/high-throughput-enabled",
+                        "SettingValue": "true"
+                    },
+                    physical_resource_id=cr.PhysicalResourceId.of(f"ssm-high-throughput-{self.account}-{self.region}")
+                ),
+                policy=cr.AwsCustomResourcePolicy.from_sdk_calls(
+                    resources=[f"arn:aws:ssm:{self.region}:{self.account}:servicesetting/ssm/parameter-store/high-throughput-enabled"]
+                )
             )
-        )
 
 
 def _get_external_id_value(envname, account_id, region):


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- if `prod_sizing` is `True` enable SSM high throughput

### Relates
- https://github.com/data-dot-all/dataall/issues/953

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
