### PR TITLE
Update profiler run status on Refresh

### DIFF
--- a/frontend/src/modules/Tables/components/TableMetrics.js
+++ b/frontend/src/modules/Tables/components/TableMetrics.js
@@ -163,16 +163,16 @@ export const TableMetrics = ({ table, isAdmin }) => {
       getDatasetTableProfilingRun(table.tableUri)
     );
     if (!response.errors) {
-      if (
-        response.data.getDatasetTableProfilingRun &&
-        response.data.getDatasetTableProfilingRun.results
-      ) {
-        const res = JSON.parse(
-          response.data.getDatasetTableProfilingRun.results
-        );
-        setMetrics(res);
-        setColumn(res?.columns[0]);
-        setActiveItem(res?.columns[0]?.Name);
+      if (response.data.getDatasetTableProfilingRun) {
+        setProfilingStatus(response.data.getDatasetTableProfilingRun.status);
+        if (response.data.getDatasetTableProfilingRun.results) {
+          const res = JSON.parse(
+            response.data.getDatasetTableProfilingRun.results
+          );
+          setMetrics(res);
+          setColumn(res?.columns[0]);
+          setActiveItem(res?.columns[0]?.Name);
+        }
       }
     } else {
       dispatch({ type: SET_ERROR, error: response.errors[0].message });


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- on Metrics page profiler status now is also updated on Refresh button

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
