### PR TITLE
Fix: Remove creation of log-groups in Lambdas

### DIFF
--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -69,25 +69,10 @@ class LambdaApiStack(pyNestedClass):
         self.esproxy_dlq = self.set_dlq(f'{resource_prefix}-{envname}-esproxy-dlq')
         esproxy_sg = self.create_lambda_sgs(envname, 'esproxy', resource_prefix, vpc)
 
-        esproxy_loggroup = logs.LogGroup.from_log_group_name(
-            self, 'esproxyloggroup', f'/aws/lambda/{resource_prefix}-{envname}-esproxy'
-        )
-        graphql_loggroup = logs.LogGroup.from_log_group_name(
-            self, 'graphqlloggroup', f'/aws/lambda/{resource_prefix}-{envname}-graphql'
-        )
-        awsworker_loggroup = logs.LogGroup.from_log_group_name(
-            self, 'awsworkerloggroup', f'/aws/lambda/{resource_prefix}-{envname}-awsworker'
-        )
-
         self.elasticsearch_proxy_handler = _lambda.DockerImageFunction(
             self,
             'ElasticSearchProxyHandler',
             function_name=f'{resource_prefix}-{envname}-esproxy',
-            log_group=esproxy_loggroup
-            if esproxy_loggroup is not None
-            else logs.LogGroup(
-                self, 'esproxyloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-esproxy'
-            ),
             description='dataall es search function',
             role=self.create_function_role(envname, resource_prefix, 'esproxy', pivot_role_name, vpc),
             code=_lambda.DockerImageCode.from_ecr(
@@ -116,11 +101,6 @@ class LambdaApiStack(pyNestedClass):
             self,
             'LambdaGraphQL',
             function_name=f'{resource_prefix}-{envname}-graphql',
-            log_group=graphql_loggroup
-            if graphql_loggroup is not None
-            else logs.LogGroup(
-                self, 'graphqlloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-graphql'
-            ),
             description='dataall graphql function',
             role=self.create_function_role(envname, resource_prefix, 'graphql', pivot_role_name, vpc),
             code=_lambda.DockerImageCode.from_ecr(
@@ -148,11 +128,6 @@ class LambdaApiStack(pyNestedClass):
             self,
             'AWSWorker',
             function_name=f'{resource_prefix}-{envname}-awsworker',
-            log_group=awsworker_loggroup
-            if awsworker_loggroup is not None
-            else logs.LogGroup(
-                self, 'awsworkerloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-awsworker'
-            ),
             description='dataall aws worker for aws asynchronous tasks function',
             role=self.create_function_role(envname, resource_prefix, 'awsworker', pivot_role_name, vpc),
             code=_lambda.DockerImageCode.from_ecr(

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -15,7 +15,6 @@ from aws_cdk import (
     aws_sqs as sqs,
     aws_logs as logs,
     Duration,
-    CfnCondition,
     CfnOutput,
     Fn,
     RemovalPolicy,
@@ -70,59 +69,10 @@ class LambdaApiStack(pyNestedClass):
         self.esproxy_dlq = self.set_dlq(f'{resource_prefix}-{envname}-esproxy-dlq')
         esproxy_sg = self.create_lambda_sgs(envname, 'esproxy', resource_prefix, vpc)
 
-        # Conditional creation of esproxy log group
-        esproxy_loggroup = logs.LogGroup.from_log_group_name(
-            self, 'esproxyloggroup', f'/aws/lambda/{resource_prefix}-{envname}-esproxy'
-        )
-        esproxy_loggroup_condition = CfnCondition(
-            self,
-            'esproxyloggroupcondition',
-            expression=Fn.condition_equals(
-                esproxy_loggroup.log_group_physical_name(), f'/aws/lambda/{resource_prefix}-{envname}-esproxy'
-            ),
-        )
-        cfn_esproxy_loggroup = logs.CfnLogGroup(
-            self, 'cfnesproxyloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-esproxy'
-        )
-        cfn_esproxy_loggroup.cfn_options.condition = esproxy_loggroup_condition
-
-        # Conditional creation of graphql lambda log group
-        graphql_loggroup = logs.LogGroup.from_log_group_name(
-            self, 'graphqlloggroup', f'/aws/lambda/{resource_prefix}-{envname}-graphql'
-        )
-        graphql_loggroup_condition = CfnCondition(
-            self,
-            'graphqlloggroupcondition',
-            expression=Fn.condition_equals(
-                graphql_loggroup.log_group_physical_name(), f'/aws/lambda/{resource_prefix}-{envname}-graphql'
-            ),
-        )
-        cfn_graphql_loggroup = logs.CfnLogGroup(
-            self, 'cfngraphqlloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-graphql'
-        )
-        cfn_graphql_loggroup.cfn_options.condition = graphql_loggroup_condition
-
-        # Conditional creation of worker lambda log group
-        awsworker_loggroup = logs.LogGroup.from_log_group_name(
-            self, 'awsworkerloggroup', f'/aws/lambda/{resource_prefix}-{envname}-awsworker'
-        )
-        awsworker_loggroup_condition = CfnCondition(
-            self,
-            'awsworkerloggroupcondition',
-            expression=Fn.condition_equals(
-                awsworker_loggroup.log_group_physical_name(), f'/aws/lambda/{resource_prefix}-{envname}-awsworker'
-            ),
-        )
-        cfn_awsworker_loggroup = logs.CfnLogGroup(
-            self, 'cfnawsworkerloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-awsworker'
-        )
-        cfn_awsworker_loggroup.cfn_options.condition = awsworker_loggroup_condition
-
         self.elasticsearch_proxy_handler = _lambda.DockerImageFunction(
             self,
             'ElasticSearchProxyHandler',
             function_name=f'{resource_prefix}-{envname}-esproxy',
-            log_group=esproxy_loggroup,
             description='dataall es search function',
             role=self.create_function_role(envname, resource_prefix, 'esproxy', pivot_role_name, vpc),
             code=_lambda.DockerImageCode.from_ecr(
@@ -151,7 +101,6 @@ class LambdaApiStack(pyNestedClass):
             self,
             'LambdaGraphQL',
             function_name=f'{resource_prefix}-{envname}-graphql',
-            log_group=graphql_loggroup,
             description='dataall graphql function',
             role=self.create_function_role(envname, resource_prefix, 'graphql', pivot_role_name, vpc),
             code=_lambda.DockerImageCode.from_ecr(
@@ -179,7 +128,6 @@ class LambdaApiStack(pyNestedClass):
             self,
             'AWSWorker',
             function_name=f'{resource_prefix}-{envname}-awsworker',
-            log_group=awsworker_loggroup,
             description='dataall aws worker for aws asynchronous tasks function',
             role=self.create_function_role(envname, resource_prefix, 'awsworker', pivot_role_name, vpc),
             code=_lambda.DockerImageCode.from_ecr(

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -69,24 +69,12 @@ class LambdaApiStack(pyNestedClass):
         self.esproxy_dlq = self.set_dlq(f'{resource_prefix}-{envname}-esproxy-dlq')
         esproxy_sg = self.create_lambda_sgs(envname, 'esproxy', resource_prefix, vpc)
 
-        esproxy_loggroup = logs.LogGroup.from_log_group_name(
-            self, 'esproxyloggroup', f'/aws/lambda/{resource_prefix}-{envname}-esproxy'
-        )
-        graphql_loggroup = logs.LogGroup.from_log_group_name(
-            self, 'graphqlloggroup', f'/aws/lambda/{resource_prefix}-{envname}-graphql'
-        )
-        awsworker_loggroup = logs.LogGroup.from_log_group_name(
-            self, 'awsworkerloggroup', f'/aws/lambda/{resource_prefix}-{envname}-awsworker'
-        )
-
         self.elasticsearch_proxy_handler = _lambda.DockerImageFunction(
             self,
             'ElasticSearchProxyHandler',
             function_name=f'{resource_prefix}-{envname}-esproxy',
-            log_group=esproxy_loggroup
-            if esproxy_loggroup is not None
-            else logs.LogGroup(
-                self, 'esproxyloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-esproxy'
+            log_group=logs.LogGroup(
+                self, 'esproxyloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-backend-esproxy'
             ),
             description='dataall es search function',
             role=self.create_function_role(envname, resource_prefix, 'esproxy', pivot_role_name, vpc),
@@ -116,10 +104,8 @@ class LambdaApiStack(pyNestedClass):
             self,
             'LambdaGraphQL',
             function_name=f'{resource_prefix}-{envname}-graphql',
-            log_group=graphql_loggroup
-            if graphql_loggroup is not None
-            else logs.LogGroup(
-                self, 'graphqlloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-graphql'
+            log_group=logs.LogGroup(
+                self, 'graphqlloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-backend-graphql'
             ),
             description='dataall graphql function',
             role=self.create_function_role(envname, resource_prefix, 'graphql', pivot_role_name, vpc),
@@ -148,10 +134,8 @@ class LambdaApiStack(pyNestedClass):
             self,
             'AWSWorker',
             function_name=f'{resource_prefix}-{envname}-awsworker',
-            log_group=awsworker_loggroup
-            if awsworker_loggroup is not None
-            else logs.LogGroup(
-                self, 'awsworkerloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-awsworker'
+            log_group=logs.LogGroup(
+                self, 'awsworkerloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-backend-awsworker'
             ),
             description='dataall aws worker for aws asynchronous tasks function',
             role=self.create_function_role(envname, resource_prefix, 'awsworker', pivot_role_name, vpc),

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -69,10 +69,25 @@ class LambdaApiStack(pyNestedClass):
         self.esproxy_dlq = self.set_dlq(f'{resource_prefix}-{envname}-esproxy-dlq')
         esproxy_sg = self.create_lambda_sgs(envname, 'esproxy', resource_prefix, vpc)
 
+        esproxy_loggroup = logs.LogGroup.from_log_group_name(
+            self, 'esproxyloggroup', f'/aws/lambda/{resource_prefix}-{envname}-esproxy'
+        )
+        graphql_loggroup = logs.LogGroup.from_log_group_name(
+            self, 'graphqlloggroup', f'/aws/lambda/{resource_prefix}-{envname}-graphql'
+        )
+        awsworker_loggroup = logs.LogGroup.from_log_group_name(
+            self, 'awsworkerloggroup', f'/aws/lambda/{resource_prefix}-{envname}-awsworker'
+        )
+
         self.elasticsearch_proxy_handler = _lambda.DockerImageFunction(
             self,
             'ElasticSearchProxyHandler',
             function_name=f'{resource_prefix}-{envname}-esproxy',
+            log_group=esproxy_loggroup
+            if esproxy_loggroup is not None
+            else logs.LogGroup(
+                self, 'esproxyloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-esproxy'
+            ),
             description='dataall es search function',
             role=self.create_function_role(envname, resource_prefix, 'esproxy', pivot_role_name, vpc),
             code=_lambda.DockerImageCode.from_ecr(
@@ -101,6 +116,11 @@ class LambdaApiStack(pyNestedClass):
             self,
             'LambdaGraphQL',
             function_name=f'{resource_prefix}-{envname}-graphql',
+            log_group=graphql_loggroup
+            if graphql_loggroup is not None
+            else logs.LogGroup(
+                self, 'graphqlloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-graphql'
+            ),
             description='dataall graphql function',
             role=self.create_function_role(envname, resource_prefix, 'graphql', pivot_role_name, vpc),
             code=_lambda.DockerImageCode.from_ecr(
@@ -128,6 +148,11 @@ class LambdaApiStack(pyNestedClass):
             self,
             'AWSWorker',
             function_name=f'{resource_prefix}-{envname}-awsworker',
+            log_group=awsworker_loggroup
+            if awsworker_loggroup is not None
+            else logs.LogGroup(
+                self, 'awsworkerloggroup', log_group_name=f'/aws/lambda/{resource_prefix}-{envname}-awsworker'
+            ),
             description='dataall aws worker for aws asynchronous tasks function',
             role=self.create_function_role(envname, resource_prefix, 'awsworker', pivot_role_name, vpc),
             code=_lambda.DockerImageCode.from_ecr(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
In #1134 log groups are created explicitly for each Lambda in the backend, which results in errors when the log-groups do not exist.  (see #1190 )

This PR removes the `log_group` parameter from the definition of the Lambdas. It reverts back to the previous (2.3) settings. 

Tested: on a fresh deployment, making sure that no log-groups were previously created, the stack creates the log-groups with the Lambda name. For example `/aws/lambda/<resource_prefix>-<env_name>-esproxy`.

Update: we need to explicitly define the log groups to avoid the log retention lambdas and their roles and policies that CDK automatically creates. So to cope with existing groups and non-existing groups this PR adds a CfnCondition to the creation of the log-group

### Relates
- #1134

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/). `n/a`

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
