### PR TITLE
Generic shares_base module and specific s3_datasets_shares module - part 4 (remove s3 info from shareItem db models)

### DIFF
--- a/backend/dataall/modules/s3_datasets_shares/api/resolvers.py
+++ b/backend/dataall/modules/s3_datasets_shares/api/resolvers.py
@@ -270,14 +270,15 @@ def list_shareable_objects(context: Context, source: ShareObject, filter: dict =
     return ShareItemService.list_shareable_objects(share=source, is_revokable=is_revokable, filter=filter)
 
 
-def resolve_shared_database_name(context: Context, source):
+def resolve_shared_database_name(context: Context, source: ShareObject):
     if not source:
         return None
-    old_shared_db_name = (source.GlueDatabaseName + '_shared_' + source.shareUri)[:254]
     with context.engine.scoped_session() as session:
         share = ShareObjectService.get_share_object_in_environment(
             uri=source.targetEnvironmentUri, shareUri=source.shareUri
         )
+        dataset = DatasetRepository.get_dataset_by_uri(session=session, dataset_uri=source.datasetUri)
+        old_shared_db_name = (dataset.GlueDatabaseName + '_shared_' + source.shareUri)[:254]
         env = EnvironmentService.get_environment_by_uri(session, share.environmentUri)
         database = GlueClient(
             account_id=env.AwsAccountId, database=old_shared_db_name, region=env.region

--- a/backend/dataall/modules/s3_datasets_shares/api/types.py
+++ b/backend/dataall/modules/s3_datasets_shares/api/types.py
@@ -204,6 +204,7 @@ EnvironmentPublishedItem = gql.ObjectType(
         gql.Field(name='datasetName', type=gql.NonNullableType(gql.String)),
         gql.Field(name='itemAccess', type=gql.NonNullableType(gql.String)),
         gql.Field(name='itemType', type=gql.NonNullableType(gql.String)),
+        gql.Field(name='itemName', type=gql.NonNullableType(gql.String)),
         gql.Field(name='environmentUri', type=gql.NonNullableType(gql.String)),
         gql.Field(name='targetEnvironmentUri', type=gql.NonNullableType(gql.String)),
         gql.Field(name='principalId', type=gql.NonNullableType(gql.String)),
@@ -211,9 +212,8 @@ EnvironmentPublishedItem = gql.ObjectType(
         gql.Field(name='organizationUri', type=gql.NonNullableType(gql.String)),
         gql.Field(name='organizationName', type=gql.NonNullableType(gql.String)),
         gql.Field(name='created', type=gql.NonNullableType(gql.String)),
-        gql.Field(name='GlueDatabaseName', type=gql.String),
-        gql.Field(name='GlueTableName', type=gql.String),
-        gql.Field(name='S3AccessPointName', type=gql.String),
+        gql.Field(name='GlueDatabaseName', type=gql.String),  # TODO: remove when splitting API calls
+        gql.Field(name='GlueTableName', type=gql.String),  # TODO: remove when splitting API calls
         gql.Field(
             'sharedGlueDatabaseName',
             type=gql.String,

--- a/backend/dataall/modules/s3_datasets_shares/db/share_object_repositories.py
+++ b/backend/dataall/modules/s3_datasets_shares/db/share_object_repositories.py
@@ -844,9 +844,9 @@ class ShareObjectRepository:
                 ShareObject.principalType.label('principalType'),
                 ShareObject.environmentUri.label('targetEnvironmentUri'),
                 ShareObjectItem.itemType.label('itemType'),
+                ShareObjectItem.itemName.label('itemName'),
                 S3Dataset.GlueDatabaseName.label('GlueDatabaseName'),
                 DatasetTable.GlueTableName.label('GlueTableName'),
-                ShareObjectItem.S3AccessPointName.label('S3AccessPointName'),
                 Organization.organizationUri.label('organizationUri'),
                 Organization.name.label('organizationName'),
                 case(

--- a/backend/dataall/modules/s3_datasets_shares/db/share_object_repositories.py
+++ b/backend/dataall/modules/s3_datasets_shares/db/share_object_repositories.py
@@ -815,7 +815,7 @@ class ShareObjectRepository:
             query = query.filter(ShareObjectItem.itemType == item_type)
         shares_datasets = []
         for share in query.all():
-            dataset = DatasetRepository.get_dataset_by_uri(session, share.datasetUri)
+            dataset: S3Dataset = DatasetRepository.get_dataset_by_uri(session, share.datasetUri)
             shares_datasets.append(
                 {'shareUri': share.shareUri, 'databaseName': f'{dataset.GlueDatabaseName}_shared_{share.shareUri}'}
             )
@@ -844,7 +844,7 @@ class ShareObjectRepository:
                 ShareObject.principalType.label('principalType'),
                 ShareObject.environmentUri.label('targetEnvironmentUri'),
                 ShareObjectItem.itemType.label('itemType'),
-                ShareObjectItem.GlueDatabaseName.label('GlueDatabaseName'),
+                S3Dataset.GlueDatabaseName.label('GlueDatabaseName'),
                 ShareObjectItem.GlueTableName.label('GlueTableName'),
                 ShareObjectItem.S3AccessPointName.label('S3AccessPointName'),
                 Organization.organizationUri.label('organizationUri'),

--- a/backend/dataall/modules/s3_datasets_shares/db/share_object_repositories.py
+++ b/backend/dataall/modules/s3_datasets_shares/db/share_object_repositories.py
@@ -845,7 +845,7 @@ class ShareObjectRepository:
                 ShareObject.environmentUri.label('targetEnvironmentUri'),
                 ShareObjectItem.itemType.label('itemType'),
                 S3Dataset.GlueDatabaseName.label('GlueDatabaseName'),
-                ShareObjectItem.GlueTableName.label('GlueTableName'),
+                DatasetTable.GlueTableName.label('GlueTableName'),
                 ShareObjectItem.S3AccessPointName.label('S3AccessPointName'),
                 Organization.organizationUri.label('organizationUri'),
                 Organization.name.label('organizationName'),

--- a/backend/dataall/modules/s3_datasets_shares/services/share_item_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_item_service.py
@@ -163,7 +163,6 @@ class ShareItemService:
                     itemName=item.name,
                     status=ShareItemStatus.PendingApproval.value,
                     owner=context.username,
-                    S3AccessPointName=s3_access_point_name if item_type == ShareableType.StorageLocation.value else '',
                 )
                 session.add(share_item)
         return share_item

--- a/backend/dataall/modules/s3_datasets_shares/services/share_item_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_item_service.py
@@ -140,7 +140,7 @@ class ShareItemService:
                 raise UnauthorizedOperation(
                     action=ADD_ITEM,
                     message=f'Lake Formation cross region sharing is not supported. '
-                    f'Table {item.GlueTableName} is in {item.region} and target environment '
+                    f'Table {item.itemUri} is in {item.region} and target environment '
                     f'{target_environment.name} is in {target_environment.region} ',
                 )
 
@@ -163,7 +163,6 @@ class ShareItemService:
                     itemName=item.name,
                     status=ShareItemStatus.PendingApproval.value,
                     owner=context.username,
-                    GlueTableName=item.GlueTableName if item_type == ShareableType.Table.value else '',
                     S3AccessPointName=s3_access_point_name if item_type == ShareableType.StorageLocation.value else '',
                 )
                 session.add(share_item)

--- a/backend/dataall/modules/s3_datasets_shares/services/share_item_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_item_service.py
@@ -163,11 +163,6 @@ class ShareItemService:
                     itemName=item.name,
                     status=ShareItemStatus.PendingApproval.value,
                     owner=context.username,
-                    GlueDatabaseName=ShareItemService._get_glue_database_for_share(
-                        dataset.GlueDatabaseName, dataset.AwsAccountId, dataset.region
-                    )
-                    if item_type == ShareableType.Table.value
-                    else '',
                     GlueTableName=item.GlueTableName if item_type == ShareableType.Table.value else '',
                     S3AccessPointName=s3_access_point_name if item_type == ShareableType.StorageLocation.value else '',
                 )

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
@@ -56,7 +56,7 @@ class S3AccessPointShareManager:
             share_data.share.shareUri,
             target_folder.locationUri,
         )
-        self.access_point_name = self.share_item.S3AccessPointName
+        self.access_point_name = self.build_access_point_name(share=share_data.share)
 
         self.source_account_id = share_data.dataset.AwsAccountId
         self.target_account_id = share_data.target_environment.AwsAccountId

--- a/backend/dataall/modules/s3_datasets_shares/services/share_object_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_object_service.py
@@ -208,9 +208,6 @@ class ShareObjectService:
                         itemName=item.name,
                         status=ShareItemStatus.PendingApproval.value,
                         owner=context.username,
-                        S3AccessPointName=s3_access_point_name
-                        if item_type == ShareableType.StorageLocation.value
-                        else '',
                     )
                     session.add(new_share_item)
 

--- a/backend/dataall/modules/s3_datasets_shares/services/share_object_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_object_service.py
@@ -208,11 +208,6 @@ class ShareObjectService:
                         itemName=item.name,
                         status=ShareItemStatus.PendingApproval.value,
                         owner=context.username,
-                        GlueDatabaseName=ShareItemService._get_glue_database_for_share(
-                            dataset.GlueDatabaseName, dataset.AwsAccountId, dataset.region
-                        )
-                        if item_type == ShareableType.Table.value
-                        else '',
                         GlueTableName=item.GlueTableName if item_type == ShareableType.Table.value else '',
                         S3AccessPointName=s3_access_point_name
                         if item_type == ShareableType.StorageLocation.value

--- a/backend/dataall/modules/s3_datasets_shares/services/share_object_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_object_service.py
@@ -208,7 +208,6 @@ class ShareObjectService:
                         itemName=item.name,
                         status=ShareItemStatus.PendingApproval.value,
                         owner=context.username,
-                        GlueTableName=item.GlueTableName if item_type == ShareableType.Table.value else '',
                         S3AccessPointName=s3_access_point_name
                         if item_type == ShareableType.StorageLocation.value
                         else '',

--- a/backend/dataall/modules/shares_base/db/share_object_models.py
+++ b/backend/dataall/modules/shares_base/db/share_object_models.py
@@ -57,5 +57,3 @@ class ShareObjectItem(Base):
     healthStatus = Column(String, nullable=True)
     healthMessage = Column(String, nullable=True)
     lastVerificationTime = Column(DateTime, nullable=True)
-
-    # todo: MIGRATION SCRIPT TO REMOVE GlueDatabaseName, GlueTableName, S3AccessPointName --> replaced by itemConsumptionDetails

--- a/backend/dataall/modules/shares_base/db/share_object_models.py
+++ b/backend/dataall/modules/shares_base/db/share_object_models.py
@@ -52,11 +52,10 @@ class ShareObjectItem(Base):
     updated = Column(DateTime, nullable=True, onupdate=datetime.now)
     deleted = Column(DateTime, nullable=True)
     owner = Column(String, nullable=False)
-    S3AccessPointName = Column(String, nullable=True)  # TODO: remove
     status = Column(String, nullable=False, default=ShareItemStatus.PendingApproval.value)
     action = Column(String, nullable=True)
     healthStatus = Column(String, nullable=True)
     healthMessage = Column(String, nullable=True)
     lastVerificationTime = Column(DateTime, nullable=True)
 
-    # todo: MIGRATION SCRIPT TO REMOVE GlueDatabaseName, GlueTableName, S3AccessPointName
+    # todo: MIGRATION SCRIPT TO REMOVE GlueDatabaseName, GlueTableName, S3AccessPointName --> replaced by itemConsumptionDetails

--- a/backend/dataall/modules/shares_base/db/share_object_models.py
+++ b/backend/dataall/modules/shares_base/db/share_object_models.py
@@ -52,7 +52,6 @@ class ShareObjectItem(Base):
     updated = Column(DateTime, nullable=True, onupdate=datetime.now)
     deleted = Column(DateTime, nullable=True)
     owner = Column(String, nullable=False)
-    GlueTableName = Column(String, nullable=True)  # TODO: remove
     S3AccessPointName = Column(String, nullable=True)  # TODO: remove
     status = Column(String, nullable=False, default=ShareItemStatus.PendingApproval.value)
     action = Column(String, nullable=True)

--- a/backend/dataall/modules/shares_base/db/share_object_models.py
+++ b/backend/dataall/modules/shares_base/db/share_object_models.py
@@ -52,7 +52,6 @@ class ShareObjectItem(Base):
     updated = Column(DateTime, nullable=True, onupdate=datetime.now)
     deleted = Column(DateTime, nullable=True)
     owner = Column(String, nullable=False)
-    GlueDatabaseName = Column(String, nullable=True)  # TODO: remove
     GlueTableName = Column(String, nullable=True)  # TODO: remove
     S3AccessPointName = Column(String, nullable=True)  # TODO: remove
     status = Column(String, nullable=False, default=ShareItemStatus.PendingApproval.value)
@@ -60,3 +59,5 @@ class ShareObjectItem(Base):
     healthStatus = Column(String, nullable=True)
     healthMessage = Column(String, nullable=True)
     lastVerificationTime = Column(DateTime, nullable=True)
+
+    # todo: MIGRATION SCRIPT TO REMOVE GlueDatabaseName, GlueTableName, S3AccessPointName

--- a/backend/migrations/versions/6adce90ab470_drop_share_object_item_s3_columns.py
+++ b/backend/migrations/versions/6adce90ab470_drop_share_object_item_s3_columns.py
@@ -1,0 +1,29 @@
+"""drop_share_object_item_s3_columns
+
+Revision ID: 6adce90ab470
+Revises: 5cdcf6cc1d73
+Create Date: 2024-06-05 08:27:05.393712
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6adce90ab470'
+down_revision = '5cdcf6cc1d73'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column('share_object_item', 'S3AccessPointName')
+    op.drop_column('share_object_item', 'GlueTableName')
+    op.drop_column('share_object_item', 'GlueDatabaseName')
+
+
+def downgrade():
+    op.add_column('share_object_item', sa.Column('GlueDatabaseName', sa.VARCHAR(), autoincrement=False, nullable=True))
+    op.add_column('share_object_item', sa.Column('GlueTableName', sa.VARCHAR(), autoincrement=False, nullable=True))
+    op.add_column('share_object_item', sa.Column('S3AccessPointName', sa.VARCHAR(), autoincrement=False, nullable=True))

--- a/frontend/src/modules/Environments/components/EnvironmentSharedDatasets.js
+++ b/frontend/src/modules/Environments/components/EnvironmentSharedDatasets.js
@@ -135,9 +135,7 @@ export const EnvironmentSharedDatasets = ({ environment }) => {
                   items.nodes.map((item) => (
                     <TableRow hover key={item.itemUri}>
                       <TableCell>{item.itemType}</TableCell>
-                      <TableCell>
-                        {item.itemName}
-                      </TableCell>
+                      <TableCell>{item.itemName}</TableCell>
                       <TableCell>{item.datasetName}</TableCell>
                       <TableCell>{item.environmentName}</TableCell>
                       <TableCell>{item.principalId}</TableCell>

--- a/frontend/src/modules/Environments/components/EnvironmentSharedDatasets.js
+++ b/frontend/src/modules/Environments/components/EnvironmentSharedDatasets.js
@@ -136,7 +136,7 @@ export const EnvironmentSharedDatasets = ({ environment }) => {
                     <TableRow hover key={item.itemUri}>
                       <TableCell>{item.itemType}</TableCell>
                       <TableCell>
-                        {item.GlueTableName || item.S3AccessPointName}
+                        {item.itemName}
                       </TableCell>
                       <TableCell>{item.datasetName}</TableCell>
                       <TableCell>{item.environmentName}</TableCell>

--- a/frontend/src/services/graphql/Environment/searchEnvironmentDataItems.js
+++ b/frontend/src/services/graphql/Environment/searchEnvironmentDataItems.js
@@ -28,10 +28,10 @@ export const searchEnvironmentDataItems = ({ filter, environmentUri }) => ({
           datasetUri
           datasetName
           itemType
+          itemName
           itemAccess
           GlueDatabaseName
           GlueTableName
-          S3AccessPointName
           created
           principalId
           sharedGlueDatabaseName


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
As explained in the design for #1123 and #1283 we are trying to implement generic `datasets_base` and `shares_base` modules that can be used by any type of datasets and by any type of shareable object in a generic way. 

In this PR:
- Remove the fields `GlueDatabaseName`, `GlueTableName` and `S3AccessPointName` from the ShareObjectItem db model. The goal is to have a generic ShareObjectItem and access the specific item information through its itemUri and itemType.
- Migration script to drop those columns. 
- Disclaimer, there is still work to do on the gql types; but that is out of the scope for this PR

### Relates
- #1283 
- #1123 
- #955 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
