### PR TITLE
split cognito urls setup and cognito user creation

### DIFF
--- a/deploy/custom_resources/cognito_config/cognito_urls.py
+++ b/deploy/custom_resources/cognito_config/cognito_urls.py
@@ -1,0 +1,82 @@
+import logging
+import os
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
+log = logging.getLogger(__name__)
+
+
+def setup_cognito(
+    region,
+    envname,
+    custom_domain='False',
+):
+    ssm = boto3.client('ssm', region_name=region)
+    user_pool_id = ssm.get_parameter(Name=f'/dataall/{envname}/cognito/userpool')['Parameter']['Value']
+    log.info(f'Cognito Pool ID: {user_pool_id}')
+    app_client = ssm.get_parameter(Name=f'/dataall/{envname}/cognito/appclient')['Parameter']['Value']
+
+    if custom_domain == 'False':
+        log.info('Switching to us-east-1 region...')
+        ssm = boto3.client('ssm', region_name='us-east-1')
+        signin_singout_link = ssm.get_parameter(Name=f'/dataall/{envname}/CloudfrontDistributionDomainName')[
+            'Parameter'
+        ]['Value']
+        user_guide_link = ssm.get_parameter(
+            Name=f'/dataall/{envname}/cloudfront/docs/user/CloudfrontDistributionDomainName'
+        )['Parameter']['Value']
+    else:
+        signin_singout_link = ssm.get_parameter(Name=f'/dataall/{envname}/frontend/custom_domain_name')['Parameter'][
+            'Value'
+        ]
+        user_guide_link = ssm.get_parameter(Name=f'/dataall/{envname}/userguide/custom_domain_name')['Parameter'][
+            'Value'
+        ]
+
+    log.info(f'UI: {signin_singout_link}')
+    log.info(f'USERGUIDE: {user_guide_link}')
+
+    cognito = boto3.client('cognito-idp', region_name=region)
+    user_pool = cognito.describe_user_pool_client(UserPoolId=user_pool_id, ClientId=app_client)
+
+    del user_pool['UserPoolClient']['CreationDate']
+    del user_pool['UserPoolClient']['LastModifiedDate']
+
+    config_callbacks = [
+        f'https://{signin_singout_link}',
+        f'https://{user_guide_link}/parseauth',
+    ]
+    existing_callbacks = user_pool['UserPoolClient'].get('CallbackURLs', [])
+    if 'https://example.com' in existing_callbacks:
+        existing_callbacks.remove('https://example.com')
+    updated_callbacks = existing_callbacks + list(set(config_callbacks) - set(existing_callbacks))
+    log.info(f'Updated CallBackUrls: {updated_callbacks}')
+
+    config_logout_urls = [f'https://{signin_singout_link}']
+    existing_logout_urls = user_pool['UserPoolClient'].get('LogoutURLs', [])
+    updated_logout_urls = existing_logout_urls + list(set(config_logout_urls) - set(existing_logout_urls))
+    log.info(f'Updated LogOutUrls: {updated_logout_urls}')
+
+    user_pool['UserPoolClient']['CallbackURLs'] = updated_callbacks
+    user_pool['UserPoolClient']['LogoutURLs'] = updated_logout_urls
+
+    response = cognito.update_user_pool_client(
+        **user_pool['UserPoolClient'],
+    )
+
+    log.info(f'CallbackUrls and LogOutUrls updated successfully: {response}')
+
+
+def handler(event, context) -> None:
+    log.info('Starting Cognito Configuration...')
+    envname = os.environ.get('envname')
+    region = os.environ.get('deployment_region')
+    custom_domain = os.environ.get('custom_domain')
+    setup_cognito(
+        region,
+        envname,
+        custom_domain,
+    )
+    log.info('Cognito Configuration Finished Successfully')

--- a/deploy/custom_resources/cognito_config/cognito_users.py
+++ b/deploy/custom_resources/cognito_config/cognito_users.py
@@ -22,65 +22,13 @@ def setup_cognito(
     region,
     resource_prefix,
     envname,
-    internet_facing='True',
-    custom_domain='False',
     enable_cw_canaries='False',
     with_approval_tests='False',
 ):
     ssm = boto3.client('ssm', region_name=region)
     user_pool_id = ssm.get_parameter(Name=f'/dataall/{envname}/cognito/userpool')['Parameter']['Value']
     log.info(f'Cognito Pool ID: {user_pool_id}')
-    app_client = ssm.get_parameter(Name=f'/dataall/{envname}/cognito/appclient')['Parameter']['Value']
-
-    if custom_domain == 'False' and internet_facing == 'True':
-        log.info('Switching to us-east-1 region...')
-        ssm = boto3.client('ssm', region_name='us-east-1')
-        signin_singout_link = ssm.get_parameter(Name=f'/dataall/{envname}/CloudfrontDistributionDomainName')[
-            'Parameter'
-        ]['Value']
-        user_guide_link = ssm.get_parameter(
-            Name=f'/dataall/{envname}/cloudfront/docs/user/CloudfrontDistributionDomainName'
-        )['Parameter']['Value']
-    else:
-        signin_singout_link = ssm.get_parameter(Name=f'/dataall/{envname}/frontend/custom_domain_name')['Parameter'][
-            'Value'
-        ]
-        user_guide_link = ssm.get_parameter(Name=f'/dataall/{envname}/userguide/custom_domain_name')['Parameter'][
-            'Value'
-        ]
-
-    log.info(f'UI: {signin_singout_link}')
-    log.info(f'USERGUIDE: {user_guide_link}')
-
     cognito = boto3.client('cognito-idp', region_name=region)
