### PR TITLE
Bugfix: timeout error when listing Consumption Roles

### DIFF
--- a/backend/dataall/core/environment/api/queries.py
+++ b/backend/dataall/core/environment/api/queries.py
@@ -21,7 +21,6 @@ from dataall.core.environment.api.resolvers import (
     list_environments,
     list_groups,
     list_valid_environments,
-    get_policies,
     get_consumption_role_policies,
 )
 from dataall.core.environment.api.types import (

--- a/backend/dataall/core/environment/api/queries.py
+++ b/backend/dataall/core/environment/api/queries.py
@@ -21,9 +21,15 @@ from dataall.core.environment.api.resolvers import (
     list_environments,
     list_groups,
     list_valid_environments,
+    get_policies,
+    get_consumption_role_policies,
 )
-from dataall.core.environment.api.types import Environment, EnvironmentSearchResult, EnvironmentSimplifiedSearchResult
-
+from dataall.core.environment.api.types import (
+    Environment,
+    EnvironmentSearchResult,
+    EnvironmentSimplifiedSearchResult,
+    RoleManagedPolicy,
+)
 
 getTrustAccount = gql.QueryField(
     name='getTrustAccount',
@@ -202,5 +208,16 @@ getPivotRoleName = gql.QueryField(
     args=[gql.Argument(name='organizationUri', type=gql.NonNullableType(gql.String))],
     type=gql.String,
     resolver=get_pivot_role_name,
+    test_scope='Environment',
+)
+
+getConsumptionRolePolicies = gql.QueryField(
+    name='getConsumptionRolePolicies',
+    args=[
+        gql.Argument(name='environmentUri', type=gql.NonNullableType(gql.String)),
+        gql.Argument(name='IAMRoleName', type=gql.NonNullableType(gql.String)),
+    ],
+    type=gql.ArrayType(RoleManagedPolicy),
+    resolver=get_consumption_role_policies,
     test_scope='Environment',
 )

--- a/backend/dataall/core/environment/api/resolvers.py
+++ b/backend/dataall/core/environment/api/resolvers.py
@@ -178,26 +178,16 @@ def get_parent_organization(context: Context, source, **kwargs):
     return org
 
 
-def get_policies(context: Context, source, **kwargs):
-    environment = EnvironmentService.find_environment_by_uri(uri=source.environmentUri)
-    return PolicyManager(
-        role_name=source.IAMRoleName,
-        environmentUri=environment.environmentUri,
-        account=environment.AwsAccountId,
-        region=environment.region,
-        resource_prefix=environment.resourcePrefix,
-    ).get_all_policies()
+# used from ConsumptionRole type as field resolver
+def resolve_consumption_role_policies(context: Context, source, **kwargs):
+    return EnvironmentService.resolve_consumption_role_policies(
+        uri=source.environmentUri, IAMRoleName=source.IAMRoleName
+    )
 
 
+# used from getConsumptionRolePolicies query -- query resolver
 def get_consumption_role_policies(context: Context, source, environmentUri, IAMRoleName):
-    environment = EnvironmentService.find_environment_by_uri(uri=environmentUri)
-    return PolicyManager(
-        role_name=IAMRoleName,
-        environmentUri=environmentUri,
-        account=environment.AwsAccountId,
-        region=environment.region,
-        resource_prefix=environment.resourcePrefix,
-    ).get_all_policies()
+    return EnvironmentService.resolve_consumption_role_policies(uri=environmentUri, IAMRoleName=IAMRoleName)
 
 
 def resolve_environment_networks(context: Context, source, **kwargs):

--- a/backend/dataall/core/environment/api/resolvers.py
+++ b/backend/dataall/core/environment/api/resolvers.py
@@ -189,6 +189,17 @@ def get_policies(context: Context, source, **kwargs):
     ).get_all_policies()
 
 
+def get_consumption_role_policies(context: Context, source, environmentUri, IAMRoleName):
+    environment = EnvironmentService.find_environment_by_uri(uri=environmentUri)
+    return PolicyManager(
+        role_name=IAMRoleName,
+        environmentUri=environmentUri,
+        account=environment.AwsAccountId,
+        region=environment.region,
+        resource_prefix=environment.resourcePrefix,
+    ).get_all_policies()
+
+
 def resolve_environment_networks(context: Context, source, **kwargs):
     return VpcService.get_environment_networks(environment_uri=source.environmentUri)
 

--- a/backend/dataall/core/environment/api/types.py
+++ b/backend/dataall/core/environment/api/types.py
@@ -3,7 +3,7 @@ from dataall.base.api import gql
 from dataall.core.environment.api.resolvers import (
     get_environment_stack,
     get_parent_organization,
-    get_policies,
+    resolve_consumption_role_policies,
     resolve_environment_networks,
     resolve_parameters,
     resolve_user_role,
@@ -180,7 +180,9 @@ ConsumptionRole = gql.ObjectType(
         gql.Field(name='created', type=gql.String),
         gql.Field(name='updated', type=gql.String),
         gql.Field(name='deleted', type=gql.String),
-        gql.Field(name='managedPolicies', type=gql.ArrayType(RoleManagedPolicy), resolver=get_policies),
+        gql.Field(
+            name='managedPolicies', type=gql.ArrayType(RoleManagedPolicy), resolver=resolve_consumption_role_policies
+        ),
     ],
 )
 

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -1115,3 +1115,15 @@ class EnvironmentService:
                 )
 
             return S3_client.get_presigned_url(region, resource_bucket, template_key)
