### PR TITLE
Add Athena List permissions to use AWS SDK for Pandas in SageMaker

### DIFF
--- a/backend/dataall/core/environment/cdk/env_role_core_policies/athena.py
+++ b/backend/dataall/core/environment/cdk/env_role_core_policies/athena.py
@@ -14,7 +14,10 @@ class Athena(ServicePolicy):
         statements = [
             iam.PolicyStatement(
                 # sid="ListAthena",
-                actions=['athena:ListWorkGroups', 'athena:ListTagsForResource', 'athena:GetWorkgroup'],
+                actions=[
+                    'athena:List*',
+                    'athena:GetWorkgroup'
+                ],
                 effect=iam.Effect.ALLOW,
                 resources=['*'],
             ),
@@ -23,7 +26,6 @@ class Athena(ServicePolicy):
                 actions=[
                     'athena:Get*',
                     'athena:BatchGet*',
-                    'athena:List*',
                     'athena:StartQueryExecution',
                     'athena:StopQueryExecution',
                     'athena:CreateNamedQuery',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Gran `athena:List:*` permissions to environment-team-roles. We could have added the following permissions one by one, but since we are dangerously close to IAM service quotas on managed policies per IAM role this PR grants athena:List:* instead. 

```
{ "Action": [ "athena:ListDataCatalogs" ], "Resource": [ "*" ], "Effect": "Allow" }, { "Action": [ "athena:ListDatabases", "athena:ListTableMetadata" ], "Resource": [ "arn:aws:athena:eu-central-1:<account>:datacatalog/*" ], "Effect": "Allow" },
```

The issue also reports missing S3 permissions when using the SDK for pandas. These issues cannot be reproduced if using `ctas_approach` set to False in the read_sql statement (link to [docs](https://aws-sdk-pandas.readthedocs.io/en/stable/tutorials/006%20-%20Amazon%20Athena.html)). So no additional S3 permissions have been granted.

```
df = wr.athena.read_sql_table(
    table="table",
    database="dataall_DATABASE_shared",
    workgroup= "dataall-GROUP",
    ctas_approach=False
)
```


### Relates
- #1022 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? `NO`
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization? `NO`
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? `NO`
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users? `Yes`
  - Have you used the least-privilege principle? How? `Yes, the user only gets List permissions to Athena resources`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
