### PR TITLE
Notification link routes to a share request page

### DIFF
--- a/frontend/src/design/components/popovers/NotificationsPopover.js
+++ b/frontend/src/design/components/popovers/NotificationsPopover.js
@@ -1,4 +1,5 @@
 import { DeleteOutlined } from '@mui/icons-material';
+import { Link as RouterLink } from 'react-router-dom';
 import {
   Avatar,
   Badge,
@@ -163,6 +164,10 @@ export const NotificationsPopover = () => {
                           color="textPrimary"
                           sx={{ cursor: 'pointer' }}
                           variant="subtitle2"
+                          component={RouterLink}
+                          to={`/console/shares/${
+                            notification.target_uri.split('|')[0]
+                          }`}
                         >
                           {notification.message}
                         </Link>

--- a/frontend/src/services/graphql/Notification/listNotifications.js
+++ b/frontend/src/services/graphql/Notification/listNotifications.js
@@ -17,6 +17,7 @@ export const listNotifications = (filter) => ({
           message
           type
           is_read
+          target_uri
         }
       }
     }


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- in notification object field `target_uri = 'shareUri|DataSetUri'`
- this value is parsed and used to redirect user to a relevant Share Request page

### Relates
- #1115 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
