### PR TITLE
Allow descriptions schema

### DIFF
--- a/backend/dataall/base/api/gql/graphql_argument.py
+++ b/backend/dataall/base/api/gql/graphql_argument.py
@@ -18,9 +18,9 @@ class Argument:
 
     def gql(self):
         description_str = ''
-        n = "\n"
+        n = '\n'
         if self.description:
-            description_str = f" \"\"\"{self.description}\"\"\" {n}"
+            description_str = f' """{self.description}""" {n}'
 
         if isinstance(self.type, Enum):
             return f'{description_str} {self.name} : {self.type.name}'

--- a/backend/dataall/base/api/gql/graphql_argument.py
+++ b/backend/dataall/base/api/gql/graphql_argument.py
@@ -17,10 +17,7 @@ class Argument:
             raise Exception('Invalid Argument Type')
 
     def gql(self):
-        description_str = ''
-        n = '\n'
-        if self.description:
-            description_str = f' """{self.description}""" {n}'
+        description_str = f'"""{self.description}"""\n' if self.description else ''
 
         if isinstance(self.type, Enum):
             return f'{description_str}{self.name} : {self.type.name}'

--- a/backend/dataall/base/api/gql/graphql_argument.py
+++ b/backend/dataall/base/api/gql/graphql_argument.py
@@ -8,23 +8,29 @@ from .utils import get_named_type
 
 
 class Argument:
-    def __init__(self, name, type):
+    def __init__(self, name, type, description=''):
         self.name = name
+        self.description = description
         if isinstance(get_named_type(type), (Scalar, InputType, Ref, Enum)):
             self.type = type  # get_named_type(type)
         else:
             raise Exception('Invalid Argument Type')
 
     def gql(self):
+        description_str = ''
+        n = "\n"
+        if self.description:
+            description_str = f" \"\"\"{self.description}\"\"\" {n}"
+
         if isinstance(self.type, Enum):
-            return f'{self.name} : {self.type.name}'
+            return f'{description_str} {self.name} : {self.type.name}'
         elif isinstance(self.type, Ref):
-            return f'{self.name} : {self.type.name}'
+            return f'{description_str} {self.name} : {self.type.name}'
         elif isinstance(self.type, Scalar):
-            return f'{self.name} : {self.type.name}'
+            return f'{description_str} {self.name} : {self.type.name}'
         elif isinstance(self.type, InputType):
-            return f'{self.name} : {self.type.name}'
+            return f'{description_str} {self.name} : {self.type.name}'
         elif isinstance(self.type, (ArrayType, NonNullableType)):
-            return f'{self.name} : {self.type.gql()}'
+            return f'{description_str} {self.name} : {self.type.gql()}'
         elif isinstance(self.type, Thunk):
-            return f'{self.name} : {self.type.target.gql()}'
+            return f'{description_str} {self.name} : {self.type.target.gql()}'

--- a/backend/dataall/base/api/gql/graphql_argument.py
+++ b/backend/dataall/base/api/gql/graphql_argument.py
@@ -23,14 +23,14 @@ class Argument:
             description_str = f' """{self.description}""" {n}'
 
         if isinstance(self.type, Enum):
-            return f'{description_str} {self.name} : {self.type.name}'
+            return f'{description_str}{self.name} : {self.type.name}'
         elif isinstance(self.type, Ref):
-            return f'{description_str} {self.name} : {self.type.name}'
+            return f'{description_str}{self.name} : {self.type.name}'
         elif isinstance(self.type, Scalar):
-            return f'{description_str} {self.name} : {self.type.name}'
+            return f'{description_str}{self.name} : {self.type.name}'
         elif isinstance(self.type, InputType):
-            return f'{description_str} {self.name} : {self.type.name}'
+            return f'{description_str}{self.name} : {self.type.name}'
         elif isinstance(self.type, (ArrayType, NonNullableType)):
-            return f'{description_str} {self.name} : {self.type.gql()}'
+            return f'{description_str}{self.name} : {self.type.gql()}'
         elif isinstance(self.type, Thunk):
-            return f'{description_str} {self.name} : {self.type.target.gql()}'
+            return f'{description_str}{self.name} : {self.type.target.gql()}'

--- a/backend/dataall/base/api/gql/graphql_field.py
+++ b/backend/dataall/base/api/gql/graphql_field.py
@@ -49,11 +49,11 @@ class Field:
             t = self.type.name
         else:
             raise Exception(f'Invalid type for field `{self.name}`: {type(self.type)}')
-        
+
         gql = ''
-        n = "\n"
+        n = '\n'
         if self.description:
-            gql = f" \"\"\"{self.description}\"\"\" {n}"
+            gql = f' """{self.description}""" {n}'
 
         if self.args is not None:
             for a in self.args:

--- a/backend/dataall/base/api/gql/graphql_field.py
+++ b/backend/dataall/base/api/gql/graphql_field.py
@@ -50,18 +50,15 @@ class Field:
         else:
             raise Exception(f'Invalid type for field `{self.name}`: {type(self.type)}')
 
