### PR TITLE
use typing.List for hints

### DIFF
--- a/deploy/stacks/trigger_function_stack.py
+++ b/deploy/stacks/trigger_function_stack.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from aws_cdk import Duration
 from aws_cdk import (
     aws_iam as iam,
@@ -23,7 +25,7 @@ class TriggerFunctionStack(pyNestedClass):
         resource_prefix='dataall',
         vpc: ec2.IVpc = None,
         vpce_connection: ec2.IConnectable = None,
-        connectables: list[ec2.IConnectable] = [],
+        connectables: List[ec2.IConnectable] = [],
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -75,7 +77,7 @@ class TriggerFunctionStack(pyNestedClass):
             ec2.Peer.any_ipv4(), ec2.Port.tcp(443), 'Allow NAT Internet Access SG Egress'
         )
 
-    def get_policy_statements(self, resource_prefix) -> list[iam.PolicyStatement]:
+    def get_policy_statements(self, resource_prefix) -> List[iam.PolicyStatement]:
         return [
             iam.PolicyStatement(
                 actions=[


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Drop hinting as per [PEP585](https://peps.python.org/pep-0585/) and use typing.List

### Relates
Solves #1167 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
