### PR TITLE
Fix: unnecessary permission check in resolve_stack functions (failure in list datasets when there are shared datasets)

### DIFF
--- a/backend/dataall/core/environment/api/resolvers.py
+++ b/backend/dataall/core/environment/api/resolvers.py
@@ -479,7 +479,7 @@ def generate_environment_access_token(context, source, environmentUri: str = Non
 def get_environment_stack(context: Context, source: Environment, **kwargs):
     return StackService.get_stack_with_cfn_resources(
         targetUri=source.environmentUri,
-        env=source,
+        environmentUri=source.environmentUri,
     )
 
 

--- a/backend/dataall/core/stacks/services/stack_service.py
+++ b/backend/dataall/core/stacks/services/stack_service.py
@@ -18,6 +18,7 @@ from dataall.base.db.exceptions import AWSResourceNotFound
 from dataall.base.db.exceptions import RequiredParameter
 from dataall.core.stacks.db.target_type_repositories import TargetType
 from dataall.core.environment.db.environment_models import Environment
+from dataall.core.environment.db.environment_repositories import EnvironmentRepository
 
 log = logging.getLogger(__name__)
 
@@ -45,9 +46,10 @@ class StackRequestVerifier:
 
 class StackService:
     @staticmethod
-    def get_stack_with_cfn_resources(targetUri: str, env: Environment):
+    def get_stack_with_cfn_resources(targetUri: str, environmentUri: str):
         context = get_context()
         with context.db_engine.scoped_session() as session:
+            env: Environment = EnvironmentRepository.get_environment_by_uri(session, environmentUri)
             stack: Stack = StackRepository.find_stack_by_target_uri(session, target_uri=targetUri)
             if not stack:
                 stack = Stack(

--- a/backend/dataall/modules/datapipelines/api/resolvers.py
+++ b/backend/dataall/modules/datapipelines/api/resolvers.py
@@ -103,8 +103,7 @@ def resolve_clone_url_http(context: Context, source: DataPipeline, **kwargs):
 def resolve_stack(context, source: DataPipeline, **kwargs):
     if not source:
         return None
-    env = EnvironmentService.find_environment_by_uri(uri=source.environmentUri)
     return StackService.get_stack_with_cfn_resources(
         targetUri=source.DataPipelineUri,
-        env=env,
+        environmentUri=source.environmentUri,
     )

--- a/backend/dataall/modules/datasets/api/dataset/resolvers.py
+++ b/backend/dataall/modules/datasets/api/dataset/resolvers.py
@@ -144,13 +144,12 @@ def generate_dataset_access_token(context, source, datasetUri: str = None):
     return DatasetService.generate_dataset_access_token(uri=datasetUri)
 
 
-def get_dataset_stack(context: Context, source: Dataset, **kwargs):
+def resolve_dataset_stack(context: Context, source: Dataset, **kwargs):
     if not source:
         return None
-    env = EnvironmentService.find_environment_by_uri(uri=source.environmentUri)
     return StackService.get_stack_with_cfn_resources(
         targetUri=source.datasetUri,
-        env=env,
+        environmentUri=source.environmentUri,
     )
 
 

--- a/backend/dataall/modules/datasets/api/dataset/types.py
+++ b/backend/dataall/modules/datasets/api/dataset/types.py
@@ -11,7 +11,7 @@ from dataall.modules.datasets.api.dataset.resolvers import (
     get_dataset_statistics,
     list_dataset_share_objects,
     get_dataset_glossary_terms,
-    get_dataset_stack,
+    resolve_dataset_stack,
 )
 from dataall.core.environment.api.enums import EnvironmentPermission
 
@@ -132,7 +132,7 @@ Dataset = gql.ObjectType(
             args=[gql.Argument(name='environmentUri', type=gql.NonNullableType(gql.String))],
             type=gql.Boolean,
         ),
-        gql.Field(name='stack', type=gql.Ref('Stack'), resolver=get_dataset_stack),
+        gql.Field(name='stack', type=gql.Ref('Stack'), resolver=resolve_dataset_stack),
         gql.Field(name='autoApprovalEnabled', type=gql.Boolean),
     ],
 )

--- a/backend/dataall/modules/datasets/services/dataset_service.py
+++ b/backend/dataall/modules/datasets/services/dataset_service.py
@@ -364,15 +364,6 @@ class DatasetService:
         return json.dumps(credentials)
 
     @staticmethod
-    def get_dataset_stack(dataset: Dataset):
-        env = EnvironmentService.find_environment_by_uri(uri=dataset.environmentUri)
-
-        return StackService.get_stack_with_cfn_resources(
-            targetUri=dataset.datasetUri,
-            env=env,
-        )
-
-    @staticmethod
     @ResourcePolicyService.has_resource_permission(DELETE_DATASET)
     def delete_dataset(uri: str, delete_from_aws: bool = False):
         context = get_context()

--- a/backend/dataall/modules/mlstudio/api/resolvers.py
+++ b/backend/dataall/modules/mlstudio/api/resolvers.py
@@ -120,10 +120,9 @@ def resolve_sagemaker_studio_user_stack(context: Context, source: SagemakerStudi
     """
     if not source:
         return None
-    env = EnvironmentService.find_environment_by_uri(uri=source.environmentUri)
     return StackService.get_stack_with_cfn_resources(
         targetUri=source.sagemakerStudioUserUri,
-        env=env,
+        environmentUri=source.environmentUri,
     )
 
 

--- a/backend/dataall/modules/notebooks/api/resolvers.py
+++ b/backend/dataall/modules/notebooks/api/resolvers.py
@@ -88,10 +88,9 @@ def resolve_user_role(context: Context, source: SagemakerNotebook):
 def resolve_notebook_stack(context: Context, source: SagemakerNotebook, **kwargs):
     if not source:
         return None
-    env = EnvironmentService.find_environment_by_uri(uri=source.environmentUri)
     return StackService.get_stack_with_cfn_resources(
         targetUri=source.notebookUri,
-        env=env,
+        environmentUri=source.environmentUri,
     )
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail

The function `get_stack_with_cfn_resources` from `StackService` is used to resolve the CFN stack details of several stacks in data.all. It is a private function that is not used directly as resolver by any GraphQL query/mutation, so the permissions are checked indirectly by applying the permissions in the main API. Better with an example:


API Query: `GetNotebook` (what we want)
- 1. calls the service `get_notebook` decorated to check user `GET_NOTEBOOK` permissions on that Notebook1
- 2. calls `get_stack_with_cfn_resources` to resolve CFN details of the Notebook

API Query: `GetNotebook` (what we currently have)
- 1. calls the service `get_notebook` decorated to check user `GET_NOTEBOOK` permissions on that Notebook1
- 2. calls `get_stack_with_cfn_resources`
- 3. inside `get_stack_with_cfn_resources` we call find_environment, which checks the `GET_ENVIRONMENT` permissions of the user

In this PR I revert to pass the environmentUri instead of passing the environment. Instead of using the EnvironmentService, it uses the EnvironmentRepository


### Relates
- https://github.com/data-dot-all/dataall/pull/1181/files

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
