### PR TITLE
Fix reference to locationUri

### DIFF
--- a/backend/migrations/versions/c6d01930179d_add_backfill_read_folder_permissions.py
+++ b/backend/migrations/versions/c6d01930179d_add_backfill_read_folder_permissions.py
@@ -97,12 +97,12 @@ def upgrade():
                 .all()
             )
 
-            for location in share_folder_items:
+            for item in share_folder_items:
                 ResourcePolicyService.attach_resource_policy(
                     session=session,
                     group=share.groupUri,
                     permissions=DATASET_FOLDER_READ,
-                    resource_uri=location.locationUri,
+                    resource_uri=item.itemUri,
                     resource_type=DatasetStorageLocation.__name__,
                 )
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
This PR corrects the uri used to update the shared folders permissions. Instead of using the locationUri which is a field of StorageLocation objects, it uses the itemUri, which is a field of the ShareObjectItem object

### Relates
- release 2.4

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
