### PR TITLE
Extend Sagemaker permissions and fix typo

### DIFF
--- a/backend/dataall/modules/mlstudio/cdk/env_role_mlstudio_policy.py
+++ b/backend/dataall/modules/mlstudio/cdk/env_role_mlstudio_policy.py
@@ -17,7 +17,6 @@ class SagemakerStudioPolicy(ServicePolicy):
             iam.PolicyStatement(
                 actions=[
                     'sagemaker:List*',
-                    'sagemaker:List*',
                     'sagemaker:Describe*',
                     'sagemaker:BatchGet*',
                     'sagemaker:BatchDescribe*',
@@ -99,6 +98,12 @@ class SagemakerStudioPolicy(ServicePolicy):
                     f'arn:aws:sagemaker:{self.region}:{self.account}:project/*',
                 ],
                 conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_value]}},
+            ),
+            iam.PolicyStatement(
+                actions=['sagemaker:*Space*'],
+                resources=[
+                    f'arn:aws:sagemaker:{self.region}:{self.account}:space/*',
+                ],
             ),
             iam.PolicyStatement(
                 actions=['sagemaker:InvokeEndpoint', 'sagemaker:InvokeEndpointAsync'],

--- a/backend/dataall/modules/notebooks/cdk/env_role_notebook_policy.py
+++ b/backend/dataall/modules/notebooks/cdk/env_role_notebook_policy.py
@@ -103,7 +103,7 @@ class SagemakernotebookPolicy(ServicePolicy):
                     f'arn:aws:sagemaker:{self.region}:{self.account}:domain/*',
                     f'arn:aws:sagemaker:{self.region}:{self.account}:user-profile/*/*',
                 ],
-                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_key]}},
+                conditions={'StringEquals': {f'aws:ResourceTag/{self.tag_key}': [self.tag_value]}},
             ),
             # For everything that is not domains and user-profiles we allow permissions if the resource is tagged
             # Deny on creation of domains and users, generic allow for prefixed and tagged resources


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- Add permissions for Sagemaker Spaces with no Tag Condition
  - There does not seem to be a way to create a space with tags in AWS SM Studio Console
- Fix typo in iam policy condition for tag value

### Relates


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
