### PR TITLE
Fix so listValidEnvironments called only once

### DIFF
--- a/frontend/src/modules/Catalog/components/RequestAccessModal.js
+++ b/frontend/src/modules/Catalog/components/RequestAccessModal.js
@@ -65,6 +65,7 @@ export const RequestAccessModal = (props) => {
       dispatch({ type: SET_ERROR, error: e.message });
     } finally {
       setLoadingEnvs(false);
+      stopLoader();
     }
   }, [client, dispatch]);
 
@@ -132,9 +133,8 @@ export const RequestAccessModal = (props) => {
       fetchEnvironments().catch((e) =>
         dispatch({ type: SET_ERROR, error: e.message })
       );
-      stopLoader();
     }
-  }, [client, open, fetchEnvironments, dispatch, stopLoader]);
+  }, [client, open, fetchEnvironments, dispatch]);
 
   async function submit(values, setStatus, setSubmitting, setErrors) {
     try {

--- a/frontend/src/modules/Catalog/components/RequestAccessModal.js
+++ b/frontend/src/modules/Catalog/components/RequestAccessModal.js
@@ -64,12 +64,9 @@ export const RequestAccessModal = (props) => {
     } catch (e) {
       dispatch({ type: SET_ERROR, error: e.message });
     } finally {
-      if (stopLoader) {
-        stopLoader();
-      }
       setLoadingEnvs(false);
     }
-  }, [client, dispatch, stopLoader]);
+  }, [client, dispatch]);
 
   const fetchGroups = async (environmentUri) => {
     setLoadingGroups(true);
@@ -135,8 +132,9 @@ export const RequestAccessModal = (props) => {
       fetchEnvironments().catch((e) =>
         dispatch({ type: SET_ERROR, error: e.message })
       );
+      stopLoader();
     }
-  }, [client, open, fetchEnvironments, dispatch]);
+  }, [client, open, fetchEnvironments, dispatch, stopLoader]);
 
   async function submit(values, setStatus, setSubmitting, setErrors) {
     try {


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- When request access to a share on data.all the query to `listValidEnvironments` used to be called twice which (depending on how long for query results to return) could cause the environment initially selected to disappear


### Relates
- Continuation of https://github.com/data-dot-all/dataall/issues/916

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
