### PR TITLE
Rename alias for env_vars kms key in cognito lambdas FE and BE

### DIFF
--- a/deploy/stacks/cloudfront.py
+++ b/deploy/stacks/cloudfront.py
@@ -500,9 +500,9 @@ class CloudfrontDistro(pyNestedClass):
     def cognito_urls_config(self, resource_prefix, envname, backend_region, custom_domain, execute_after):
         lambda_env_key = aws_kms.Key(
             self,
-            f'{resource_prefix}-cogn-lambda-env-var-key',
+            f'{resource_prefix}-{envname}-cogn-urls-lambda-env-var-key',
             removal_policy=RemovalPolicy.DESTROY,
-            alias=f'{resource_prefix}-cogn-lambda-env-var-key',
+            alias=f'{resource_prefix}-{envname}-cogn-urls-lambda-env-var-key',
             enable_key_rotation=True,
             policy=iam.PolicyDocument(
                 statements=[

--- a/deploy/stacks/cognito.py
+++ b/deploy/stacks/cognito.py
@@ -242,9 +242,9 @@ class IdpStack(pyNestedClass):
 
         lambda_env_key = kms.Key(
             self,
-            f'{resource_prefix}-cogn-lambda-env-var-key',
+            f'{resource_prefix}-{envname}-cogn-config-lambda-env-var-key',
             removal_policy=RemovalPolicy.DESTROY,
-            alias=f'{resource_prefix}-cogn-lambda-env-var-key',
+            alias=f'{resource_prefix}-{envname}-cogn-config-lambda-env-var-key',
             enable_key_rotation=True,
             policy=iam.PolicyDocument(
                 statements=[


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
For the case in which we deploy FE and BE in us-east-1 the new lambda env_key alias is the same one for TriggerFunctionCognitoUrlsConfig in FE and for TriggerFunctionCognitoConfig in BE, which results in a failure of the CICD in the FE stack because the alias already exists.

This PR changes the name of both aliases to avoid this conflict. It also adds envname to avoid issues with other deployment environments/tooling account in the future

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
