### PR TITLE
Fix missing session in resolve_environment

### DIFF
--- a/backend/dataall/core/environment/api/resolvers.py
+++ b/backend/dataall/core/environment/api/resolvers.py
@@ -679,7 +679,7 @@ def resolve_environment(context, source, **kwargs):
         return None
 
     with context.engine.scoped_session() as session:
-        return EnvironmentService.get_environment_by_uri(source.environmentUri)
+        return EnvironmentService.get_environment_by_uri(session, source.environmentUri)
 
 
 def resolve_parameters(context, source: Environment, **kwargs):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
`EnvironmentService.get_environment_by_uri` receives `session` and `environment_uri` as inputs. In one of the calls `session` was missing

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