-    user_pool = cognito.describe_user_pool_client(UserPoolId=user_pool_id, ClientId=app_client)
-
-    del user_pool['UserPoolClient']['CreationDate']
-    del user_pool['UserPoolClient']['LastModifiedDate']
-
-    config_callbacks = [
-        f'https://{signin_singout_link}',
-        f'https://{user_guide_link}/parseauth',
-    ]
-    existing_callbacks = user_pool['UserPoolClient'].get('CallbackURLs', [])
-    if 'https://example.com' in existing_callbacks:
-        existing_callbacks.remove('https://example.com')
-    updated_callbacks = existing_callbacks + list(set(config_callbacks) - set(existing_callbacks))
-    log.info(f'Updated CallBackUrls: {updated_callbacks}')
-
-    config_logout_urls = [f'https://{signin_singout_link}']
-    existing_logout_urls = user_pool['UserPoolClient'].get('LogoutURLs', [])
-    updated_logout_urls = existing_logout_urls + list(set(config_logout_urls) - set(existing_logout_urls))
-    log.info(f'Updated LogOutUrls: {updated_logout_urls}')
-
-    user_pool['UserPoolClient']['CallbackURLs'] = updated_callbacks
-    user_pool['UserPoolClient']['LogoutURLs'] = updated_logout_urls
-
-    response = cognito.update_user_pool_client(
-        **user_pool['UserPoolClient'],
-    )
-
-    log.info(f'CallbackUrls and LogOutUrls updated successfully: {response}')
 
     try:
         response = cognito.create_group(
@@ -162,8 +110,6 @@ def handler(event, context) -> None:
     log.info('Starting Cognito Configuration...')
     envname = os.environ.get('envname')
     region = os.environ.get('deployment_region')
-    internet_facing = os.environ.get('internet_facing')
-    custom_domain = os.environ.get('custom_domain')
     enable_cw_canaries = os.environ.get('enable_cw_canaries')
     resource_prefix = os.environ.get('resource_prefix')
     with_approval_tests = os.environ.get('with_approval_tests')
@@ -171,8 +117,6 @@ def handler(event, context) -> None:
         region,
         resource_prefix,
         envname,
-        internet_facing,
-        custom_domain,
         enable_cw_canaries,
         with_approval_tests,
     )

--- a/deploy/custom_resources/utils.py
+++ b/deploy/custom_resources/utils.py
@@ -1,0 +1,23 @@
+import os
+
+from aws_cdk import aws_lambda, BundlingOptions
+from aws_cdk.aws_lambda import AssetCode
+
+from stacks.solution_bundling import SolutionBundling
+
+
+def get_lambda_code(path, image=aws_lambda.Runtime.PYTHON_3_9.bundling_image) -> AssetCode:
+    assets_path = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            path,
+        )
+    )
+
+    return aws_lambda.Code.from_asset(
+        path=assets_path,
+        bundling=BundlingOptions(
+            image=image,
+            local=SolutionBundling(source_path=assets_path),
+        ),
+    )

--- a/deploy/stacks/cloudfront_stack.py
+++ b/deploy/stacks/cloudfront_stack.py
@@ -16,6 +16,7 @@ class CloudfrontStack(Stack):
         custom_domain=None,
         custom_waf_rules=None,
         custom_auth=None,
+        backend_region=None,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -42,5 +43,6 @@ class CloudfrontStack(Stack):
             custom_domain=custom_domain,
             custom_waf_rules=custom_waf_rules,
             custom_auth=custom_auth,
+            backend_region=backend_region,
             **kwargs,
         )

--- a/deploy/stacks/cloudfront_stage.py
+++ b/deploy/stacks/cloudfront_stage.py
@@ -16,6 +16,7 @@ class CloudfrontStage(Stage):
         custom_domain=None,
         custom_waf_rules=None,
         custom_auth=None,
+        backend_region=None,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -29,6 +30,7 @@ class CloudfrontStage(Stage):
             custom_domain=custom_domain,
             custom_waf_rules=custom_waf_rules,
             custom_auth=custom_auth,
+            backend_region=backend_region,
         )
 
         Tags.of(cloudfront_stack).add('Application', f'{resource_prefix}-{envname}')

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -755,6 +755,7 @@ class PipelineStack(Stack):
                 custom_domain=target_env.get('custom_domain'),
                 custom_auth=target_env.get('custom_auth', None),
                 custom_waf_rules=target_env.get('custom_waf_rules', None),
+                backend_region=target_env.get('region', self.region),
             )
         )
         front_stage_actions = (


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix
### Details
For more details about the issue read #1353 
In this PR we are solving the problem by splitting the configuration of Cognito in 2.
* First part (cognito_users_config.py) is setting up the required groups and users and runs after UserPool deployment
* Second part (cognito_urls_config.py) is  setting up Cognito's callback/logout urls and runs after the CloudFront deployment

We chose to split the functionality because we need to have the users/groups setup for the integration tests which are run after the backend deployment.

The other althernative is to keep the config functionality as one but make the integ tests run after CloudFront stage.

### Relates
- Solves #1353 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
