### PR TITLE
move backend approval_tests as the last step within the backend stage

### DIFF
--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -185,7 +185,7 @@ class PipelineStack(Stack):
                 )
 
             if target_env.get('with_approval_tests', False):
-                self.set_approval_tests_stage(target_env)
+                self.set_approval_tests_stage(backend_stage, target_env)
 
             if target_env.get('enable_update_dataall_stacks_in_cicd_pipeline', False):
                 self.set_stacks_updater_stage(target_env)
@@ -657,6 +657,7 @@ class PipelineStack(Stack):
 
     def set_approval_tests_stage(
         self,
+        backend_stage,
         target_env,
     ):
         if target_env.get('custom_auth', None) is None:
@@ -664,8 +665,7 @@ class PipelineStack(Stack):
         else:
             frontend_deployment_role_arn = f'arn:aws:iam::{target_env["account"]}:role/{self.resource_prefix}-{target_env["envname"]}-frontend-config-role'
 
-        wave = self.pipeline.add_wave(f"{self.resource_prefix}-{target_env['envname']}-approval-tests-stage")
-        wave.add_post(
+        backend_stage.add_post(
             pipelines.CodeBuildStep(
                 id='ApprovalTests',
                 build_environment=codebuild.BuildEnvironment(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Currently if approval tests are running and a new backend deployment happens (tests take a long time ~50 minutes so this scenario if very likely) then the tests will run against the new deployment.
With the propose change the tests are running as part of the backend deployment stage which is an atomic unit.

![image](https://github.com/user-attachments/assets/0068d1ac-7783-4a11-97fa-770eed21246f)


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