+
+    @staticmethod
+    @ResourcePolicyService.has_resource_permission(environment_permissions.GET_ENVIRONMENT)
+    def resolve_consumption_role_policies(uri, IAMRoleName):
+        environment = EnvironmentService.find_environment_by_uri(uri=uri)
+        return PolicyManager(
+            role_name=IAMRoleName,
+            environmentUri=uri,
+            account=environment.AwsAccountId,
+            region=environment.region,
+            resource_prefix=environment.resourcePrefix,
+        ).get_all_policies()

--- a/frontend/src/modules/Catalog/components/RequestAccessModal.js
+++ b/frontend/src/modules/Catalog/components/RequestAccessModal.js
@@ -25,6 +25,7 @@ import {
   listEnvironmentGroups,
   listValidEnvironments,
   requestDashboardShare,
+  getConsumptionRolePolicies,
   useClient
 } from 'services';
 import { useNavigate } from 'react-router-dom';
@@ -41,6 +42,8 @@ export const RequestAccessModal = (props) => {
   const [groupOptions, setGroupOptions] = useState([]);
   const [loadingRoles, setLoadingRoles] = useState(false);
   const [roleOptions, setRoleOptions] = useState([]);
+  const [isSharePolicyAttached, setIsSharePolicyAttached] = useState(true);
+  const [policyName, setPolicyName] = useState('');
 
   const fetchEnvironments = useCallback(async () => {
     setLoadingEnvs(true);
@@ -109,15 +112,39 @@ export const RequestAccessModal = (props) => {
           response.data.listEnvironmentConsumptionRoles.nodes.map((g) => ({
             value: g.consumptionRoleUri,
             label: [g.consumptionRoleName, ' [', g.IAMRoleArn, ']'].join(''),
-            dataallManaged: g.dataallManaged,
-            isSharePolicyAttached: g.managedPolicies.find(
-              (policy) => policy.policy_type === 'SharePolicy'
-            ).attached,
-            policyName: g.managedPolicies.find(
-              (policy) => policy.policy_type === 'SharePolicy'
-            ).policy_name
+            IAMRoleName: g.IAMRoleName,
+            dataallManaged: g.dataallManaged
           }))
         );
+      } else {
+        dispatch({ type: SET_ERROR, error: response.errors[0].message });
+      }
+    } catch (e) {
+      dispatch({ type: SET_ERROR, error: e.message });
+    } finally {
+      setLoadingRoles(false);
+    }
+  };
+
+  const fetchRolePolicies = async (environmentUri, IAMRoleName) => {
+    setLoadingRoles(true);
+    try {
+      const response = await client.query(
+        getConsumptionRolePolicies({
+          environmentUri,
+          IAMRoleName
+        })
+      );
+      if (!response.errors) {
+        var isSharePolicyAttached =
+          response.data.getConsumptionRolePolicies.find(
+            (policy) => policy.policy_type === 'SharePolicy'
+          ).attached;
+        setIsSharePolicyAttached(isSharePolicyAttached);
+        var policyName = response.data.getConsumptionRolePolicies.find(
+          (policy) => policy.policy_type === 'SharePolicy'
+        ).policy_name;
+        setPolicyName(policyName);
       } else {
         dispatch({ type: SET_ERROR, error: response.errors[0].message });
       }
@@ -435,6 +462,15 @@ export const RequestAccessModal = (props) => {
                                     'consumptionRoleObj',
                                     event.target.value
                                   );
+                                  fetchRolePolicies(
+                                    values.environment.environmentUri,
+                                    event.target.value.IAMRoleName
+                                  ).catch((e) =>
+                                    dispatch({
+                                      type: SET_ERROR,
+                                      error: e.message
+                                    })
+                                  );
                                 }}
                                 select
                                 value={values.consumptionRoleObj}
