### PR TITLE
Refactor: uncouple datasets and dataset_sharing modules - part 1

### DIFF
--- a/backend/dataall/modules/dataset_sharing/services/dataset_sharing_alarm_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/dataset_sharing_alarm_service.py
@@ -3,13 +3,13 @@ from datetime import datetime
 
 from dataall.core.environment.db.environment_models import Environment
 from dataall.modules.dataset_sharing.db.share_object_models import ShareObject
-from dataall.modules.datasets_base.db.dataset_models import DatasetTable, Dataset, DatasetStorageLocation, DatasetBucket
+from dataall.modules.datasets_base.db.dataset_models import DatasetTable, DatasetStorageLocation, DatasetBucket
 from dataall.base.utils.alarm_service import AlarmService
 
 log = logging.getLogger(__name__)
 
 
-class DatasetAlarmService(AlarmService):
+class DatasetSharingAlarmService(AlarmService):
     """Contains set of alarms for datasets"""
 
     def trigger_table_sharing_failure_alarm(
@@ -69,24 +69,6 @@ class DatasetAlarmService(AlarmService):
         - AWS Account:                {target_environment.AwsAccountId}
         - Region:                            {target_environment.region}
         - Glue Database:              {table.GlueDatabaseName}shared
-    """
-        return self.publish_message_to_alarms_topic(subject, message)
-
-    def trigger_dataset_sync_failure_alarm(self, dataset: Dataset, error: str):
-        log.info(f'Triggering dataset {dataset.name} tables sync failure alarm...')
-        subject = f'Data.all Dataset Tables Sync Failure for {dataset.name}'[:100]
-        message = f"""
-You are receiving this email because your Data.all {self.envname} environment in the {self.region} region has entered the ALARM state, because it failed to synchronize Dataset {dataset.name} tables from AWS Glue to the Search Catalog.
-
-Alarm Details:
-    - State Change:               	OK -> ALARM
-    - Reason for State Change:      {error}
-    - Timestamp:                              {datetime.now()}
-    Dataset
-     - Dataset URI:                   {dataset.datasetUri}
-     - AWS Account:                {dataset.AwsAccountId}
-     - Region:                            {dataset.region}
-     - Glue Database:              {dataset.GlueDatabaseName}
     """
         return self.publish_message_to_alarms_topic(subject, message)
 

--- a/backend/dataall/modules/dataset_sharing/services/share_managers/lf_share_manager.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_managers/lf_share_manager.py
@@ -19,7 +19,7 @@ from dataall.modules.dataset_sharing.services.dataset_sharing_enums import (
     ShareItemHealthStatus,
 )
 from dataall.modules.datasets_base.db.dataset_models import DatasetTable, Dataset
-from dataall.modules.dataset_sharing.services.dataset_alarm_service import DatasetAlarmService
+from dataall.modules.dataset_sharing.services.dataset_sharing_alarm_service import DatasetSharingAlarmService
 from dataall.modules.dataset_sharing.db.share_object_models import ShareObjectItem, ShareObject
 from dataall.modules.dataset_sharing.services.share_managers.share_manager_utils import ShareErrorFormatter
 
@@ -584,7 +584,7 @@ class LFShareManager:
             f'due to: {error}'
         )
 
-        DatasetAlarmService().trigger_table_sharing_failure_alarm(table, self.share, self.target_environment)
+        DatasetSharingAlarmService().trigger_table_sharing_failure_alarm(table, self.share, self.target_environment)
         return True
 
     def handle_revoke_failure(
@@ -604,7 +604,9 @@ class LFShareManager:
             f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region} '
             f'due to: {error}'
         )
-        DatasetAlarmService().trigger_revoke_table_sharing_failure_alarm(table, self.share, self.target_environment)
+        DatasetSharingAlarmService().trigger_revoke_table_sharing_failure_alarm(
+            table, self.share, self.target_environment
+        )
         return True
 
     def handle_share_failure_for_all_tables(self, tables, error, share_item_status, reapply=False):

--- a/backend/dataall/modules/dataset_sharing/services/share_managers/s3_access_point_share_manager.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_managers/s3_access_point_share_manager.py
@@ -21,7 +21,7 @@ from dataall.modules.dataset_sharing.aws.kms_client import (
 )
 from dataall.base.aws.iam import IAM
 from dataall.modules.dataset_sharing.db.share_object_models import ShareObject
-from dataall.modules.dataset_sharing.services.dataset_alarm_service import DatasetAlarmService
+from dataall.modules.dataset_sharing.services.dataset_sharing_alarm_service import DatasetSharingAlarmService
 from dataall.modules.dataset_sharing.db.share_object_repositories import ShareObjectRepository
 from dataall.modules.dataset_sharing.services.share_exceptions import PrincipalRoleNotFound
 from dataall.modules.dataset_sharing.services.share_managers.share_manager_utils import ShareErrorFormatter
@@ -736,7 +736,7 @@ class S3AccessPointShareManager:
             f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region} '
             f'due to: {error}'
         )
-        DatasetAlarmService().trigger_folder_sharing_failure_alarm(
+        DatasetSharingAlarmService().trigger_folder_sharing_failure_alarm(
             self.target_folder, self.share, self.target_environment
         )
 
@@ -753,7 +753,7 @@ class S3AccessPointShareManager:
             f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region} '
             f'due to: {error}'
         )
-        DatasetAlarmService().trigger_revoke_folder_sharing_failure_alarm(
+        DatasetSharingAlarmService().trigger_revoke_folder_sharing_failure_alarm(
             self.target_folder, self.share, self.target_environment
         )
         return True

--- a/backend/dataall/modules/dataset_sharing/services/share_managers/s3_bucket_share_manager.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_managers/s3_bucket_share_manager.py
@@ -16,7 +16,7 @@ from dataall.modules.dataset_sharing.aws.s3_client import S3ControlClient, S3Cli
 from dataall.modules.dataset_sharing.db.share_object_models import ShareObject
 from dataall.modules.dataset_sharing.services.share_exceptions import PrincipalRoleNotFound
 from dataall.modules.dataset_sharing.services.share_managers.share_manager_utils import ShareErrorFormatter
-from dataall.modules.dataset_sharing.services.dataset_alarm_service import DatasetAlarmService
+from dataall.modules.dataset_sharing.services.dataset_sharing_alarm_service import DatasetSharingAlarmService
 from dataall.modules.dataset_sharing.services.managed_share_policy_service import (
     SharePolicyService,
     IAM_S3_BUCKETS_STATEMENT_SID,
@@ -591,7 +591,7 @@ class S3BucketShareManager:
             f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region} '
             f'due to: {error}'
         )
-        DatasetAlarmService().trigger_s3_bucket_sharing_failure_alarm(
+        DatasetSharingAlarmService().trigger_s3_bucket_sharing_failure_alarm(
             self.target_bucket, self.share, self.target_environment
         )
         return True
@@ -609,7 +609,7 @@ class S3BucketShareManager:
             f'with target account {self.target_environment.AwsAccountId}/{self.target_environment.region} '
             f'due to: {error}'
         )
-        DatasetAlarmService().trigger_revoke_s3_bucket_sharing_failure_alarm(
+        DatasetSharingAlarmService().trigger_revoke_s3_bucket_sharing_failure_alarm(
             self.target_bucket, self.share, self.target_environment
         )
         return True

--- a/backend/dataall/modules/datasets/services/dataset_alarm_service.py
+++ b/backend/dataall/modules/datasets/services/dataset_alarm_service.py
@@ -1,0 +1,30 @@
+import logging
+from datetime import datetime
+
+
+from dataall.modules.datasets_base.db.dataset_models import Dataset
+from dataall.base.utils.alarm_service import AlarmService
+
+log = logging.getLogger(__name__)
+
+
+class DatasetAlarmService(AlarmService):
+    """Contains set of alarms for datasets"""
+
+    def trigger_dataset_sync_failure_alarm(self, dataset: Dataset, error: str):
+        log.info(f'Triggering dataset {dataset.name} tables sync failure alarm...')
+        subject = f'Data.all Dataset Tables Sync Failure for {dataset.name}'[:100]
+        message = f"""
+You are receiving this email because your Data.all {self.envname} environment in the {self.region} region has entered the ALARM state, because it failed to synchronize Dataset {dataset.name} tables from AWS Glue to the Search Catalog.
+
+Alarm Details:
+    - State Change:               	OK -> ALARM
+    - Reason for State Change:      {error}
+    - Timestamp:                              {datetime.now()}
+    Dataset
+     - Dataset URI:                   {dataset.datasetUri}
+     - AWS Account:                {dataset.AwsAccountId}
+     - Region:                            {dataset.region}
+     - Glue Database:              {dataset.GlueDatabaseName}
+    """
+        return self.publish_message_to_alarms_topic(subject, message)

--- a/backend/dataall/modules/datasets/tasks/tables_syncer.py
+++ b/backend/dataall/modules/datasets/tasks/tables_syncer.py
@@ -13,7 +13,7 @@ from dataall.modules.datasets.services.dataset_table_service import DatasetTable
 from dataall.modules.datasets_base.db.dataset_repositories import DatasetRepository
 from dataall.modules.datasets_base.db.dataset_models import DatasetTable, Dataset
 from dataall.modules.datasets.indexers.table_indexer import DatasetTableIndexer
-from dataall.modules.dataset_sharing.services.dataset_alarm_service import DatasetAlarmService
+from dataall.modules.datasets.services.dataset_alarm_service import DatasetAlarmService
 
 root = logging.getLogger()
 root.setLevel(logging.INFO)

--- a/tests/modules/datasets/tasks/test_lf_share_manager.py
+++ b/tests/modules/datasets/tasks/test_lf_share_manager.py
@@ -17,7 +17,7 @@ from dataall.core.environment.db.environment_models import Environment, Environm
 from dataall.modules.dataset_sharing.services.dataset_sharing_enums import ShareItemStatus
 from dataall.modules.dataset_sharing.db.share_object_models import ShareObject, ShareObjectItem
 from dataall.modules.datasets_base.db.dataset_models import DatasetTable, Dataset
-from dataall.modules.dataset_sharing.services.dataset_alarm_service import DatasetAlarmService
+from dataall.modules.dataset_sharing.services.dataset_sharing_alarm_service import DatasetSharingAlarmService
 from dataall.modules.dataset_sharing.services.share_processors.lakeformation_process_share import (
     ProcessLakeFormationShare,
 )
@@ -868,7 +868,7 @@ def test_check_catalog_account_exists_and_update_processor_with_catalog_doesnt_e
 
 def test_handle_share_failure(processor_with_mocks, table1: DatasetTable, mocker):
     # Given
-    alarm_service_mock = mocker.patch.object(DatasetAlarmService, 'trigger_table_sharing_failure_alarm')
+    alarm_service_mock = mocker.patch.object(DatasetSharingAlarmService, 'trigger_table_sharing_failure_alarm')
     error = Exception()
     processor, lf_client, glue_client, mock_glue_client = processor_with_mocks
 
@@ -885,7 +885,7 @@ def test_handle_revoke_failure(
     mocker,
 ):
     # Given
-    alarm_service_mock = mocker.patch.object(DatasetAlarmService, 'trigger_revoke_table_sharing_failure_alarm')
+    alarm_service_mock = mocker.patch.object(DatasetSharingAlarmService, 'trigger_revoke_table_sharing_failure_alarm')
     error = Exception()
     processor, lf_client, glue_client, mock_glue_client = processor_with_mocks
 


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
- Split the DatasetAlarm service into the alarms related to datasets and those related to sharing. This is needed as explained in full PR #1179 

### Relates
- #1179

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/). `N/A`

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
