### PR TITLE
Fix lambda_env_key out of scope for vpc-facing cognito setup

### DIFF
--- a/deploy/stacks/cognito.py
+++ b/deploy/stacks/cognito.py
@@ -240,6 +240,34 @@ class IdpStack(pyNestedClass):
             string_value=cross_account_frontend_config_role.role_name,
         )
 
+        lambda_env_key = kms.Key(
+            self,
+            f'{resource_prefix}-cogn-lambda-env-var-key',
+            removal_policy=RemovalPolicy.DESTROY,
+            alias=f'{resource_prefix}-cogn-lambda-env-var-key',
+            enable_key_rotation=True,
+            policy=iam.PolicyDocument(
+                statements=[
+                    iam.PolicyStatement(
+                        resources=['*'],
+                        effect=iam.Effect.ALLOW,
+                        principals=[
+                            iam.AccountPrincipal(account_id=self.account),
+                        ],
+                        actions=['kms:*'],
+                    ),
+                    iam.PolicyStatement(
+                        resources=['*'],
+                        effect=iam.Effect.ALLOW,
+                        principals=[
+                            iam.ServicePrincipal(service='lambda.amazonaws.com'),
+                        ],
+                        actions=['kms:GenerateDataKey*', 'kms:Decrypt'],
+                    ),
+                ],
+            ),
+        )
+
         if internet_facing:
             role_inline_policy = iam.Policy(
                 self,
@@ -280,33 +308,6 @@ class IdpStack(pyNestedClass):
                     'custom_resources',
                     'sync_congito_params',
                 )
-            )
-            lambda_env_key = kms.Key(
-                self,
-                f'{resource_prefix}-cogn-lambda-env-var-key',
-                removal_policy=RemovalPolicy.DESTROY,
-                alias=f'{resource_prefix}-cogn-lambda-env-var-key',
-                enable_key_rotation=True,
-                policy=iam.PolicyDocument(
-                    statements=[
-                        iam.PolicyStatement(
-                            resources=['*'],
-                            effect=iam.Effect.ALLOW,
-                            principals=[
-                                iam.AccountPrincipal(account_id=self.account),
-                            ],
-                            actions=['kms:*'],
-                        ),
-                        iam.PolicyStatement(
-                            resources=['*'],
-                            effect=iam.Effect.ALLOW,
-                            principals=[
-                                iam.ServicePrincipal(service='lambda.amazonaws.com'),
-                            ],
-                            actions=['kms:GenerateDataKey*', 'kms:Decrypt'],
-                        ),
-                    ],
-                ),
             )
             cognito_sync_handler = _lambda.Function(
                 self,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
The KMS key for the Lambda environment variables in the Cognito IdP stack was defined inside an if-clause for internet facing frontend. Outside of that if, for vpc-facing architecture the kms key does not exist and the CICD pipeline fails. This PRs move the creation of the KMS key outside of the if.

### Relates

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
