### PR TITLE
Implement less restrictive trust policy for local development pivot roles

### DIFF
--- a/backend/dataall/core/environment/cdk/pivot_role_stack.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_stack.py
@@ -110,7 +110,7 @@ class PivotRole(NestedStack):
             managed_policies=managed_policies,
         )
 
-        if ENVNAME == 'local':
+        if ENVNAME in ['local', 'dkrcompose']:
             # Less restrictive trust policy for local development
             role.assume_role_policy.add_statements(
                 iam.PolicyStatement(

--- a/backend/dataall/core/environment/cdk/pivot_role_stack.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_stack.py
@@ -7,6 +7,7 @@ from dataall.base.utils.iam_policy_utils import split_policy_statements_in_chunk
 
 logger = logging.getLogger(__name__)
 
+ENVNAME = os.getenv('envname', 'local')
 
 class PivotRoleStatementSet(object):
     def __init__(self, stack, env_resource_prefix, role_name, account, region, environmentUri):
@@ -108,7 +109,7 @@ class PivotRole(NestedStack):
             managed_policies=managed_policies,
         )
 
-        if os.getenv("envname", "local") == "local":
+        if ENVNAME == "local":
             # Less restrictive trust policy for local development
             role.assume_role_policy.add_statements(
                 iam.PolicyStatement(

--- a/backend/dataall/core/environment/cdk/pivot_role_stack.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_stack.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 ENVNAME = os.getenv('envname', 'local')
 
+
 class PivotRoleStatementSet(object):
     def __init__(self, stack, env_resource_prefix, role_name, account, region, environmentUri):
         self.stack = stack
@@ -109,13 +110,13 @@ class PivotRole(NestedStack):
             managed_policies=managed_policies,
         )
 
-        if ENVNAME == "local":
+        if ENVNAME == 'local':
             # Less restrictive trust policy for local development
             role.assume_role_policy.add_statements(
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,
                     principals=[iam.AccountPrincipal(account_id=principal_id)],
-                    actions=['sts:AssumeRole']
+                    actions=['sts:AssumeRole'],
                 )
             )
         else:


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
When the environment is local (local deployment using docker), the pivot role that is created has a more open trust policy. Instead of restricting with externalId and naming conventions, the local pivot role can be assumed by the credentials account.

### Relates
- #1144 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? `N/A`.
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization? `N/A`.
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? `N/A`.
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users? ---> ⚠️ Yes, in this PR the trust policy for the pivot role created by CDK in the data.all local environment changes. The trust policy for AWS deployments stays the same
  - Have you used the least-privilege principle? How? ---> the change only affects local deployment where the trust policy requirements can be more relaxed because it is going to be used by developers to develop locally


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
