### PR TITLE
Generic dataset module and specific s3_datasets module - part 7 (split config.json)

### DIFF
--- a/backend/dataall/modules/datasets_base/services/datasets_enums.py
+++ b/backend/dataall/modules/datasets_base/services/datasets_enums.py
@@ -40,7 +40,7 @@ class ConfidentialityClassification(GraphQLEnumMapper):
 
     @staticmethod
     def validate_confidentiality_level(confidentiality):
-        if config.get_property('modules.s3_datasets.features.confidentiality_dropdown', False):
+        if config.get_property('modules.datasets_base.features.confidentiality_dropdown', False):
             confidentiality = ConfidentialityClassification.get_confidentiality_level(confidentiality)
             if confidentiality not in [item.value for item in list(ConfidentialityClassification)]:
                 raise InvalidInput(

--- a/backend/dataall/modules/s3_datasets/cdk/dataset_stack.py
+++ b/backend/dataall/modules/s3_datasets/cdk/dataset_stack.py
@@ -501,7 +501,7 @@ class DatasetStack(Stack):
             )
             trigger.node.add_dependency(job)
 
-        if config.get_property('modules.s3_datasets.features.confidentiality_dropdown', False):
+        if config.get_property('modules.datasets_base.features.confidentiality_dropdown', False):
             Tags.of(self).add('Classification', dataset.confidentiality)
 
         TagsUtil.add_tags(stack=self, model=S3Dataset, target_type='dataset')