@@ -468,10 +504,9 @@ export const RequestAccessModal = (props) => {
                       </CardContent>
                     </Box>
                   )}
-
                   {!values.consumptionRole ||
                   values.consumptionRoleObj.dataallManaged ||
-                  values.consumptionRoleObj.isSharePolicyAttached ? (
+                  isSharePolicyAttached ? (
                     <Box />
                   ) : (
                     <CardContent sx={{ ml: 2 }}>
@@ -496,16 +531,13 @@ export const RequestAccessModal = (props) => {
                             {values.consumptionRoleObj &&
                             !(
                               values.consumptionRoleObj.dataallManaged ||
-                              values.consumptionRoleObj.isSharePolicyAttached ||
+                              isSharePolicyAttached ||
                               values.attachMissingPolicies
                             ) ? (
                               <FormHelperText error>
                                 Selected consumption role is managed by
                                 customer, but the share policy{' '}
-                                <strong>
-                                  {values.consumptionRoleObj.policyName}
-                                </strong>{' '}
-                                is not attached.
+                                <strong>{policyName}</strong> is not attached.
                                 <br />
                                 Please attach it or let Data.all attach it for
                                 you.
@@ -556,7 +588,7 @@ export const RequestAccessModal = (props) => {
                       (values.consumptionRoleObj &&
                         !(
                           values.consumptionRoleObj.dataallManaged ||
-                          values.consumptionRoleObj.isSharePolicyAttached ||
+                          isSharePolicyAttached ||
                           values.attachMissingPolicies
                         ))
                     }

--- a/frontend/src/services/graphql/Environment/getConsumptionRolePolicy.js
+++ b/frontend/src/services/graphql/Environment/getConsumptionRolePolicy.js
@@ -1,0 +1,27 @@
+import { gql } from 'apollo-boost';
+
+export const getConsumptionRolePolicies = ({
+  environmentUri,
+  IAMRoleName
+}) => ({
+  variables: {
+    environmentUri,
+    IAMRoleName
+  },
+  query: gql`
+    query getConsumptionRolePolicies(
+      $environmentUri: String!
+      $IAMRoleName: String!
+    ) {
+      getConsumptionRolePolicies(
+        environmentUri: $environmentUri
+        IAMRoleName: $IAMRoleName
+      ) {
+        policy_type
+        policy_name
+        attached
+        exists
+      }
+    }
+  `
+});

--- a/frontend/src/services/graphql/Environment/index.js
+++ b/frontend/src/services/graphql/Environment/index.js
@@ -6,3 +6,4 @@ export * from './listEnvironmentGroups';
 export * from './listEnvironments';
 export * from './listValidEnvironments';
 export * from './searchEnvironmentDataItems';
+export * from './getConsumptionRolePolicy';

--- a/frontend/src/services/graphql/Environment/listEnvironmentConsumptionRoles.js
+++ b/frontend/src/services/graphql/Environment/listEnvironmentConsumptionRoles.js
@@ -28,12 +28,8 @@ export const listEnvironmentConsumptionRoles = ({
           environmentUri
           groupUri
           IAMRoleArn
+          IAMRoleName
           dataallManaged
-          managedPolicies {
-            policy_type
-            policy_name
-            attached
-          }
         }
       }
     }


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix


### Detail
- as GraphQL resolvers are 'lazy', for ShareRequest Modal window we simply don't fetch the managedPolicy property -- no timeout
- managed policies are fetched, when consumption role is selected from dropdown

### Relates
- #1288 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
