### PR TITLE
Restrict S3 permissions to readonly for consumption role dataset sharing policy 

### DIFF
--- a/backend/dataall/modules/dataset_sharing/services/managed_share_policy_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/managed_share_policy_service.py
@@ -209,7 +209,7 @@ class SharePolicyService(ManagedPolicy):
             additional_policy = {
                 'Sid': f'{statement_sid}S3',
                 'Effect': 'Allow',
-                'Action': ['s3:*'],
+                'Action': ['s3:*','s3:List*','s3:Describe*'],
                 'Resource': existing_s3,
             }
             policy['Statement'].append(additional_policy)

--- a/backend/dataall/modules/dataset_sharing/services/managed_share_policy_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/managed_share_policy_service.py
@@ -209,7 +209,7 @@ class SharePolicyService(ManagedPolicy):
             additional_policy = {
                 'Sid': f'{statement_sid}S3',
                 'Effect': 'Allow',
-                'Action': ['s3:*','s3:List*','s3:Describe*'],
+                'Action': ['s3:*', 's3:List*', 's3:Describe*'],
                 'Resource': existing_s3,
             }
             policy['Statement'].append(additional_policy)


### PR DESCRIPTION
… read only for consumption role

### Feature or Bugfix
- Bugfix

### Detail
- This PR will address the issue - 1226
- 
### Relates
- [<URL or Ticket>](https://github.com/data-dot-all/dataall/issues/1226)

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
  - Is the input sanitized? N/A
  - What precautions are you taking before deserializing the data you consume? N/A
  - Is injection prevented by parametrizing queries? N/A
  - Have you ensured no `eval` or similar functions are used? N/A
- Does this PR introduce any functionality or component that requires authorization? N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms? N/A
  - Are you logging failed auth attempts? N/A
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations? Yes
  - Are the used keys controlled by the customer? Where are they stored? N/A
- Are you introducing any new policies/roles/users? No
  - Have you used the least-privilege principle? How? Yes, restricted the s3:* permissions to s3 readonly permissions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
