### PR TITLE
Allow DA admins to view share logs

### DIFF
--- a/backend/dataall/modules/dataset_sharing/api/queries.py
+++ b/backend/dataall/modules/dataset_sharing/api/queries.py
@@ -2,6 +2,7 @@ from dataall.base.api import gql
 from dataall.modules.dataset_sharing.api.resolvers import (
     get_dataset_shared_assume_role_url,
     get_share_object,
+    get_share_logs,
     list_shared_with_environment_data_items,
     list_shares_in_my_inbox,
     list_shares_in_my_outbox,
@@ -69,4 +70,12 @@ getDatasetSharedAssumeRoleUrl = gql.QueryField(
     type=gql.String,
     resolver=get_dataset_shared_assume_role_url,
     test_scope='Dataset',
+)
+
+
+getShareLogs = gql.QueryField(
+    name='getShareLogs',
+    args=[gql.Argument(name='shareUri', type=gql.NonNullableType(gql.String))],
+    type=gql.ArrayType(gql.Ref('ShareLog')),
+    resolver=get_share_logs,
 )

--- a/backend/dataall/modules/dataset_sharing/api/types.py
+++ b/backend/dataall/modules/dataset_sharing/api/types.py
@@ -261,3 +261,13 @@ PrincipalSearchResult = gql.ObjectType(
         gql.Field(name='hasPrevious', type=gql.Boolean),
     ],
 )
+
+ShareLog = gql.ObjectType(
+    name='ShareLog',
+    fields=[
+        gql.Field(name='logStream', type=gql.String),
+        gql.Field(name='logGroup', type=gql.String),
+        gql.Field(name='timestamp', type=gql.String),
+        gql.Field(name='message', type=gql.String),
+    ],
+)

--- a/backend/dataall/modules/dataset_sharing/services/share_object_service.py
+++ b/backend/dataall/modules/dataset_sharing/services/share_object_service.py
@@ -590,3 +590,22 @@ class ShareObjectService:
                 log.info(
                     f'Resource permission policy {DATASET_FOLDER_READ} to table {location.itemUri} for group {share.groupUri} already exists. Skip... '
                 )
+
+    @staticmethod
+    def get_share_logs_name_query(shareUri):
+        log.info(f'Get share Logs stream name for share {shareUri}')
+
+        query = """fields @logStream
+                        |filter  @message like 'bmm02skg'
+                        | sort @timestamp desc
+                        | limit 1
+                    """
+        return query
+
+    @staticmethod
+    def get_share_logs_query(log_stream_name):
+        query = f"""fields @timestamp, @message, @logStream, @log as @logGroup
+                    | sort @timestamp asc
+                    | filter @logStream like "{log_stream_name}"
+                    """
+        return query

