### PR TITLE
Fix/remove edit team modals

### DIFF
--- a/frontend/src/design/components/DeleteObjectWithFrictionModal.js
+++ b/frontend/src/design/components/DeleteObjectWithFrictionModal.js
@@ -95,6 +95,7 @@ export const DeleteObjectWithFrictionModal = (props) => {
               variant="contained"
               onClick={() => {
                 deleteFunction(deleteFromAWS);
+                setConfirmValue(null);
               }}
             >
               Delete

--- a/frontend/src/modules/Organizations/components/OrganizationTeams.js
+++ b/frontend/src/modules/Organizations/components/OrganizationTeams.js
@@ -45,29 +45,22 @@ import {
   OrganizationTeamInviteForm
 } from '../components';
 
-function TeamRow({ team, permissions, organization, fetchItems }) {
+function TeamRow({
+  team,
+  permissions,
+  organization,
+  fetchItems,
+  handleDeleteGroupModalOpen,
+  handleDeleteGroupModalClosed,
+  handlePermissionsModalOpen,
+  handlePermissionsModalClose,
+  isDeleteGroupModalOpenId,
+  isPermissionModalOpenId
+}) {
   const client = useClient();
   const dispatch = useDispatch();
   const theme = useTheme();
   const { enqueueSnackbar } = useSnackbar();
-  const [isPermissionModalOpen, setIsPermissionsModalOpen] = useState(false);
-  const [isDeleteGroupModalOpen, setIsDeleteGroupModalOpenId] = useState(false);
-
-  const handleDeleteGroupModalClosed = () => {
-    setIsDeleteGroupModalOpenId(false);
-  };
-
-  const handleDeleteGroupModalOpen = () => {
-    setIsDeleteGroupModalOpenId(true);
-  };
-
-  const handlePermissionsModalClose = () => {
-    setIsPermissionsModalOpen(false);
-  };
-
-  const handlePermissionsModalOpen = () => {
-    setIsPermissionsModalOpen(true);
-  };
   const removeGroup = async (groupUri) => {
     try {
       const response = await client.mutate(
@@ -84,6 +77,9 @@ function TeamRow({ team, permissions, organization, fetchItems }) {
           },
           variant: 'success'
         });
+        if (handleDeleteGroupModalClosed) {
+          handleDeleteGroupModalClosed();
+        }
         if (fetchItems) {
           fetchItems();
         }
@@ -105,7 +101,9 @@ function TeamRow({ team, permissions, organization, fetchItems }) {
       </TableCell>
       <TableCell>
         {team.groupUri !== organization.SamlGroupName ? (
-          <LoadingButton onClick={() => handlePermissionsModalOpen(team)}>
+          <LoadingButton
+            onClick={() => handlePermissionsModalOpen(team.groupUri)}
+          >
             <VscChecklist
               size={20}
               color={
@@ -124,22 +122,24 @@ function TeamRow({ team, permissions, organization, fetchItems }) {
             variant="outlined"
           />
         )}
-        {isPermissionModalOpen && (
+        {isPermissionModalOpenId === team.groupUri && (
           <OrganizationTeamInviteEditForm
             organization={organization}
             team={team}
             allPermissions={permissions}
-            open
+            open={isPermissionModalOpenId === team.groupUri}
             enqueueSnackbar={enqueueSnackbar}
             reloadTeams={fetchItems}
-            onClose={handlePermissionsModalClose}
+            onClose={() => handlePermissionsModalClose()}
           />
         )}
       </TableCell>
       <TableCell>
         <Box>
           {team.groupUri !== organization.SamlGroupName && (
-            <LoadingButton onClick={() => handleDeleteGroupModalOpen()}>
+            <LoadingButton
+              onClick={() => handleDeleteGroupModalOpen(team.groupUri)}
+            >
               <HiUserRemove
                 size={25}
                 color={
@@ -155,7 +155,7 @@ function TeamRow({ team, permissions, organization, fetchItems }) {
               objectName={team.groupUri}
               onApply={() => handleDeleteGroupModalClosed()}
               onClose={() => handleDeleteGroupModalClosed()}
-              open={isDeleteGroupModalOpen}
+              open={isDeleteGroupModalOpenId === team.groupUri}
               isAWSResource={false}
               deleteFunction={() => removeGroup(team.groupUri)}
             />
@@ -170,7 +170,13 @@ TeamRow.propTypes = {
   team: PropTypes.any,
   organization: PropTypes.any,
   permissions: PropTypes.any,
-  fetchItems: PropTypes.any
+  fetchItems: PropTypes.any,
+  handleDeleteGroupModalOpen: PropTypes.any,
+  handleDeleteGroupModalClosed: PropTypes.any,
+  handlePermissionsModalOpen: PropTypes.any,
+  handlePermissionsModalClose: PropTypes.any,
+  isDeleteGroupModalOpenId: PropTypes.string,
+  isPermissionModalOpenId: PropTypes.string
 };
 
 export const OrganizationTeams = ({ organization }) => {
@@ -182,6 +188,25 @@ export const OrganizationTeams = ({ organization }) => {
   const [permissions, setPermissions] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [isTeamInviteModalOpen, setIsTeamInviteModalOpen] = useState(false);
+  const [isPermissionModalOpenId, setIsPermissionsModalOpen] = useState('');
+  const [isDeleteGroupModalOpenId, setIsDeleteGroupModalOpenId] = useState('');
+
+  const handleDeleteGroupModalClosed = () => {
+    setIsDeleteGroupModalOpenId('');
+  };
+
+  const handleDeleteGroupModalOpen = (groupUri) => {
+    setIsDeleteGroupModalOpenId(groupUri);
+  };
+
+  const handlePermissionsModalClose = () => {
+    setIsPermissionsModalOpen('');
+  };
+
+  const handlePermissionsModalOpen = (groupUri) => {
+    setIsPermissionsModalOpen(groupUri);
+  };
+
   const handleTeamInviteModalOpen = () => {
     setIsTeamInviteModalOpen(true);
   };
@@ -356,6 +381,16 @@ export const OrganizationTeams = ({ organization }) => {
                         permissions={permissions}
                         organization={organization}
                         fetchItems={fetchItems}
+                        handleDeleteGroupModalOpen={handleDeleteGroupModalOpen}
+                        handleDeleteGroupModalClosed={
+                          handleDeleteGroupModalClosed
+                        }
+                        handlePermissionsModalOpen={handlePermissionsModalOpen}
+                        handlePermissionsModalClose={
+                          handlePermissionsModalClose
+                        }
+                        isDeleteGroupModalOpenId={isDeleteGroupModalOpenId}
+                        isPermissionModalOpenId={isPermissionModalOpenId}
                       />
                     ))
                   ) : (


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Originally - we were opening up a modal per TeamRow for EnvironmentTeam and OrganizationTeam Tables whenever we wanted to edit or remove a singular team
  - For delete team in specific there was a bug when 1 team was removed another modal remained asking to remove a separate team from the environment (not the one user clicked on)

- This PR ensures that the Edit Team Modal or Remove Team Modal only opens for the particular team clicked on and not for any other for both EnvTeams and OrgTeams (prevents the above from happening)
  - This design is in line with how modal showing is handled with consumption Roles for Envs as well

### Relates
N/A

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
