### PR TITLE
codebuild reads cognito-test-users param from environment account

### DIFF
--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -670,12 +670,6 @@ class PipelineStack(Stack):
                 id='ApprovalTests',
                 build_environment=codebuild.BuildEnvironment(
                     build_image=codebuild.LinuxBuildImage.AMAZON_LINUX_2_5,
-                    environment_variables={
-                        'USERDATA': BuildEnvironmentVariable(
-                            value=os.path.join('/', self.resource_prefix, target_env['envname'], 'cognito-test-users'),
-                            type=BuildEnvironmentVariableType.PARAMETER_STORE,
-                        ),
-                    },
                 ),
                 partial_build_spec=codebuild.BuildSpec.from_object(
                     dict(
@@ -691,6 +685,7 @@ class PipelineStack(Stack):
                                     'aws sts get-caller-identity --profile buildprofile',
                                     f'export COGNITO_CLIENT=$(aws ssm get-parameter --name /dataall/{target_env["envname"]}/cognito/appclient --profile buildprofile --output text --query "Parameter.Value")',
                                     f'export API_ENDPOINT=$(aws ssm get-parameter --name /dataall/{target_env["envname"]}/apiGateway/backendUrl --profile buildprofile --output text --query "Parameter.Value")',
+                                    f'export USERDATA=$(aws ssm get-parameter --name /dataall/{target_env["envname"]}/cognito-test-users --profile buildprofile --output text --query "Parameter.Value")',
                                     f'export ENVNAME={target_env["envname"]}',
                                     f'export AWS_REGION={target_env["region"]}',
                                     f'aws codeartifact login --tool pip --repository {self.codeartifact.codeartifact_pip_repo_name} --domain {self.codeartifact.codeartifact_domain_name} --domain-owner {self.codeartifact.domain.attr_owner}',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Integration tests are running from a CodeBuild job in the tooling account but the `cognito-test-users` param exists in the environment account.

### Relates
Fixes an issue introduced #1289 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
