### PR TITLE
Fix: sagemaker tagging permissions

### DIFF
--- a/backend/dataall/modules/mlstudio/cdk/env_role_mlstudio_policy.py
+++ b/backend/dataall/modules/mlstudio/cdk/env_role_mlstudio_policy.py
@@ -37,6 +37,11 @@ class SagemakerStudioPolicy(ServicePolicy):
                 conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_value]}},
             ),
             iam.PolicyStatement(
+                actions=['sagemaker:AddTags'],
+                resources=['*'],
+                conditions={'Null': {'sagemaker:TaggingAction': 'false'}},
+            ),
+            iam.PolicyStatement(
                 actions=['sagemaker:Delete*'],
                 resources=[
                     f'arn:aws:sagemaker:{self.region}:{self.account}:notebook-instance/*',
@@ -58,7 +63,6 @@ class SagemakerStudioPolicy(ServicePolicy):
                 ],
                 conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_value]}},
             ),
-            iam.PolicyStatement(actions=['sagemaker:CreateApp'], resources=['*']),
             iam.PolicyStatement(
                 actions=['sagemaker:Create*'],
                 resources=['*'],

--- a/backend/dataall/modules/mlstudio/cdk/env_role_mlstudio_policy.py
+++ b/backend/dataall/modules/mlstudio/cdk/env_role_mlstudio_policy.py
@@ -34,7 +34,7 @@ class SagemakerStudioPolicy(ServicePolicy):
             iam.PolicyStatement(
                 actions=['sagemaker:AddTags'],
                 resources=['*'],
-                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_key]}},
+                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_value]}},
             ),
             iam.PolicyStatement(
                 actions=['sagemaker:Delete*'],
@@ -56,7 +56,7 @@ class SagemakerStudioPolicy(ServicePolicy):
                     f'arn:aws:sagemaker:{self.region}:{self.account}:project/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:app/*',
                 ],
-                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_key]}},
+                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_value]}},
             ),
             iam.PolicyStatement(actions=['sagemaker:CreateApp'], resources=['*']),
             iam.PolicyStatement(
@@ -75,7 +75,7 @@ class SagemakerStudioPolicy(ServicePolicy):
                     f'arn:aws:sagemaker:{self.region}:{self.account}:transform-job/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:automl-job/*',
                 ],
-                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_key]}},
+                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_value]}},
             ),
             iam.PolicyStatement(
                 actions=['sagemaker:Update*'],
@@ -94,12 +94,12 @@ class SagemakerStudioPolicy(ServicePolicy):
                     f'arn:aws:sagemaker:{self.region}:{self.account}:training-job/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:project/*',
                 ],
-                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_key]}},
+                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_value]}},
             ),
             iam.PolicyStatement(
                 actions=['sagemaker:InvokeEndpoint', 'sagemaker:InvokeEndpointAsync'],
                 resources=[f'arn:aws:sagemaker:{self.region}:{self.account}:endpoint/*'],
-                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_key]}},
+                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_value]}},
             ),
             iam.PolicyStatement(
                 actions=['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Fix value of key-value conditions for tags in SageMaker
- Add permissions for tags coming from creation of resources in sagemaker: https://docs.aws.amazon.com/sagemaker/latest/dg/security_iam_id-based-policy-examples.html#access-tag-policy


### Relates
- #1208 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
