### PR TITLE
Add Worksheet integration tests - all except run sql query

### DIFF
--- a/backend/dataall/modules/worksheets/api/resolvers.py
+++ b/backend/dataall/modules/worksheets/api/resolvers.py
@@ -18,7 +18,6 @@ def create_worksheet(context: Context, source, input: dict = None):
         return WorksheetService.create_worksheet(
             session=session,
             username=context.username,
-            uri=None,
             data=input,
         )
 

--- a/backend/dataall/modules/worksheets/services/worksheet_service.py
+++ b/backend/dataall/modules/worksheets/services/worksheet_service.py
@@ -33,7 +33,7 @@ class WorksheetService:
 
     @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_WORKSHEETS)
-    def create_worksheet(session, username, uri, data=None) -> Worksheet:
+    def create_worksheet(session, username, data=None) -> Worksheet:
         worksheet = Worksheet(
             owner=username,
             label=data.get('label'),

--- a/tests_new/integration_tests/modules/worksheets/conftest.py
+++ b/tests_new/integration_tests/modules/worksheets/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+from integration_tests.modules.worksheets.queries import create_worksheet, delete_worksheet
+
+
+@pytest.fixture(scope='session')
+def worksheet1(client1, group1, session_id):
+    """
+    Session worksheet owned by group1
+    """
+    ws = None
+    try:
+        ws = create_worksheet(client1, 'worksheet1', group=group1, tags=[session_id])
+        yield ws
+    finally:
+        if ws:
+            delete_worksheet(client1, ws.worksheetUri)

--- a/tests_new/integration_tests/modules/worksheets/queries.py
+++ b/tests_new/integration_tests/modules/worksheets/queries.py
@@ -1,0 +1,184 @@
+# TODO: This file will be replaced by using the SDK directly
+
+
+def create_worksheet(client, name, group, tags=[]):
+    query = {
+        'operationName': 'CreateWorksheet',
+        'variables': {
+            'input': {
+                'label': name,
+                'SamlAdminGroupName': group,
+                'description': 'Created for integration testing',
+                'tags': tags,
+            }
+        },
+        'query': """
+            mutation CreateWorksheet($input: NewWorksheetInput) {
+              createWorksheet(input: $input) {
+                worksheetUri
+                label
+                created
+              }
+            }
+                """,
+    }
+    response = client.query(query=query)
+    return response.data.createWorksheet
+
+
+def delete_worksheet(client, worksheet_uri):
+    query = {
+        'operationName': 'deleteWorksheet',
+        'variables': {'worksheetUri': worksheet_uri},
+        'query': """
+            mutation deleteWorksheet($worksheetUri: String!) {
+              deleteWorksheet(worksheetUri: $worksheetUri)
+            }
+        """,
+    }
+    response = client.query(query=query)
+    return response.data.deleteWorksheet
+
+
+def get_worksheet(client, worksheet_uri):
+    query = {
+        'operationName': 'GetWorksheet',
+        'variables': {'worksheetUri': worksheet_uri},
+        'query': """
+            query GetWorksheet($worksheetUri: String!) {
+                  getWorksheet(worksheetUri: $worksheetUri) {
+                    worksheetUri
+                    label
+                    description
+                    SamlAdminGroupName
+                    tags
+                    sqlBody
+                    chartConfig {
+                      dimensions {
+                        columnName
+                      }
+                      measures {
+                        columnName
+                        aggregationName
+                      }
+                    }
+                    owner
+                    created
+                    updated
+                    userRoleForWorksheet
+                    lastSavedQueryResult {
+                      AthenaQueryId
+                      ElapsedTimeInMs
+                      Error
+                      DataScannedInBytes
+                      Status
+                      columns {
+                        columnName
+                        typeName
+                      }
+                      rows {
+                        cells {
+                          value
+                          columnName
+                        }
+                      }
+                    }
+                  }
+                }
+            """,
+    }
+    response = client.query(query=query)
+    return response.data.getWorksheet
+
+
+def list_worksheets(client, term=''):
+    query = {
+        'operationName': 'ListWorksheets',
+        'variables': {'filter': {'page': 1, 'pageSize': 10, 'term': term}},
+        'query': """
+            query ListWorksheets($filter: WorksheetFilter) {
+              listWorksheets(filter: $filter) {
+                count
+                page
+                pages
+                hasNext
+                hasPrevious
+                nodes {
+                  worksheetUri
+                  label
+                  description
+                  tags
+                  owner
+                  created
+                  userRoleForWorksheet
+                  SamlAdminGroupName
+                }
+              }
+            }
+        """,
+    }
+    response = client.query(query=query)
+    return response.data.listWorksheets
+
+
+def run_athena_sql_query(client, query, environment_uri, worksheet_uri):
+    query = {
+        'operationName': 'runAthenaSqlQuery',
+        'variables': {'sqlQuery': query, 'environmentUri': environment_uri, 'worksheetUri': worksheet_uri},
+        'query': """
+                query runAthenaSqlQuery(
+                      $environmentUri: String!
+                      $worksheetUri: String!
+                      $sqlQuery: String!
+                    ) {
+                      runAthenaSqlQuery(
+                        environmentUri: $environmentUri
+                        worksheetUri: $worksheetUri
+                        sqlQuery: $sqlQuery
+                      ) {
+                        rows {
+                          cells {
+                            columnName
+                            typeName
+                            value
+                          }
+                        }
+                        columns {
+                          columnName
+                          typeName
+                        }
+                      }
+                    }
+                """,
+    }
+    response = client.query(query=query)
+    return response.data.runAthenaSqlQuery
+
+
+def update_worksheet(client, worksheet_uri, name='', description='', tags=[]):
+    query = {
+        'operationName': 'UpdateWorksheet',
+        'variables': {
+            'worksheetUri': worksheet_uri,
+            'input': {
+                'label': name,
+                'description': description,
+                'tags': tags,
+            },
+        },
+        'query': """
+            mutation UpdateWorksheet(
+                  $worksheetUri: String!
+                  $input: UpdateWorksheetInput
+                ) {
+                  updateWorksheet(worksheetUri: $worksheetUri, input: $input) {
+                    worksheetUri
+                    label
+                    created
+                    description
+                  }
+                }
+            """,
+    }
+    response = client.query(query=query)
+    return response.data.updateWorksheet

--- a/tests_new/integration_tests/modules/worksheets/test_worksheet.py
+++ b/tests_new/integration_tests/modules/worksheets/test_worksheet.py
@@ -18,7 +18,7 @@ def test_create_worksheet(client1, worksheet1):
 
 def test_delete_worksheet(client1, group1, session_id):
     ws = create_worksheet(client1, 'worksheetdelete', group1, tags=[session_id])
-    assert assert_that(ws.label).is_equal_to('worksheetdelete')
+    assert_that(ws).contains_entry(label='worksheetdelete')
     response = delete_worksheet(client1, ws.worksheetUri)
     assert_that(response).is_equal_to(True)
 
@@ -31,8 +31,7 @@ def test_delete_worksheet_unauthorized(client2, worksheet1):
 
 def test_get_worksheet(client1, group1, worksheet1):
     ws = get_worksheet(client1, worksheet1.worksheetUri)
-    assert_that(ws.SamlAdminGroupName).is_equal_to(group1)
-    assert_that(ws.worksheetUri).is_equal_to(worksheet1.worksheetUri)
+    assert_that(ws).contains_entry(SamlAdminGroupName=group1, worksheetUri=worksheet1.worksheetUri)
 
 
 def test_get_worksheet_unauthorized(client2, worksheet1):
@@ -53,7 +52,7 @@ def test_list_worksheets_no_admin(client2, worksheet1, session_id):
 
 def test_update_worksheet(client1, worksheet1):
     ws = update_worksheet(client1, worksheet1.worksheetUri, worksheet1.label, 'updated desc', worksheet1.tags)
-    assert_that(ws.description).is_equal_to('updated desc')
+    assert_that(ws).contains_entry(description='updated desc')
 
 
 def test_update_worksheet_unauthorized(client2, worksheet1):

--- a/tests_new/integration_tests/modules/worksheets/test_worksheet.py
+++ b/tests_new/integration_tests/modules/worksheets/test_worksheet.py
@@ -1,0 +1,72 @@
+from assertpy import assert_that
+
+from integration_tests.modules.worksheets.queries import (
+    create_worksheet,
+    delete_worksheet,
+    get_worksheet,
+    list_worksheets,
+    run_athena_sql_query,
+    update_worksheet,
+)
+from integration_tests.errors import GqlError
+
+
+def test_create_worksheet(client1, worksheet1):
+    assert_that(worksheet1.worksheetUri).is_length(8)
+    assert_that(worksheet1.label).is_equal_to('worksheet1')
+
+
+def test_delete_worksheet(client1, group1, session_id):
+    ws = create_worksheet(client1, 'worksheetdelete', group1, tags=[session_id])
+    assert assert_that(ws.label).is_equal_to('worksheetdelete')
+    response = delete_worksheet(client1, ws.worksheetUri)
+    assert_that(response).is_equal_to(True)
+
+
+def test_delete_worksheet_unauthorized(client2, worksheet1):
+    assert_that(delete_worksheet).raises(GqlError).when_called_with(client2, worksheet1.worksheetUri).contains(
+        'UnauthorizedOperation', 'DELETE_WORKSHEET'
+    )
+
+
+def test_get_worksheet(client1, group1, worksheet1):
+    ws = get_worksheet(client1, worksheet1.worksheetUri)
+    assert_that(ws.SamlAdminGroupName).is_equal_to(group1)
+    assert_that(ws.worksheetUri).is_equal_to(worksheet1.worksheetUri)
+
+
+def test_get_worksheet_unauthorized(client2, worksheet1):
+    assert_that(get_worksheet).raises(GqlError).when_called_with(client2, worksheet1.worksheetUri).contains(
+        'UnauthorizedOperation', 'GET_WORKSHEET'
+    )
+
+
+def test_list_worksheets(client1, worksheet1, session_id):
+    response = list_worksheets(client1, term=session_id)
+    assert_that(response.count).is_equal_to(1)
+
+
+def test_list_worksheets_no_admin(client2, worksheet1, session_id):
+    response = list_worksheets(client2, term=session_id)
+    assert_that(response.count).is_equal_to(0)
+
+
+# def test_run_athena_sql_query(client1, session_env1, worksheet1):
+#     response = run_athena_sql_query(client1, environment_uri=session_env1.environmentUri, worksheet_uri=worksheet1.worksheetUri, query="select * from randomTable")
+#     assert response
+# def test_run_athena_sql_query_unauthorized(client2, session_env1, worksheet1):
+#     assert_that(update_worksheet).raises(GqlError).when_called_with(
+#         client2, session_env1.environmentUri, worksheet1.worksheetUri, "select * from random_table"
+#     ).contains('UnauthorizedOperation', 'RUN_ATHENA_QUERY')
+#
+
+
+def test_update_worksheet(client1, worksheet1):
+    ws = update_worksheet(client1, worksheet1.worksheetUri, worksheet1.label, 'updated desc', worksheet1.tags)
+    assert_that(ws.description).is_equal_to('updated desc')
+
+
+def test_update_worksheet_unauthorized(client2, worksheet1):
+    assert_that(update_worksheet).raises(GqlError).when_called_with(
+        client2, worksheet1.worksheetUri, worksheet1.label, 'updated desc', worksheet1.tags
+    ).contains('UnauthorizedOperation', 'UPDATE_WORKSHEET')

--- a/tests_new/integration_tests/modules/worksheets/test_worksheet.py
+++ b/tests_new/integration_tests/modules/worksheets/test_worksheet.py
@@ -51,16 +51,6 @@ def test_list_worksheets_no_admin(client2, worksheet1, session_id):
     assert_that(response.count).is_equal_to(0)
 
 
-# def test_run_athena_sql_query(client1, session_env1, worksheet1):
-#     response = run_athena_sql_query(client1, environment_uri=session_env1.environmentUri, worksheet_uri=worksheet1.worksheetUri, query="select * from randomTable")
-#     assert response
-# def test_run_athena_sql_query_unauthorized(client2, session_env1, worksheet1):
-#     assert_that(update_worksheet).raises(GqlError).when_called_with(
-#         client2, session_env1.environmentUri, worksheet1.worksheetUri, "select * from random_table"
-#     ).contains('UnauthorizedOperation', 'RUN_ATHENA_QUERY')
-#
-
-
 def test_update_worksheet(client1, worksheet1):
     ws = update_worksheet(client1, worksheet1.worksheetUri, worksheet1.label, 'updated desc', worksheet1.tags)
     assert_that(ws.description).is_equal_to('updated desc')


### PR DESCRIPTION
### Feature or Bugfix
- Feature - tests

### Detail
Integration tests for all API calls except for run athena sql - the draft is commented out in the second commit; but to unblock this PR I removed them

<img width="995" alt="image" src="https://github.com/data-dot-all/dataall/assets/71252798/943769b9-1e9f-4bce-80e3-ce0f7e7c9a94">


### Relates
https://github.com/data-dot-all/dataall/issues/1220

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