-        gql = ''
-        n = '\n'
-        if self.description:
-            gql = f' """{self.description}""" {n}'
+        description_str = f'"""{self.description}"""\n' if self.description else ''
 
         if self.args is not None:
             for a in self.args:
                 if not isinstance(a, Argument):
                     raise Exception(f'Found wrong argument in field {self.name}')
-            gql += f'{self.name}({", ".join([a.name+":"+a.type.name for a in self.args])}) : {t}'
+            gql = f'{description_str}{self.name}({", ".join([a.name+":"+a.type.name for a in self.args])}) : {t}'
         else:
-            gql += f'{self.name} : {t}'
+            gql = f'{description_str}{self.name} : {t}'
 
         if not len(self.directives):
             return gql

--- a/backend/dataall/base/api/gql/graphql_field.py
+++ b/backend/dataall/base/api/gql/graphql_field.py
@@ -21,7 +21,7 @@ class Field:
         resolver=None,
         test_scope: str = None,
         test_cases: typing.List[str] = ['*'],
-        doc='',
+        description='',
     ):
         self.name: str = name
         self.type: typing.Union[Scalar, ObjectType, Ref] = type
@@ -30,6 +30,7 @@ class Field:
         self.resolver: typing.Callable = resolver
         self.test_scope: str = test_scope
         self.test_cases: typing.List[str] = test_cases
+        self.description = description
 
     def gql(self, with_directives=True) -> str:
         if isinstance(self.type, GraphqlEnum):
@@ -48,13 +49,19 @@ class Field:
             t = self.type.name
         else:
             raise Exception(f'Invalid type for field `{self.name}`: {type(self.type)}')
+        
+        gql = ''
+        n = "\n"
+        if self.description:
+            gql = f" \"\"\"{self.description}\"\"\" {n}"
+
         if self.args is not None:
             for a in self.args:
                 if not isinstance(a, Argument):
                     raise Exception(f'Found wrong argument in field {self.name}')
-            gql = f'{self.name}({", ".join([a.name+":"+a.type.name for a in self.args])}) : {t}'
+            gql += f'{self.name}({", ".join([a.name+":"+a.type.name for a in self.args])}) : {t}'
         else:
-            gql = f'{self.name} : {t}'
+            gql += f'{self.name} : {t}'
 
         if not len(self.directives):
             return gql

--- a/backend/dataall/base/api/gql/graphql_input.py
+++ b/backend/dataall/base/api/gql/graphql_input.py
@@ -2,15 +2,19 @@ import textwrap
 
 from ._cache import cache_instances
 
-
 @cache_instances
 class InputType:
-    def __init__(self, name, arguments):
+    def __init__(self, name, arguments, description=''):
         self.name = name
         self.arguments = arguments
+        self.description = description
 
     def gql(self):
-        n = '\n'
+        description_str = ''
+        n = "\n"
+        if self.description:
+            description_str = f" \"\"\"{self.description}\"\"\" {n}"
+
         # args = f"{', '.join([arg.name+':'+ arg.type.gql() for arg in self.arguments])}"
         args = f"{', '.join([arg.gql() for arg in self.arguments])}"
-        return '\n'.join(textwrap.wrap(f'input {self.name}{{{n} {args} }}'))
+        return description_str + '\n'.join(textwrap.wrap(f'input {self.name}{{{n} {args} }}'))

--- a/backend/dataall/base/api/gql/graphql_input.py
+++ b/backend/dataall/base/api/gql/graphql_input.py
@@ -2,6 +2,7 @@ import textwrap
 
 from ._cache import cache_instances
 
+
 @cache_instances
 class InputType:
     def __init__(self, name, arguments, description=''):
@@ -11,9 +12,9 @@ class InputType:
 
     def gql(self):
         description_str = ''
-        n = "\n"
+        n = '\n'
         if self.description:
-            description_str = f" \"\"\"{self.description}\"\"\" {n}"
+            description_str = f' """{self.description}""" {n}'
 
         # args = f"{', '.join([arg.name+':'+ arg.type.gql() for arg in self.arguments])}"
         args = f"{', '.join([arg.gql() for arg in self.arguments])}"

--- a/backend/dataall/base/api/gql/graphql_input.py
+++ b/backend/dataall/base/api/gql/graphql_input.py
@@ -11,11 +11,9 @@ class InputType:
         self.description = description
 
     def gql(self):
-        description_str = ''
         n = '\n'
-        if self.description:
-            description_str = f' """{self.description}""" {n}'
+        description_str = f'"""{self.description}"""{n}' if self.description else ''
 
         # args = f"{', '.join([arg.name+':'+ arg.type.gql() for arg in self.arguments])}"
         args = f"{', '.join([arg.gql() for arg in self.arguments])}"
-        return description_str + '\n'.join(textwrap.wrap(f'input {self.name}{{{n} {args} }}'))
+        return description_str + n.join(textwrap.wrap(f'input {self.name}{{{n} {args} }}'))

