### PR TITLE
Fix Env Group Option Forms for create Pipelines and Omic Runs

### DIFF
--- a/frontend/src/modules/Pipelines/views/PipelineCreateForm.js
+++ b/frontend/src/modules/Pipelines/views/PipelineCreateForm.js
@@ -96,7 +96,7 @@ const PipelineCreateForm = (props) => {
               label: values.label,
               environmentUri: values.environment.environmentUri,
               description: values.description,
-              SamlGroupName: values.SamlGroupName,
+              SamlGroupName: values.SamlAdminGroupName,
               tags: values.tags,
               devStrategy: values.devStrategy
             }
@@ -202,7 +202,7 @@ const PipelineCreateForm = (props) => {
               initialValues={{
                 label: '',
                 description: '',
-                SamlGroupName: '',
+                SamlAdminGroupName: '',
                 environment: '',
                 tags: [],
                 devStrategy: 'cdk-trunk'
@@ -212,7 +212,7 @@ const PipelineCreateForm = (props) => {
                   .max(255)
                   .required('*Pipeline name is required'),
                 description: Yup.string().max(5000),
-                SamlGroupName: Yup.string().max(255),
+                SamlAdminGroupName: Yup.string().max(255),
                 environment: Yup.object(),
                 devStrategy: Yup.string().required(
                   '*A CICD strategy is required'

--- a/frontend/src/modules/Shared/EnvironmentGroupSelect/EnvironmentTeamDatasetsDropdown.js
+++ b/frontend/src/modules/Shared/EnvironmentGroupSelect/EnvironmentTeamDatasetsDropdown.js
@@ -184,7 +184,7 @@ export const EnvironmentTeamDatasetsDropdown = (props) => {
               setFieldValue('dataset', '');
               if (value && value.value) {
                 setFieldValue('SamlAdminGroupName', value.value);
-                fetchDatasets(value).catch((e) =>
+                fetchDatasets(value.value).catch((e) =>
                   dispatch({ type: SET_ERROR, error: e.message })
                 );
               } else {


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- Fix `SamlAdminGroupName` for `createDataPipeline` form
- Fix `value.value` for `fetchDataset(datasetUri)` in `EnvironmentTeamDatasetsDropdown.js` (used by Omics)


### Relates
N/A

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
