### PR TITLE
Introduce check for actions in share_verify bucket and access points

### DIFF
--- a/backend/dataall/modules/s3_datasets_shares/services/s3_share_managed_policy_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/s3_share_managed_policy_service.py
@@ -1,4 +1,5 @@
 import json
+from typing import List
 from dataall.base.aws.iam import IAM
 from dataall.base.utils.naming_convention import NamingConventionService, NamingConventionPattern
 from dataall.core.environment.services.managed_iam_policies import ManagedPolicy
@@ -127,6 +128,19 @@ class S3SharePolicyService(ManagedPolicy):
             if target_resource not in existing_policy_statement['Resource']:
                 return False
         return True
+
+    @staticmethod
+    def check_correct_actions_in_policy_statement(existing_policy_statement: dict) -> List[str]:
+        """
+        Checks if there are incorrect actions in the existing policy
+        :param existing_policy_statement: dict
+        :return list of incorrect actions if any. None if everything is alright
+        """
+        return [
+            action
+            for action in existing_policy_statement['Action']
+            if action not in ['s3:List*', 's3:Describe*', 's3:GetObject']
+        ]
 
     @staticmethod
     def _get_statement_by_sid(policy, sid):

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
@@ -227,6 +227,24 @@ class S3AccessPointShareManager:
                 )
             )
 
+        elif len(
+            incorrect_actions := share_policy_service.check_correct_actions_in_policy_statement(
+                existing_policy_statement=policy_document['Statement'][s3_statement_index]
+            )
+        ):
+            logger.info(
+                f'IAM Policy Statement {IAM_S3_ACCESS_POINTS_STATEMENT_SID}S3 contains incorrect actions {incorrect_actions}'
+            )
+            self.folder_errors.append(
+                ShareErrorFormatter.missing_permission_error_msg(
+                    self.target_requester_IAMRoleName,
+                    'IAM Policy Actions',
+                    f'{IAM_S3_ACCESS_POINTS_STATEMENT_SID}S3',
+                    'S3 Bucket',
+                    f'{self.bucket_name}',
+                )
+            )
+
         if kms_key_id:
             kms_statement_index = S3SharePolicyService._get_statement_by_sid(
                 policy_document, f'{IAM_S3_ACCESS_POINTS_STATEMENT_SID}KMS'

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_bucket_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_bucket_share_manager.py
@@ -118,12 +118,29 @@ class S3BucketShareManager:
             existing_policy_statement=policy_document['Statement'][s3_statement_index],
         ):
             logger.info(
-                f'IAM Policy Statement {IAM_S3_BUCKETS_STATEMENT_SID}KMS does not contain resources {s3_target_resources}'
+                f'IAM Policy Statement {IAM_S3_BUCKETS_STATEMENT_SID}S3 does not contain resources {s3_target_resources}'
             )
             self.bucket_errors.append(
                 ShareErrorFormatter.missing_permission_error_msg(
                     self.target_requester_IAMRoleName,
                     'IAM Policy Resource',
+                    f'{IAM_S3_BUCKETS_STATEMENT_SID}S3',
+                    'S3 Bucket',
+                    f'{self.bucket_name}',
+                )
+            )
+        elif len(
+            incorrect_actions := share_policy_service.check_correct_actions_in_policy_statement(
+                existing_policy_statement=policy_document['Statement'][s3_statement_index]
+            )
+        ):
+            logger.info(
+                f'IAM Policy Statement {IAM_S3_BUCKETS_STATEMENT_SID}S3 contains incorrect actions {incorrect_actions}'
+            )
+            self.bucket_errors.append(
+                ShareErrorFormatter.missing_permission_error_msg(
+                    self.target_requester_IAMRoleName,
+                    'IAM Policy Actions',
                     f'{IAM_S3_BUCKETS_STATEMENT_SID}S3',
                     'S3 Bucket',
                     f'{self.bucket_name}',


### PR DESCRIPTION
### Feature or Bugfix
-Feature/ Bugfix

### Detail
When sharing access points or buckets, there is an IAM policy attached to the requester role that gets updated with every share request. This policy used to grant`s3:*` permissions, in https://github.com/data-dot-all/dataall/pull/1280/files we scoped down the S3 actions allowed in the IAM policy to `['s3:List*', 's3:Describe*', 's3:GetObject']`. 

The issue is that previous share requests will still contain the too permissive `s3:*`, which is incorrect. For this reason and for any additional action granted outside of data.all; in this PR we:
- add a verify step for s3 access points and buckets that checks the s3: actions granted
- if there are actions that do not belong to `['s3:List*', 's3:Describe*', 's3:GetObject']` the share verify tasks will report the error.

⚠️ TODO: fix and add tests

### Relates
- #1280
- #1374 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
