### PR TITLE
Fix positional args generate env access

### DIFF
--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -984,7 +984,9 @@ class EnvironmentService:
                     message=f'User: {username} is not member of the environment admins team {environment.SamlGroupName}',
                 )
         else:
-            env_group = EnvironmentService.get_environment_group(session, environment.environmentUri, groupUri)
+            env_group = EnvironmentService.get_environment_group(
+                session, group_uri=groupUri, environment_uri=environment.environmentUri
+            )
             if not env_group:
                 raise exceptions.UnauthorizedOperation(
                     action='ENVIRONMENT_AWS_ACCESS',


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- Positional Args in incorrect order `get_environment_grop()` for `generate_environment_access_token()`


### Relates
N/A

### Security
N/A
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