--- a/frontend/src/modules/Shares/components/ShareLogs.js
+++ b/frontend/src/modules/Shares/components/ShareLogs.js
@@ -1,0 +1,119 @@
+import Editor from '@monaco-editor/react';
+import { RefreshRounded } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  Grid,
+  Typography
+} from '@mui/material';
+import PropTypes from 'prop-types';
+import React, { useCallback, useEffect, useState } from 'react';
+import { THEMES, useSettings } from 'design';
+import { SET_ERROR, useDispatch } from 'globalErrors';
+import { getShareLogs, useClient } from 'services';
+
+export const ShareLogs = (props) => {
+  const { shareUri, onClose, open } = props;
+  const { settings } = useSettings();
+  const client = useClient();
+  const dispatch = useDispatch();
+  const [logs, setLogs] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const getLogs = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await client.query(getShareLogs(shareUri));
+      if (response && !response.errors) {
+        setLogs(response.data.getShareLogs.map((l) => l.message));
+      } else {
+        dispatch({ type: SET_ERROR, error: response.errors[0].message });
+      }
+    } catch (e) {
+      dispatch({ type: SET_ERROR, error: e.message });
+    }
+    setLoading(false);
+  }, [client, dispatch, shareUri]);
+
+  useEffect(() => {
+    if (client) {
+      getLogs().catch((e) => dispatch({ type: SET_ERROR, error: e.message }));
+    }
+  }, [client, dispatch, getLogs]);
+
+  return (
+    <Dialog maxWidth="md" fullWidth onClose={onClose} open={open}>
+      <Box sx={{ p: 3 }}>
+        <Grid container justifyContent="space-between" spacing={3}>
+          <Grid item>
+            <Typography color="textPrimary" gutterBottom variant="h6">
+              Logs for share {shareUri}
+            </Typography>
+          </Grid>
+          <Grid item />
+          <Box sx={{ m: -1, mt: 2 }}>
+            <Button
+              color="primary"
+              startIcon={<RefreshRounded fontSize="small" />}
+              variant="outlined"
+              onClick={getLogs}
+            >
+              Refresh
+            </Button>
+          </Box>
+        </Grid>
+        <Box sx={{ height: '35rem' }}>
+          {loading ? (
+            <CircularProgress />
+          ) : (
+            <Box>
+              {logs && (
+                <Box sx={{ mt: 1 }}>
+                  <div
+                    style={{
+                      width: '100%',
+                      border:
+                        settings.theme === THEMES.LIGHT ? '1px solid #eee' : ''
+                    }}
+                  >
+                    <Editor
+                      value={
+                        logs.length > 0
+                          ? logs.join('\n')
+                          : 'No logs available. Logs may take few minutes after the share is processed...'
+                      }
+                      options={{ minimap: { enabled: false } }}
+                      theme="vs-dark"
+                      inDiffEditor={false}
+                      height="35rem"
+                      language="text"
+                      showPrintMargin
+                      showGutter
+                      highlightActiveLine
+                      editorProps={{
+                        $blockScrolling: Infinity
+                      }}
+                      setOptions={{
+                        enableBasicAutocompletion: true,
+                        enableLiveAutocompletion: true,
+                        enableSnippets: true,
+                        showLineNumbers: true,
+                        tabSize: 2
+                      }}
+                    />
+                  </div>
+                </Box>
+              )}
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Dialog>
+  );
+};
+
+ShareLogs.propTypes = {
+  shareUri: PropTypes.string.isRequired
+};

--- a/frontend/src/modules/Shares/components/ShareLogs.js
+++ b/frontend/src/modules/Shares/components/ShareLogs.js
@@ -82,7 +82,7 @@ export const ShareLogs = (props) => {
                       value={
                         logs.length > 0
                           ? logs.join('\n')
-                          : 'No logs available. Logs may take few minutes after the share is processed...'
+                          : 'No logs available for the last 24 hours. Logs may take few minutes after the share is processed...'
                       }
                       options={{ minimap: { enabled: false } }}
                       theme="vs-dark"

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -1,4 +1,5 @@
 import {
+  Article,
   BlockOutlined,
   CheckCircleOutlined,
   CopyAllOutlined,
@@ -73,6 +74,7 @@ import {
   UpdateRequestReason
 } from '../components';
 import { generateShareItemLabel } from 'utils';
+import { ShareLogs } from '../components/ShareLogs';
 
 function ShareViewHeader(props) {
   const {
@@ -89,6 +91,8 @@ function ShareViewHeader(props) {
   const [rejecting, setRejecting] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [isRejectShareModalOpen, setIsRejectShareModalOpen] = useState(false);
+  const [openLogsModal, setOpenLogsModal] = useState(null);
+
   const submit = async () => {
     setSubmitting(true);
     const response = await client.mutate(
@@ -131,6 +135,13 @@ function ShareViewHeader(props) {
     } else {
       dispatch({ type: SET_ERROR, error: response.errors[0].message });
     }
+  };
+
+  const handleOpenLogsModal = () => {
+    setOpenLogsModal(true);
+  };
+  const handleCloseOpenLogs = () => {
+    setOpenLogsModal(false);
   };
 
   const handleRejectShareModalOpen = () => {
@@ -246,6 +257,15 @@ function ShareViewHeader(props) {
               >
                 Refresh
               </Button>
+              <Button
+                color="primary"
+                startIcon={<Article fontSize="small" />}
+                sx={{ m: 1 }}
+                variant="outlined"
+                onClick={handleOpenLogsModal}
+              >
+                Logs
+              </Button>
               {(share.userRoleForShareObject === 'Approvers' ||
                 share.userRoleForShareObject === 'ApproversAndRequesters') && (
                 <>
@@ -319,6 +339,11 @@ function ShareViewHeader(props) {
           rejectFunction={reject}
         />
       )}
+      <ShareLogs
+        shareUri={share.shareUri}
+        onClose={handleCloseOpenLogs}
+        open={openLogsModal}
+      />
     </>
   );
 }

--- a/frontend/src/services/graphql/ShareObject/getShareLogs.js
+++ b/frontend/src/services/graphql/ShareObject/getShareLogs.js
@@ -1,0 +1,15 @@
+import { gql } from 'apollo-boost';
+
+export const getShareLogs = (shareUri) => ({
+  variables: {
+    shareUri
+  },
+  query: gql`
+    query getShareLogs($shareUri: String!) {
+      getShareLogs(shareUri: $shareUri) {
+        message
+        timestamp
+      }
+    }
+  `
+});

--- a/frontend/src/services/graphql/ShareObject/index.js
+++ b/frontend/src/services/graphql/ShareObject/index.js
@@ -1,2 +1,3 @@
 export * from './createShareObject';
 export * from './getShareRequestsToMe';
+export * from './getShareLogs';


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- The latest logstream  (last 24 hours) is loaded into modal window on Share Object page
- User can see "Logs" button, if they are admins


### Relates
- #1215 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
