### PR TITLE
Share UI fix: revoke items from share in revoked state

### DIFF
--- a/frontend/src/modules/Shared/Shares/ShareEditForm.js
+++ b/frontend/src/modules/Shared/Shares/ShareEditForm.js
@@ -42,7 +42,7 @@ const ItemRow = (props) => {
   } = props;
 
   const whatToDo = () => {
-    if (!item.status) return 'Request';
+    if (!item.status && shareStatus !== 'Revoked') return 'Request';
     if (
       item.status === 'Revoke_Succeeded' ||
       item.status === 'PendingApproval' ||
@@ -152,6 +152,7 @@ const ItemRow = (props) => {
       {(shareStatus === 'Draft' ||
         shareStatus === 'Processed' ||
         shareStatus === 'Rejected' ||
+        shareStatus === 'Revoked' ||
         shareStatus === 'Submitted') && (
         <TableCell>
           {possibleAction === 'Delete' && (


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- Due to confusion with statuses, "Revoke" item wasn't shown for items, when share was in Revoked state. So, it was possible to revoke only one Item every run of the aws-worker, which is annoying
- Now, we can revoke or delete eligible items, when share is in Revoked state

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
