### PR TITLE
Feature:1221 - Make visibility of auto-approval toggle configurable based on confidentiality

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,7 +26,12 @@
                 "preview_data": true,
                 "glue_crawler": true,
                 "confidentiality_dropdown" : true,
-                "topics_dropdown" : true
+                "topics_dropdown" : true,
+                "auto_approval_for_confidentiality_level" : {
+                    "Unclassified" : true,
+                    "Official" : true,
+                    "Secret" : false
+                }
             }
         },
         "worksheets": {

--- a/config.json
+++ b/config.json
@@ -30,7 +30,7 @@
                 "auto_approval_for_confidentiality_level" : {
                     "Unclassified" : true,
                     "Official" : true,
-                    "Secret" : false
+                    "Secret" : true
                 }
             }
         },

--- a/frontend/src/modules/Datasets/views/DatasetCreateForm.js
+++ b/frontend/src/modules/Datasets/views/DatasetCreateForm.js
@@ -396,22 +396,27 @@ const DatasetCreateForm = (props) => {
                           </Box>
                         </CardContent>
                         <CardContent>
-                          <TextField
-                            fullWidth
-                            label="Auto Approval"
-                            name="autoApprovalEnabled"
-                            onChange={handleChange}
-                            select
-                            value={values.autoApprovalEnabled}
-                            variant="outlined"
-                          >
-                            <MenuItem key={'Enabled'} value={true}>
-                              Enabled
-                            </MenuItem>
-                            <MenuItem key={'Enabled'} value={false}>
-                              Disabled
-                            </MenuItem>
-                          </TextField>
+                          {config.modules.datasets.features
+                            .auto_approval_for_confidentiality_level[
+                            values.confidentiality
+                          ] === true && (
+                            <TextField
+                              fullWidth
+                              label="Auto Approval"
+                              name="autoApprovalEnabled"
+                              onChange={handleChange}
+                              select
+                              value={values.autoApprovalEnabled}
+                              variant="outlined"
+                            >
+                              <MenuItem key={'Enabled'} value={true}>
+                                Enabled
+                              </MenuItem>
+                              <MenuItem key={'Enabled'} value={false}>
+                                Disabled
+                              </MenuItem>
+                            </TextField>
+                          )}
                         </CardContent>
                       </Card>
                     </Grid>

--- a/frontend/src/modules/Datasets/views/DatasetEditForm.js
+++ b/frontend/src/modules/Datasets/views/DatasetEditForm.js
@@ -482,22 +482,27 @@ const DatasetEditForm = (props) => {
                           </Box>
                         </CardContent>
                         <CardContent>
-                          <TextField
-                            fullWidth
-                            label="Auto Approval"
-                            name="autoApprovalEnabled"
-                            onChange={handleChange}
-                            select
-                            value={values.autoApprovalEnabled}
-                            variant="outlined"
-                          >
-                            <MenuItem key={'Enabled'} value={true}>
-                              Enabled
-                            </MenuItem>
-                            <MenuItem key={'Enabled'} value={false}>
-                              Disabled
-                            </MenuItem>
-                          </TextField>
+                          {config.modules.datasets.features
+                            .auto_approval_for_confidentiality_level[
+                            values.confidentiality
+                          ] === true && (
+                            <TextField
+                              fullWidth
+                              label="Auto Approval"
+                              name="autoApprovalEnabled"
+                              onChange={handleChange}
+                              select
+                              value={values.autoApprovalEnabled}
+                              variant="outlined"
+                            >
+                              <MenuItem key={'Enabled'} value={true}>
+                                Enabled
+                              </MenuItem>
+                              <MenuItem key={'Enabled'} value={false}>
+                                Disabled
+                              </MenuItem>
+                            </TextField>
+                          )}
                         </CardContent>
                       </Card>
                     </Grid>

--- a/frontend/src/modules/Datasets/views/DatasetImportForm.js
+++ b/frontend/src/modules/Datasets/views/DatasetImportForm.js
@@ -409,22 +409,27 @@ const DatasetImportForm = (props) => {
                           </Box>
                         </CardContent>
                         <CardContent>
-                          <TextField
-                            fullWidth
-                            label="Auto Approval"
-                            name="autoApprovalEnabled"
-                            onChange={handleChange}
-                            select
-                            value={values.autoApprovalEnabled}
-                            variant="outlined"
-                          >
-                            <MenuItem key={'Enabled'} value={true}>
-                              Enabled
-                            </MenuItem>
-                            <MenuItem key={'Enabled'} value={false}>
-                              Disabled
-                            </MenuItem>
-                          </TextField>
+                          {config.modules.datasets.features
+                            .auto_approval_for_confidentiality_level[
+                            values.confidentiality
+                          ] === true && (
+                            <TextField
+                              fullWidth
+                              label="Auto Approval"
+                              name="autoApprovalEnabled"
+                              onChange={handleChange}
+                              select
+                              value={values.autoApprovalEnabled}
+                              variant="outlined"
+                            >
+                              <MenuItem key={'Enabled'} value={true}>
+                                Enabled
+                              </MenuItem>
+                              <MenuItem key={'Enabled'} value={false}>
+                                Disabled
+                              </MenuItem>
+                            </TextField>
+                          )}
                         </CardContent>
                       </Card>
                     </Grid>


### PR DESCRIPTION
### Feature or Bugfix

- Feature


### Detail
- Users should be able to disable visibility of auto-approval toggle with code. For example, at our company, we require that shares always go through approval process if their confidentiality classification is Secret. We dont even want to give the option to users to be able to set autoApproval enabled to ensure they dont do so by mistake and end up over sharing.

Video demo: https://github.com/data-dot-all/dataall/issues/1221#issuecomment-2077412044

### Relates
- https://github.com/data-dot-all/dataall/issues/1221

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
