### PR TITLE
Enable encryption for lambda environment variables

### DIFF
--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -66,6 +66,34 @@ class LambdaApiStack(pyNestedClass):
 
         image_tag = f'lambdas-{image_tag}'
 
+        lambda_env_key = kms.Key(
+            self,
+            f'{resource_prefix}-lambda-env-var-key',
+            removal_policy=RemovalPolicy.DESTROY,
+            alias= f'{resource_prefix}-lambda-env-var-key',
+            enable_key_rotation=True,
+            policy=iam.PolicyDocument(
+                statements=[
+                    iam.PolicyStatement(
+                        resources=['*'],
+                        effect=iam.Effect.ALLOW,
+                        principals=[
+                            iam.AccountPrincipal(account_id=self.account),
+                        ],
+                        actions=['kms:*'],
+                    ),
+                    iam.PolicyStatement(
+                        resources=['*'],
+                        effect=iam.Effect.ALLOW,
+                        principals=[
+                            iam.ServicePrincipal(service='lambda.amazonaws.com'),
+                        ],
+                        actions=['kms:GenerateDataKey*', 'kms:Decrypt'],
+                    ),
+                ],
+            ),
+        )
+
         self.esproxy_dlq = self.set_dlq(f'{resource_prefix}-{envname}-esproxy-dlq')
         esproxy_sg = self.create_lambda_sgs(envname, 'esproxy', resource_prefix, vpc)
 
@@ -86,6 +114,7 @@ class LambdaApiStack(pyNestedClass):
             memory_size=1664 if prod_sizing else 256,
             timeout=Duration.minutes(15),
             environment={'envname': envname, 'LOG_LEVEL': 'INFO'},
+            environment_encryption=lambda_env_key,
             dead_letter_queue_enabled=True,
             dead_letter_queue=self.esproxy_dlq,
             on_failure=lambda_destination.SqsDestination(self.esproxy_dlq),
@@ -117,6 +146,7 @@ class LambdaApiStack(pyNestedClass):
             memory_size=3008 if prod_sizing else 1024,
             timeout=Duration.minutes(15),
             environment=api_handler_env,
+            environment_encryption=lambda_env_key,
             dead_letter_queue_enabled=True,
             dead_letter_queue=self.api_handler_dlq,
             on_failure=lambda_destination.SqsDestination(self.api_handler_dlq),
@@ -143,6 +173,7 @@ class LambdaApiStack(pyNestedClass):
                 repository=ecr_repository, tag=image_tag, cmd=['aws_handler.handler']
             ),
             environment=awshandler_env,
+            environment_encryption=lambda_env_key,
             memory_size=1664 if prod_sizing else 256,
             timeout=Duration.minutes(15),
             vpc=vpc,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- The environment variables for the lambda functions are not encrypted in cdk which are identified by checkov scans. This fix is to enable kms encryption for the lambda environment variables.

### Relates
- [<URL or Ticket>
](https://github.com/data-dot-all/dataall/issues/1201)
### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
  - Is the input sanitized? N/A
  - What precautions are you taking before deserializing the data you consume? N/A
  - Is injection prevented by parametrizing queries? N/A
  - Have you ensured no `eval` or similar functions are used? N/A
- Does this PR introduce any functionality or component that requires authorization? N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms? N/A
  - Are you logging failed auth attempts? N/A
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations? N/A
  - Are the used keys controlled by the customer? Where are they stored? the KMS keys are generated by cdk and are used to encrypt the environment variables for all lambda functions in the lambda-api stack
- Are you introducing any new policies/roles/users? - N/A
  - Have you used the least-privilege principle? How? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
