### PR TITLE
Add "/ "to prefix in crawlers if it is not specified in input

### DIFF
--- a/backend/dataall/modules/datasets/services/dataset_service.py
+++ b/backend/dataall/modules/datasets/services/dataset_service.py
@@ -312,18 +312,20 @@ class DatasetService:
         engine = get_context().db_engine
         with engine.scoped_session() as session:
             dataset = DatasetRepository.get_dataset_by_uri(session, uri)
-
-            location = (
-                f's3://{dataset.S3BucketName}/{data.get("prefix")}'
-                if data.get('prefix')
-                else f's3://{dataset.S3BucketName}'
-            )
+            if data.get('prefix'):
+                location = (
+                    f's3://{dataset.S3BucketName}/{data.get("prefix")}'
+                    if data.get('prefix')[-1] == '/'
+                    else f's3://{dataset.S3BucketName}/{data.get("prefix")}/'
+                )
+            else:
+                location = f's3://{dataset.S3BucketName}'
 
             crawler = DatasetCrawler(dataset).get_crawler()
             if not crawler:
                 raise exceptions.AWSResourceNotFound(
                     action=CRAWL_DATASET,
-                    message=f'Crawler {dataset.GlueCrawlerName} can not be found',
+                    message=f'Crawler {dataset.GlueCrawlerName} cannot be found',
                 )
 
             task = Task(

--- a/backend/dataall/modules/datasets/services/dataset_service.py
+++ b/backend/dataall/modules/datasets/services/dataset_service.py
@@ -1,3 +1,4 @@
+import os
 import json
 import logging
 
@@ -312,15 +313,7 @@ class DatasetService:
         engine = get_context().db_engine
         with engine.scoped_session() as session:
             dataset = DatasetRepository.get_dataset_by_uri(session, uri)
-            if data.get('prefix'):
-                location = (
-                    f's3://{dataset.S3BucketName}/{data.get("prefix")}'
-                    if data.get('prefix')[-1] == '/'
-                    else f's3://{dataset.S3BucketName}/{data.get("prefix")}/'
-                )
-            else:
-                location = f's3://{dataset.S3BucketName}'
-
+            location = os.path.join('s3://', dataset.S3BucketName, data.get('prefix', ''), '')
             crawler = DatasetCrawler(dataset).get_crawler()
             if not crawler:
                 raise exceptions.AWSResourceNotFound(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Glue crawlers in data.all allow users to specify a prefix to be crawled. If the users provide `prefix` as input without adding a backslash at the end `prefix/` the Glue crawler crawls the whole bucket. This PR checks if the input contains the backslash and appends a backslash in case it is not there yet

Testing:
- [X] Crawl dataset without prefix
- [X] Crawl dataset with prefix = `prefix` --> data.all adds backslash when updating the crawler
- [X] Crawl dataset without prefix --> data.all updates the crawler to use just the bucket top directory
- [X] Crawl dataset with prefix = `prefix/`--> data.all DOES NOT add backslash when updating the crawler

More testing
- [X] To ensure that the data source updated in the Glue crawler is the one we need (`s3://BUCKET/PREFIX/`). I ran the crawler on a database without tables, crawling a bucket with 2 prefixes and data in each of them. When I introduce the prefix1 (`PREFIX1/`) as input in the run of the crawler, it recognizes a table from the data in that prefix, it does not create the table from the other prefix.
- [X] Re-tested after last commit to simplify string manipulation. `s3://BUCKET/` works exactly as `s3://BUCKET`

Next steps:
- Suggestions from @zsaltys in this Issue and from issues #987 #407 

### Relates
- #428 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes `N/A`
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