--- a/backend/dataall/modules/s3_datasets_shares/services/share_notification_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_notification_service.py
@@ -140,7 +140,7 @@ class ShareNotificationService:
             - share.owner (person that opened the request) OR share.groupUri (if group_notifications=true)
         """
         share_notification_config = config.get_property(
-            'modules.s3_datasets.features.share_notifications', default=None
+            'modules.datasets_base.features.share_notifications', default=None
         )
         if share_notification_config:
             for share_notification_config_type in share_notification_config.keys():

--- a/config.json
+++ b/config.json
@@ -9,12 +9,9 @@
         "datapipelines": {
             "active": true
         },
-        "s3_datasets": {
+        "datasets_base": {
             "active": true,
             "features": {
-                "file_uploads": true,
-                "file_actions": true,
-                "aws_actions": true,
                 "share_notifications": {
                     "email": {
                         "active": false,
@@ -23,8 +20,6 @@
                         }
                     }
                 },
-                "preview_data": true,
-                "glue_crawler": true,
                 "confidentiality_dropdown" : true,
                 "topics_dropdown" : true,
                 "auto_approval_for_confidentiality_level" : {
@@ -32,6 +27,16 @@
                     "Official" : true,
                     "Secret" : true
                 }
+            }
+        },
+        "s3_datasets": {
+            "active": true,
+            "features": {
+                "file_uploads": true,
+                "file_actions": true,
+                "aws_actions": true,
+                "preview_data": true,
+                "glue_crawler": true
             }
         },
         "s3_datasets_shares": {

--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -435,7 +435,7 @@ class BackendStack(Stack):
                 internet_facing=internet_facing,
             )
 
-    @run_if(['modules.s3_datasets.features.share_notifications.email.active'])
+    @run_if(['modules.datasets_base.features.share_notifications.email.active'])
     def create_ses_stack(self, custom_domain, envname, kwargs, resource_prefix):
         if custom_domain is None or None in [
             custom_domain.get('hosted_zone_name', None),

--- a/frontend/src/modules/Catalog/views/Catalog.js
+++ b/frontend/src/modules/Catalog/views/Catalog.js
@@ -183,9 +183,9 @@ const Catalog = () => {
     setIsCreateModalOpen(false);
   };
 
-  if (config.modules.s3_datasets.features.topics_dropdown === true)
+  if (config.modules.datasets_base.features.topics_dropdown === true)
     dataFieldList.push('topics');
-  if (config.modules.s3_datasets.features.confidentiality_dropdown === true)
+  if (config.modules.datasets_base.features.confidentiality_dropdown === true)
     dataFieldList.push('classification');
 
   const filterItemsInit = [
@@ -209,14 +209,14 @@ const Catalog = () => {
     }
   ];
 
-  if (config.modules.s3_datasets.features.topics_dropdown === true)
+  if (config.modules.datasets_base.features.topics_dropdown === true)
     filterItemsInit.push({
       title: 'Topics',
       dataField: 'topics',
       componentId: 'TopicSensor',
       filterLabel: 'Topics'
     });
-  if (config.modules.s3_datasets.features.confidentiality_dropdown === true)
+  if (config.modules.datasets_base.features.confidentiality_dropdown === true)
     filterItemsInit.push({
       title: 'Classification',
       dataField: 'classification',

--- a/frontend/src/modules/S3_Datasets/components/DatasetGovernance.js
+++ b/frontend/src/modules/S3_Datasets/components/DatasetGovernance.js
@@ -49,7 +49,7 @@ export const DatasetGovernance = (props) => {
           </Label>
         </Box>
       </CardContent>
-      {isFeatureEnabled('s3_datasets', 'confidentiality_dropdown') && (
+      {isFeatureEnabled('datasets_base', 'confidentiality_dropdown') && (
         <CardContent>
           <Typography color="textSecondary" variant="subtitle2">
             Classification
@@ -59,7 +59,7 @@ export const DatasetGovernance = (props) => {
           </Box>
         </CardContent>
       )}
-      {isFeatureEnabled('s3_datasets', 'topics_dropdown') && (
+      {isFeatureEnabled('datasets_base', 'topics_dropdown') && (
         <CardContent>
           <Typography color="textSecondary" variant="subtitle2">
             Topics

--- a/frontend/src/modules/S3_Datasets/views/DatasetCreateForm.js
+++ b/frontend/src/modules/S3_Datasets/views/DatasetCreateForm.js
@@ -51,7 +51,7 @@ const DatasetCreateForm = (props) => {
   const [groupOptions, setGroupOptions] = useState([]);
   const [environmentOptions, setEnvironmentOptions] = useState([]);
   const [confidentialityOptions] = useState(
-    config.modules.s3_datasets.features.confidentiality_dropdown === true &&
+    config.modules.datasets_base.features.confidentiality_dropdown === true &&
       config.modules.s3_datasets.features.custom_confidentiality_mapping
       ? Object.keys(
           config.modules.s3_datasets.features.custom_confidentiality_mapping
@@ -233,14 +233,14 @@ const DatasetCreateForm = (props) => {
                 SamlGroupName: Yup.string()
                   .max(255)
                   .required('*Owners team is required'),
-                topics: isFeatureEnabled('s3_datasets', 'topics_dropdown')
+                topics: isFeatureEnabled('datasets_base', 'topics_dropdown')
                   ? Yup.array().min(1).required('*Topics are required')
                   : Yup.array(),
                 environment: Yup.object().required('*Environment is required'),
                 tags: Yup.array().min(1).required('*Tags are required'),
                 stewards: Yup.string().max(255).nullable(),
                 confidentiality: isFeatureEnabled(
-                  's3_datasets',
+                  'datasets_base',
                   'confidentiality_dropdown'
                 )
                   ? Yup.string()
@@ -321,7 +321,7 @@ const DatasetCreateForm = (props) => {
                       <Card sx={{ mt: 3 }}>
                         <CardHeader title="Classification" />
                         {isFeatureEnabled(
-                          's3_datasets',
+                          'datasets_base',
                           'confidentiality_dropdown'
                         ) && (
                           <CardContent>
@@ -350,7 +350,10 @@ const DatasetCreateForm = (props) => {
                             </TextField>
                           </CardContent>
                         )}
-                        {isFeatureEnabled('s3_datasets', 'topics_dropdown') && (
+                        {isFeatureEnabled(
+                          'datasets_base',
+                          'topics_dropdown'
+                        ) && (
                           <CardContent>
                             <Autocomplete
                               multiple
@@ -398,7 +401,7 @@ const DatasetCreateForm = (props) => {
                           </Box>
                         </CardContent>
                         <CardContent>
-                          {config.modules.s3_datasets.features
+                          {config.modules.datasets_base.features
                             .auto_approval_for_confidentiality_level[
                             values.confidentiality
                           ] === true && (

--- a/frontend/src/modules/S3_Datasets/views/DatasetEditForm.js
+++ b/frontend/src/modules/S3_Datasets/views/DatasetEditForm.js
@@ -55,7 +55,7 @@ const DatasetEditForm = (props) => {
   const [selectableTerms, setSelectableTerms] = useState([]);
   const [tableTerms, setTableTerms] = useState([]);
   const [confidentialityOptions] = useState(
-    config.modules.s3_datasets.features.confidentiality_dropdown === true &&
+    config.modules.datasets_base.features.confidentiality_dropdown === true &&
       config.modules.s3_datasets.features.custom_confidentiality_mapping
       ? Object.keys(
           config.modules.s3_datasets.features.custom_confidentiality_mapping
@@ -278,12 +278,12 @@ const DatasetEditForm = (props) => {
                   .required('*Dataset name is required'),
                 description: Yup.string().max(5000),
                 KmsAlias: Yup.string().max(255),
-                topics: isFeatureEnabled('s3_datasets', 'topics_dropdown')
+                topics: isFeatureEnabled('datasets_base', 'topics_dropdown')
                   ? Yup.array().min(1).required('*Topics are required')
                   : Yup.array(),
                 tags: Yup.array().min(1).required('*Tags are required'),
                 confidentiality: isFeatureEnabled(
-                  's3_datasets',
+                  'datasets_base',
                   'confidentiality_dropdown'
                 )
                   ? Yup.string()
@@ -365,7 +365,7 @@ const DatasetEditForm = (props) => {
                       <Card sx={{ mt: 3 }}>
                         <CardHeader title="Classification" />
                         {isFeatureEnabled(
-                          's3_datasets',
+                          'datasets_base',
                           'confidentiality_dropdown'
                         ) && (
                           <CardContent>
@@ -395,7 +395,10 @@ const DatasetEditForm = (props) => {
                             </TextField>
                           </CardContent>
                         )}
-                        {isFeatureEnabled('s3_datasets', 'topics_dropdown') && (
+                        {isFeatureEnabled(
+                          'datasets_base',
+                          'topics_dropdown'
+                        ) && (
                           <CardContent>
                             <Autocomplete
                               multiple
@@ -484,7 +487,7 @@ const DatasetEditForm = (props) => {
                           </Box>
                         </CardContent>
                         <CardContent>
-                          {config.modules.s3_datasets.features
+                          {config.modules.datasets_base.features
                             .auto_approval_for_confidentiality_level[
                             values.confidentiality
                           ] === true && (

--- a/frontend/src/modules/S3_Datasets/views/DatasetImportForm.js
+++ b/frontend/src/modules/S3_Datasets/views/DatasetImportForm.js
@@ -51,7 +51,7 @@ const DatasetImportForm = (props) => {
   const [groupOptions, setGroupOptions] = useState([]);
   const [environmentOptions, setEnvironmentOptions] = useState([]);
   const [confidentialityOptions] = useState(
-    config.modules.s3_datasets.features.confidentiality_dropdown === true &&
+    config.modules.datasets_base.features.confidentiality_dropdown === true &&
       config.modules.s3_datasets.features.custom_confidentiality_mapping
       ? Object.keys(
           config.modules.s3_datasets.features.custom_confidentiality_mapping
@@ -241,7 +241,7 @@ const DatasetImportForm = (props) => {
                 SamlGroupName: Yup.string()
                   .max(255)
                   .required('*Team is required'),
-                topics: isFeatureEnabled('s3_datasets', 'topics_dropdown')
+                topics: isFeatureEnabled('datasets_base', 'topics_dropdown')
                   ? Yup.array().min(1).required('*Topics are required')
                   : Yup.array(),
                 environment: Yup.object().required('*Environment is required'),
@@ -252,7 +252,7 @@ const DatasetImportForm = (props) => {
                   .max(255)
                   .required('*S3 bucket name is required'),
                 confidentiality: isFeatureEnabled(
-                  's3_datasets',
+                  'datasets_base',
                   'confidentiality_dropdown'
                 )
                   ? Yup.string()
@@ -334,7 +334,7 @@ const DatasetImportForm = (props) => {
                       <Card sx={{ mt: 3 }}>
                         <CardHeader title="Classification" />
                         {isFeatureEnabled(
-                          's3_datasets',
+                          'datasets_base',
                           'confidentiality_dropdown'
                         ) && (
                           <CardContent>
@@ -363,7 +363,10 @@ const DatasetImportForm = (props) => {
                             </TextField>
                           </CardContent>
                         )}
-                        {isFeatureEnabled('s3_datasets', 'topics_dropdown') && (
+                        {isFeatureEnabled(
+                          'datasets_base',
+                          'topics_dropdown'
+                        ) && (
                           <CardContent>
                             <Autocomplete
                               multiple
@@ -411,7 +414,7 @@ const DatasetImportForm = (props) => {
                           </Box>
                         </CardContent>
                         <CardContent>
-                          {config.modules.s3_datasets.features
+                          {config.modules.datasets_base.features
                             .auto_approval_for_confidentiality_level[
                             values.confidentiality
                           ] === true && (


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring
⚠️ ⚠️ When releasing we need to give a heads up to customers as this change might overwrite their current config.json configurations. It will probably result is some conflicting changes to resolve.

### Detail
As explained in the design for #1123 we are trying to implement a generic `datasets_base` module that can be used by any type of datasets in a generic way. 

This PR is the last one of the series, it moves the generic config.json parameters for datasets into a new field `datasets_base` in the config.json. Specific `s3_datasets` parameters stay in the s3 module configuration.

### Relates
- #1123 
- #955 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
