### PR TITLE
Updated lambda_api.py to add encryption for lambda env vars for custo…

### DIFF
--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -250,6 +250,7 @@ class LambdaApiStack(pyNestedClass):
                 description='dataall Custom authorizer replacing cognito authorizer',
                 timeout=Duration.seconds(20),
                 environment=custom_lambda_env,
+                environment_encryption=lambda_env_key,
                 vpc=vpc,
                 security_groups=[authorizer_fn_sg],
                 runtime=_lambda.Runtime.PYTHON_3_9,


### PR DESCRIPTION
Feature or Bugfix

    Bugfix

Detail

    The environment variables for the lambda functions are not encrypted in cdk which are identified by checkov scans. This fix is to enable kms encryption for the lambda environment variables.

Relates


Security

Please answer the questions below briefly where applicable, or write N/A. Based on
[OWASP 10](https://owasp.org/Top10/en/).

    Does this PR introduce or modify any input fields or queries - this includes
    fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
        Is the input sanitized? N/A
        What precautions are you taking before deserializing the data you consume? N/A
        Is injection prevented by parametrizing queries? N/A
        Have you ensured no eval or similar functions are used? N/A
    Does this PR introduce any functionality or component that requires authorization? N/A
        How have you ensured it respects the existing AuthN/AuthZ mechanisms? N/A
        Are you logging failed auth attempts? N/A
    Are you using or adding any cryptographic features? N/A
        Do you use a standard proven implementations? N/A
        Are the used keys controlled by the customer? Where are they stored? the KMS keys are generated by cdk and are used to encrypt the environment variables for all lambda functions in the lambda-api stack
    Are you introducing any new policies/roles/users? - N/A
        Have you used the least-privilege principle? How? N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.