### PR TITLE
Add check in delete environment for create_failed stacks

### DIFF
--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -868,13 +868,19 @@ class EnvironmentService:
                     f'related objects before proceeding',
                 )
             else:
-                PolicyManager(
-                    role_name=environment.EnvironmentDefaultIAMRoleName,
-                    environmentUri=environment.environmentUri,
-                    account=environment.AwsAccountId,
-                    region=environment.region,
-                    resource_prefix=environment.resourcePrefix,
-                ).delete_all_policies()
+                if StackRepository.find_stack_by_target_uri(session, environment.environmentUri) not in [
+                    StackStatus.ROLLBACK_COMPLETE.value,
+                    StackStatus.ROLLBACK_IN_PROGRESS.value,
+                    StackStatus.CREATE_FAILED.value,
+                    StackStatus.DELETE_COMPLETE.value,
+                ]:
+                    PolicyManager(
+                        role_name=environment.EnvironmentDefaultIAMRoleName,
+                        environmentUri=environment.environmentUri,
+                        account=environment.AwsAccountId,
+                        region=environment.region,
+                        resource_prefix=environment.resourcePrefix,
+                    ).delete_all_policies()
 
                 KeyValueTagRepository.delete_key_value_tags(session, environment.environmentUri, 'environment')
                 EnvironmentResourceManager.delete_env(session, environment)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
When an environment stack fails in its creation (the CloudFormation stack is not deployed), the cdk-pivot role won't be created. Then, when a user tries to delete the environment they will get an error `Data.all Environment Pivot Role does not have permissions to to get the list of attached policies to the role dataall-testenva-jv54380n: An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::XXXXXXX:assumed-role/tool-tst-graphql-role/tool-tst-graphql is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::1111111111:role/dataallPivotRole-cdk',`

Those managed permissions do not even exist if the environment stack was never deployed successfully. This PR adds a check that verifies that the environment stack was deployed before removing env-managed policies.

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
