### PR TITLE
fix migration to not rely on OrganizationService or RequestContext

### DIFF
--- a/backend/migrations/versions/328e35e39e1e_invite_env_groups_as_readers.py
+++ b/backend/migrations/versions/328e35e39e1e_invite_env_groups_as_readers.py
@@ -11,9 +11,6 @@ from sqlalchemy import orm
 from dataall.core.environment.db.environment_models import EnvironmentGroup, Environment
 from dataall.core.organizations.db.organization_repositories import OrganizationRepository
 from dataall.core.permissions.services.organization_permissions import GET_ORGANIZATION
-from dataall.core.permissions.services.organization_permissions import (
-    GET_ORGANIZATION,
-)
 from dataall.core.organizations.db import organization_models as models
 from dataall.core.permissions.services.resource_policy_service import ResourcePolicyService
 

--- a/backend/migrations/versions/328e35e39e1e_invite_env_groups_as_readers.py
+++ b/backend/migrations/versions/328e35e39e1e_invite_env_groups_as_readers.py
@@ -10,9 +10,12 @@ from alembic import op
 from sqlalchemy import orm
 from dataall.core.environment.db.environment_models import EnvironmentGroup, Environment
 from dataall.core.organizations.db.organization_repositories import OrganizationRepository
-from dataall.core.organizations.services.organization_service import OrganizationService
 from dataall.core.permissions.services.organization_permissions import GET_ORGANIZATION
-
+from dataall.core.permissions.services.organization_permissions import (
+    GET_ORGANIZATION,
+)
+from dataall.core.organizations.db import organization_models as models
+from dataall.core.permissions.services.resource_policy_service import ResourcePolicyService
 
 # revision identifiers, used by Alembic.
 revision = '328e35e39e1e'
@@ -37,15 +40,26 @@ def upgrade():
         env_org[e.environmentUri] = e.organizationUri
 
     for group in all_env_groups:
-        group_membership = OrganizationRepository.find_group_membership(
-            session, [group.groupUri], env_org[group.environmentUri]
-        )
+        organization_uri = env_org[group.environmentUri]
+
+        group_membership = OrganizationRepository.find_group_membership(session, [group.groupUri], organization_uri)
+
         if group_membership is None:
-            data = {
-                'groupUri': group.groupUri,
-                'permissions': [GET_ORGANIZATION],
-            }
-            OrganizationService.invite_group(env_org[group.environmentUri], data)
+            # 1. Add Organization Group
+            org_group = models.OrganizationGroup(
+                organizationUri=organization_uri, groupUri=group.groupUri
+            )
+            session.add(org_group)
+
+            # 2. Add Resource Policy Permissions
+            permissions = [GET_ORGANIZATION]
+            ResourcePolicyService.attach_resource_policy(
+                session=session,
+                group=group.groupUri,
+                resource_uri=organization_uri,
+                permissions=permissions,
+                resource_type=models.Organization.__name__,
+            )
 
 
 def downgrade():

--- a/backend/migrations/versions/328e35e39e1e_invite_env_groups_as_readers.py
+++ b/backend/migrations/versions/328e35e39e1e_invite_env_groups_as_readers.py
@@ -46,9 +46,7 @@ def upgrade():
 
         if group_membership is None:
             # 1. Add Organization Group
-            org_group = models.OrganizationGroup(
-                organizationUri=organization_uri, groupUri=group.groupUri
-            )
+            org_group = models.OrganizationGroup(organizationUri=organization_uri, groupUri=group.groupUri)
             session.add(org_group)
 
             # 2. Add Resource Policy Permissions


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Ensure migration script does not need RequestContext - otherwise fails in migration trigger lambda as context info not set / available


### Relates
- https://github.com/data-dot-all/dataall/pull/1306

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
