### PR TITLE
Fix: Typo, missing @staticmethod in ResourcePolicyRepository method

### DIFF
--- a/backend/dataall/core/permissions/db/resource_policy/resource_policy_repositories.py
+++ b/backend/dataall/core/permissions/db/resource_policy/resource_policy_repositories.py
@@ -70,6 +70,7 @@ class ResourcePolicyRepository:
         else:
             return policy
 
+    @staticmethod
     def query_all_resource_policies(
         session, group_uri: str, resource_uri: str, resource_type: str = None, permissions: List[str] = None
     ):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
`dataall.core.permissions.db.resource_policy.resource_policy_repositories.ResourcePolicyRepository.query_all_resource_policies` is missing @staticmethod and is taking session as self. 

I am not sure of the  implications. Because there are some arguments that can be None it was not failing, but it might not have deleted some permissions

### Relates

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
