### PR TITLE
Safety checks - Ignore disputed issue on pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ check-security: upgrade-pip install-backend install-cdkproxy
 	pip install bandit
 	pip install safety
 	bandit -lll -r backend
-	safety check --ignore=51668
+	safety check --ignore=51668,67599
 
 test:
 	export PYTHONPATH=./backend:/./tests && \


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
safety checks in the Quality gate of the CICD pipeline fail with the following error:
<img width="701" alt="image" src="https://github.com/data-dot-all/dataall/assets/71252798/a4b734b8-bebc-46df-9fc7-7ececec33d14">

As you can see in the [link](https://data.safetycli.com/v/67599/97c/) that safety provides, this is an issue reported in May 2020 and that it has been re-visited in safety. It is currently being disputed.

It affects all versions of pip and only those users that are using `--extra-index-url option`. We do not use that option and thus this vulnerability does not affect data.all

To unblock the correct run of our CICD pipelines this PR introduced an ignore for this particular item. We need to decide whether this is a temporary ignore or if we ignore it completely.

### Relates
no ticket

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