--- a/backend/dataall/base/api/gql/graphql_type.py
+++ b/backend/dataall/base/api/gql/graphql_type.py
@@ -22,9 +22,9 @@ class ObjectType:
         if len(self.directives):
             directives_gql = f'{n} {n.join([d.gql() for d in self.directives])}'
         if with_directives:
-            return f'{description_str} type {self.name} {directives_gql} {{ {n} {n.join([f.gql(with_directives=with_directives) for f in self.fields])}{n} }}{n}'
+            return f'{description_str}type {self.name} {directives_gql} {{ {n} {n.join([f.gql(with_directives=with_directives) for f in self.fields])}{n} }}{n}'
         else:
-            return f'{description_str} type {self.name} {{ {n} {n.join([f.gql(with_directives=with_directives) for f in self.fields])}{n} }}{n}'
+            return f'{description_str}type {self.name} {{ {n} {n.join([f.gql(with_directives=with_directives) for f in self.fields])}{n} }}{n}'
 
     def field(self, name):
         return next(filter(lambda f: f.name == name, self.fields), None)

--- a/backend/dataall/base/api/gql/graphql_type.py
+++ b/backend/dataall/base/api/gql/graphql_type.py
@@ -18,7 +18,7 @@ class ObjectType:
         directives_gql = ''
         description_str = ''
         if self.description:
-            description_str = f" \"\"\"{self.description}\"\"\" {n}"
+            description_str = f' """{self.description}""" {n}'
         if len(self.directives):
             directives_gql = f'{n} {n.join([d.gql() for d in self.directives])}'
         if with_directives:

--- a/backend/dataall/base/api/gql/graphql_type.py
+++ b/backend/dataall/base/api/gql/graphql_type.py
@@ -16,12 +16,15 @@ class ObjectType:
     def gql(self, with_directives=True):
         n = '\n'
         directives_gql = ''
+        description_str = ''
+        if self.description:
+            description_str = f" \"\"\"{self.description}\"\"\" {n}"
         if len(self.directives):
             directives_gql = f'{n} {n.join([d.gql() for d in self.directives])}'
         if with_directives:
-            return f'type {self.name} {directives_gql} {{ {n} {n.join([f.gql(with_directives=with_directives) for f in self.fields])}{n} }}{n}'
+            return f'{description_str} type {self.name} {directives_gql} {{ {n} {n.join([f.gql(with_directives=with_directives) for f in self.fields])}{n} }}{n}'
         else:
-            return f'type {self.name} {{ {n} {n.join([f.gql(with_directives=with_directives) for f in self.fields])}{n} }}{n}'
+            return f'{description_str} type {self.name} {{ {n} {n.join([f.gql(with_directives=with_directives) for f in self.fields])}{n} }}{n}'
 
     def field(self, name):
         return next(filter(lambda f: f.name == name, self.fields), None)

--- a/backend/dataall/base/api/gql/graphql_type.py
+++ b/backend/dataall/base/api/gql/graphql_type.py
@@ -16,9 +16,8 @@ class ObjectType:
     def gql(self, with_directives=True):
         n = '\n'
         directives_gql = ''
-        description_str = ''
-        if self.description:
-            description_str = f' """{self.description}""" {n}'
+        description_str = f'"""{self.description}"""{n}' if self.description else ''
+
         if len(self.directives):
             directives_gql = f'{n} {n.join([d.gql() for d in self.directives])}'
         if with_directives:

--- a/backend/dataall/modules/catalog/api/queries.py
+++ b/backend/dataall/modules/catalog/api/queries.py
@@ -21,7 +21,7 @@ listGlossaries = gql.QueryField(
 
 SearchGlossary = gql.QueryField(
     name='searchGlossary',
-    doc='Search glossary ',
+    description='Search glossary ',
     type=gql.Ref('GlossaryChildrenSearchResult'),
     args=[gql.Argument(name='filter', type=gql.Ref('GlossaryNodeSearchFilter'))],
     resolver=search_glossary,

--- a/backend/dataall/modules/s3_datasets/cdk/dataset_stack.py
+++ b/backend/dataall/modules/s3_datasets/cdk/dataset_stack.py
@@ -289,6 +289,7 @@ class DatasetStack(Stack):
                         f'arn:aws:glue:*:{dataset.AwsAccountId}:catalog',
                         f'arn:aws:glue:{dataset.region}:{dataset.AwsAccountId}:database/{dataset.GlueDatabaseName}',
                         f'arn:aws:glue:{dataset.region}:{dataset.AwsAccountId}:table/{dataset.GlueDatabaseName}/*',
+                        f'arn:aws:glue:{dataset.region}:{dataset.AwsAccountId}:crawler/{dataset.GlueCrawlerName}',
                     ],
                 ),
                 iam.PolicyStatement(


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Enhancement

### Detail
- Allow dataset admin role glue permissions for dataset crawler 

- Allow GQL Types, Arguments, Inputs, and Fields to take in `description` instance variable and write GQL schema including the description docstring 

### Relates
- Data.all SDK/CLI

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
