### PR TITLE
Enforce non null on GQL query string if non null defined

### DIFF
--- a/frontend/src/modules/Worksheets/services/listS3DatasetsSharedWithEnvGroup.js
+++ b/frontend/src/modules/Worksheets/services/listS3DatasetsSharedWithEnvGroup.js
@@ -9,8 +9,8 @@ export const listS3DatasetsSharedWithEnvGroup = ({
   },
   query: gql`
     query listS3DatasetsSharedWithEnvGroup(
-      $environmentUri: String
-      $groupUri: String
+      $environmentUri: String!
+      $groupUri: String!
     ) {
       listS3DatasetsSharedWithEnvGroup(
         environmentUri: $environmentUri


### PR DESCRIPTION


### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- Add `String!` to ensure non null input argument on FE if defined as such on backend GQL operation for `listS3DatasetsSharedWithEnvGroup` 


### Relates

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
