### PR TITLE
Fix for getting correct gluedb name for central cataloged dataset

### DIFF
--- a/backend/dataall/modules/s3_datasets_shares/services/s3_share_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/s3_share_service.py
@@ -260,9 +260,13 @@ class S3ShareService:
         with get_context().db_engine.scoped_session() as session:
             share = ShareObjectRepository.get_share_by_uri(session, shareUri)
             dataset = DatasetBaseRepository.get_dataset_by_uri(session, share.datasetUri)
-            datasetGlueDatabase = GlueClient(
-                account_id=dataset.AwsAccountId, region=dataset.region, database=GlueDatabaseName
-            ).get_glue_database_from_catalog()
+            try:
+                datasetGlueDatabase = GlueClient(
+                    account_id=dataset.AwsAccountId, region=dataset.region, database=GlueDatabaseName
+                ).get_glue_database_from_catalog()
+            except Exception as e:
+                log.info(f'Error while calling the get_glue_database_from_catalog when resolving db name due to: {e}')
+                datasetGlueDatabase = GlueDatabaseName
             old_shared_db_name = (datasetGlueDatabase + '_shared_' + shareUri)[:254]
             database = GlueClient(
                 account_id=targetEnvAwsAccountId, database=old_shared_db_name, region=targetEnvRegion

--- a/backend/dataall/modules/s3_datasets_shares/services/s3_share_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/s3_share_service.py
@@ -9,6 +9,8 @@ from dataall.core.permissions.services.tenant_policy_service import TenantPolicy
 from dataall.core.environment.services.environment_service import EnvironmentService
 from dataall.core.tasks.db.task_models import Task
 from dataall.core.tasks.service_handlers import Worker
+from dataall.modules.datasets_base.db.dataset_models import DatasetBase
+from dataall.modules.datasets_base.db.dataset_repositories import DatasetBaseRepository
 from dataall.modules.shares_base.db.share_object_repositories import ShareObjectRepository
 from dataall.modules.shares_base.db.share_state_machines_repositories import ShareStatusRepository
 from dataall.modules.shares_base.services.share_item_service import ShareItemService
@@ -255,8 +257,14 @@ class S3ShareService:
 
     @staticmethod
     def resolve_shared_db_name(GlueDatabaseName: str, shareUri: str, targetEnvAwsAccountId: str, targetEnvRegion: str):
-        old_shared_db_name = (GlueDatabaseName + '_shared_' + shareUri)[:254]
-        database = GlueClient(
-            account_id=targetEnvAwsAccountId, database=old_shared_db_name, region=targetEnvRegion
-        ).get_glue_database()
-        return old_shared_db_name if database else GlueDatabaseName + '_shared'
+        with get_context().db_engine.scoped_session() as session:
+            share = ShareObjectRepository.get_share_by_uri(session, shareUri)
+            dataset = DatasetBaseRepository.get_dataset_by_uri(session, share.datasetUri)
+            datasetGlueDatabase = GlueClient(
+                account_id=dataset.AwsAccountId, region=dataset.region, database=GlueDatabaseName
+            ).get_glue_database_from_catalog()
+            old_shared_db_name = (datasetGlueDatabase + '_shared_' + shareUri)[:254]
+            database = GlueClient(
+                account_id=targetEnvAwsAccountId, database=old_shared_db_name, region=targetEnvRegion
+            ).get_glue_database()
+            return old_shared_db_name if database else datasetGlueDatabase + '_shared'


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail

- Resolved issue raised in - https://github.com/data-dot-all/dataall/issues/1432

### Relates
- https://github.com/data-dot-all/dataall/issues/1432

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization? N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users? N/A
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
