### PR TITLE
Redshift dataset module testing: Re-added client factories, mocking clients

### DIFF
--- a/backend/dataall/modules/redshift_datasets/aws/redshift.py
+++ b/backend/dataall/modules/redshift_datasets/aws/redshift.py
@@ -19,3 +19,8 @@ class RedshiftClient:
         except ClientError as e:
             log.error(e)
             raise e
+
+
+def redshift_client(account_id: str, region: str) -> RedshiftClient:
+    "Factory of Client"
+    return RedshiftClient(account_id=account_id, region=region)

--- a/backend/dataall/modules/redshift_datasets/aws/redshift_data.py
+++ b/backend/dataall/modules/redshift_datasets/aws/redshift_data.py
@@ -143,3 +143,8 @@ class RedshiftDataClient:
         except ClientError as e:
             log.error(e)
             raise e
+
+
+def redshift_data_client(account_id: str, region: str, connection: RedshiftConnection) -> RedshiftDataClient:
+    "Factory of Client"
+    return RedshiftDataClient(account_id=account_id, region=region, connection=connection)

--- a/backend/dataall/modules/redshift_datasets/aws/redshift_serverless.py
+++ b/backend/dataall/modules/redshift_datasets/aws/redshift_serverless.py
@@ -32,3 +32,8 @@ class RedshiftServerlessClient:
         except ClientError as e:
             log.error(e)
             raise e
+
+
+def redshift_serverless_client(account_id: str, region: str, role: str = None) -> RedshiftServerlessClient:
+    "Factory of Client"
+    return RedshiftServerlessClient(account_id=account_id, region=region, role=role)

--- a/backend/dataall/modules/redshift_datasets/cdk/pivot_role_redshift_policy.py
+++ b/backend/dataall/modules/redshift_datasets/cdk/pivot_role_redshift_policy.py
@@ -6,7 +6,7 @@ from dataall.base.aws.sts import SessionHelper
 from dataall.base.utils.iam_policy_utils import split_policy_with_resources_in_statements
 from dataall.core.environment.cdk.pivot_role_stack import PivotRoleStatementSet
 from dataall.modules.redshift_datasets.db.redshift_connection_repositories import RedshiftConnectionRepository
-from dataall.modules.redshift_datasets.aws.redshift_serverless import RedshiftServerlessClient
+from dataall.modules.redshift_datasets.aws.redshift_serverless import redshift_serverless_client
 
 
 class RedshiftDatasetsPivotRole(PivotRoleStatementSet):
@@ -70,7 +70,7 @@ class RedshiftDatasetsPivotRole(PivotRoleStatementSet):
                 cdk_look_up_role_arn = SessionHelper.get_cdk_look_up_role_arn(
                     accountid=self.account, region=self.region
                 )
-                rs_client = RedshiftServerlessClient(
+                rs_client = redshift_serverless_client(
                     account_id=self.account, region=self.region, role=cdk_look_up_role_arn
                 )
                 cluster_arns = [

--- a/backend/dataall/modules/redshift_datasets/services/redshift_connection_service.py
+++ b/backend/dataall/modules/redshift_datasets/services/redshift_connection_service.py
@@ -17,9 +17,9 @@ from dataall.modules.redshift_datasets.services.redshift_connection_permissions 
     LIST_ENVIRONMENT_REDSHIFT_CONNECTIONS,
 )
 from dataall.modules.redshift_datasets.db.redshift_models import RedshiftConnection
-from dataall.modules.redshift_datasets.aws.redshift_data import RedshiftDataClient
-from dataall.modules.redshift_datasets.aws.redshift_serverless import RedshiftServerlessClient
-from dataall.modules.redshift_datasets.aws.redshift import RedshiftClient
+from dataall.modules.redshift_datasets.aws.redshift_data import redshift_data_client
+from dataall.modules.redshift_datasets.aws.redshift_serverless import redshift_serverless_client
+from dataall.modules.redshift_datasets.aws.redshift import redshift_client
 
 log = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ class RedshiftConnectionService:
         with context.db_engine.scoped_session() as session:
             connection = RedshiftConnectionService.get_redshift_connection_by_uri(uri=uri)
             environment = EnvironmentService.get_environment_by_uri(session, connection.environmentUri)
-            return RedshiftDataClient(
+            return redshift_data_client(
                 account_id=environment.AwsAccountId, region=environment.region, connection=connection
             ).list_redshift_schemas()
 
@@ -119,7 +119,7 @@ class RedshiftConnectionService:
         with context.db_engine.scoped_session() as session:
             connection = RedshiftConnectionService.get_redshift_connection_by_uri(uri=uri)
             environment = EnvironmentService.get_environment_by_uri(session, connection.environmentUri)
-            response = RedshiftDataClient(
+            response = redshift_data_client(
                 account_id=environment.AwsAccountId, region=environment.region, connection=connection
             ).list_redshift_tables(schema)
             return response
@@ -128,7 +128,7 @@ class RedshiftConnectionService:
     def _check_redshift_connection(account_id: str, region: str, connection: RedshiftConnection):
         if connection.nameSpaceId:
             if (
-                namespace := RedshiftServerlessClient(account_id=account_id, region=region).get_namespace_by_id(
+                namespace := redshift_serverless_client(account_id=account_id, region=region).get_namespace_by_id(
                     connection.nameSpaceId
                 )
             ) is None:
@@ -137,7 +137,7 @@ class RedshiftConnectionService:
                 )
             if connection.workgroup and connection.workgroup not in [
                 workgroup['workgroupName']
-                for workgroup in RedshiftServerlessClient(
+                for workgroup in redshift_serverless_client(
                     account_id=account_id, region=region
                 ).list_workgroups_in_namespace(namespace['namespaceName'])
             ]:
@@ -145,7 +145,7 @@ class RedshiftConnectionService:
                     f'Redshift workgroup {connection.workgroup} does not exist or is not associated to namespace {connection.nameSpaceId}'
                 )
 
-        if connection.clusterId and not RedshiftClient(account_id=account_id, region=region).describe_cluster(
+        if connection.clusterId and not redshift_client(account_id=account_id, region=region).describe_cluster(
             connection.clusterId
         ):
             raise Exception(
@@ -153,7 +153,7 @@ class RedshiftConnectionService:
             )
 
         try:
-            RedshiftDataClient(
+            redshift_data_client(
                 account_id=account_id, region=region, connection=connection
             ).get_redshift_connection_database()
         except Exception as e:

--- a/backend/dataall/modules/redshift_datasets/services/redshift_dataset_service.py
+++ b/backend/dataall/modules/redshift_datasets/services/redshift_dataset_service.py
@@ -31,7 +31,7 @@ from dataall.modules.redshift_datasets.services.redshift_dataset_permissions imp
 from dataall.modules.redshift_datasets.db.redshift_dataset_repositories import RedshiftDatasetRepository
 from dataall.modules.redshift_datasets.db.redshift_connection_repositories import RedshiftConnectionRepository
 from dataall.modules.redshift_datasets.db.redshift_models import RedshiftDataset, RedshiftTable
-from dataall.modules.redshift_datasets.aws.redshift_data import RedshiftDataClient
+from dataall.modules.redshift_datasets.aws.redshift_data import redshift_data_client
 from dataall.modules.redshift_datasets.indexers.dataset_indexer import DatasetIndexer
 from dataall.modules.redshift_datasets.indexers.table_indexer import DatasetTableIndexer
 from dataall.modules.redshift_datasets.services.redshift_constants import (
@@ -235,7 +235,7 @@ class RedshiftDatasetService:
             ]
             connection = RedshiftConnectionRepository.get_redshift_connection(session, dataset.connectionUri)
             environment = EnvironmentService.get_environment_by_uri(session, connection.environmentUri)
-            tables = RedshiftDataClient(
+            tables = redshift_data_client(
                 account_id=environment.AwsAccountId, region=environment.region, connection=connection
             ).list_redshift_tables(dataset.schema)
             for table in tables:
@@ -274,7 +274,7 @@ class RedshiftDatasetService:
             connection = RedshiftConnectionRepository.get_redshift_connection(
                 session=session, uri=dataset.connectionUri
             )
-            columns = RedshiftDataClient(
+            columns = redshift_data_client(
                 account_id=dataset.AwsAccountId, region=dataset.region, connection=connection
             ).list_redshift_table_columns(dataset.schema, table.name)
             return paginate_list(

--- a/tests/modules/redshift_datasets/conftest.py
+++ b/tests/modules/redshift_datasets/conftest.py
@@ -19,7 +19,7 @@ def patch_sts_remote_session(module_mocker):
 
 
 @pytest.fixture(scope='function')
-def patch_redshift(mocker):
+def mock_redshift(mocker):
     redshiftClient = mocker.patch('dataall.modules.redshift_datasets.aws.redshift.RedshiftClient', autospec=True)
     redshiftClient.return_value.describe_cluster.return_value = {
         'ClusterIdentifier': 'cluster_id_1',
@@ -29,7 +29,7 @@ def patch_redshift(mocker):
 
 
 @pytest.fixture(scope='function')
-def patch_redshift_data(mocker):
+def mock_redshift_data(mocker):
     redshiftDataClient = mocker.patch(
         'dataall.modules.redshift_datasets.aws.redshift_data.RedshiftDataClient', autospec=True
     )
@@ -51,7 +51,7 @@ def patch_redshift_data(mocker):
 
 
 @pytest.fixture(scope='function')
-def patch_redshift_serverless(mocker):
+def mock_redshift_serverless(mocker):
     redshiftServerlessClient = mocker.patch(
         'dataall.modules.redshift_datasets.aws.redshift_serverless.RedshiftServerlessClient', autospec=True
     )
@@ -86,7 +86,7 @@ def api_context_2(db, user2, group2):
 
 
 @pytest.fixture(scope='function')
-def connection1_serverless(db, user, group, env_fixture, patch_redshift_serverless, patch_redshift_data, api_context_1):
+def connection1_serverless(db, user, group, env_fixture, mock_redshift_serverless, mock_redshift_data, api_context_1):
     connection = RedshiftConnectionService.create_redshift_connection(
         uri=env_fixture.environmentUri,
         admin_group=group.name,
@@ -108,7 +108,7 @@ def connection1_serverless(db, user, group, env_fixture, patch_redshift_serverle
 
 
 @pytest.fixture(scope='function')
-def connection2_cluster(db, user, group, env_fixture, patch_redshift, patch_redshift_data, api_context_1):
+def connection2_cluster(db, user, group, env_fixture, mock_redshift, mock_redshift_data, api_context_1):
     connection = RedshiftConnectionService.create_redshift_connection(
         uri=env_fixture.environmentUri,
         admin_group=group.name,

--- a/tests/modules/redshift_datasets/conftest.py
+++ b/tests/modules/redshift_datasets/conftest.py
@@ -1,60 +1,13 @@
 import os
-import pytest
-import boto3
-from dataall.base.context import set_context, dispose_context, RequestContext
 
+import boto3
+import pytest
+
+from dataall.base.context import set_context, dispose_context, RequestContext
 from dataall.modules.redshift_datasets.services.redshift_connection_service import RedshiftConnectionService
 from dataall.modules.redshift_datasets.services.redshift_dataset_service import RedshiftDatasetService
-from dataall.modules.redshift_datasets.aws.redshift import RedshiftClient
-from dataall.modules.redshift_datasets.aws.redshift_serverless import RedshiftServerlessClient
-from dataall.modules.redshift_datasets.aws.redshift_data import RedshiftDataClient
 
 ENVNAME = os.environ.get('envname', 'pytest')
-
-
-class MockRedshiftDataClient:
-    def get_redshift_connection_database(self, *args, **kwargs):
-        return True
-
-    def list_redshift_schemas(self, *args, **kwargs):
-        return ['public', 'dev']
-
-    def list_redshift_tables(self, *args, **kwargs):
-        return [
-            {'name': 'table1', 'type': 'TABLE'},
-            {'name': 'table2', 'type': 'TABLE'},
-            {'name': 'table3', 'type': 'TABLE'},
-            {'name': 'table4', 'type': 'TABLE'},
-        ]
-
-    def list_redshift_table_columns(self, *args, **kwargs):
-        return [
-            {'name': 'column1', 'type': 'VARCHAR', 'nullable': True},
-            {'name': 'column2', 'type': 'INTEGER', 'nullable': False},
-            {'name': 'column3', 'type': 'DOUBLE', 'nullable': True},
-            {'name': 'column4', 'type': 'BOOLEAN', 'nullable': False},
-        ]
-
-
-class MockRedshiftClient:
-    def describe_cluster(self, *args, **kwargs):
-        return {'ClusterIdentifier': 'cluster_id_1', 'ClusterStatus': 'available'}
-
-
-class MockRedshiftServerlessClient:
-    def get_namespace_by_id(self, *args, **kwargs):
-        return {'namespaceId': 'XXXXXXXXXXXXXX', 'namespaceName': 'namespace_name_1'}
-
-    def list_workgroups_in_namespace(self, *args, **kwargs):
-        return [
-            {
-                'workgroupName': 'workgroup_name_1',
-                'workgroupArn': 'arn:aws:redshift-serverless:eu-west-1:XXXXXXXXXXXXXX:workgroup/workgroup_name_1',
-            }
-        ]
-
-    def get_workgroup_arn(self, *args, **kwargs):
-        return 'arn:aws:redshift-serverless:eu-west-1:XXXXXXXXXXXXXX:workgroup/workgroup_name_1'
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -67,25 +20,55 @@ def patch_sts_remote_session(module_mocker):
 
 @pytest.fixture(scope='function')
 def patch_redshift(mocker):
-    # autospec=True ensures methods called in the MockClient correspond to real client methods
-    mocker.patch.object(
-        RedshiftClient,
-        '__new__',
-        return_value=MockRedshiftClient(),
-        autospec=True,
+    redshiftClient = mocker.patch('dataall.modules.redshift_datasets.aws.redshift.RedshiftClient', autospec=True)
+    redshiftClient.return_value.describe_cluster.return_value = {
+        'ClusterIdentifier': 'cluster_id_1',
+        'ClusterStatus': 'available',
+    }
+    yield redshiftClient
+
+
+@pytest.fixture(scope='function')
+def patch_redshift_data(mocker):
+    redshiftDataClient = mocker.patch(
+        'dataall.modules.redshift_datasets.aws.redshift_data.RedshiftDataClient', autospec=True
     )
-    mocker.patch.object(
-        RedshiftDataClient,
-        '__new__',
-        return_value=MockRedshiftDataClient(),
-        autospec=True,
+    redshiftDataClient.return_value.get_redshift_connection_database.return_value = True
+    redshiftDataClient.return_value.list_redshift_schemas.return_value = ['public', 'dev']
+    redshiftDataClient.return_value.list_redshift_tables.return_value = [
+        {'name': 'table1', 'type': 'TABLE'},
+        {'name': 'table2', 'type': 'TABLE'},
+        {'name': 'table3', 'type': 'TABLE'},
+        {'name': 'table4', 'type': 'TABLE'},
+    ]
+    redshiftDataClient.return_value.list_redshift_table_columns.return_value = [
+        {'name': 'column1', 'type': 'VARCHAR', 'nullable': True},
+        {'name': 'column2', 'type': 'INTEGER', 'nullable': False},
+        {'name': 'column3', 'type': 'DOUBLE', 'nullable': True},
+        {'name': 'column4', 'type': 'BOOLEAN', 'nullable': False},
+    ]
+    yield redshiftDataClient
+
+
+@pytest.fixture(scope='function')
+def patch_redshift_serverless(mocker):
+    redshiftServerlessClient = mocker.patch(
+        'dataall.modules.redshift_datasets.aws.redshift_serverless.RedshiftServerlessClient', autospec=True
     )
-    mocker.patch.object(
-        RedshiftServerlessClient,
-        '__new__',
-        return_value=MockRedshiftServerlessClient(),
-        autospec=True,
+    redshiftServerlessClient.return_value.get_namespace_by_id.return_value = {
+        'namespaceId': 'XXXXXXXXXXXXXX',
+        'namespaceName': 'namespace_name_1',
+    }
+    redshiftServerlessClient.return_value.list_workgroups_in_namespace.return_value = [
+        {
+            'workgroupName': 'workgroup_name_1',
+            'workgroupArn': 'arn:aws:redshift-serverless:eu-west-1:XXXXXXXXXXXXXX:workgroup/workgroup_name_1',
+        }
+    ]
+    redshiftServerlessClient.return_value.get_workgroup_arn.return_value = (
+        'arn:aws:redshift-serverless:eu-west-1:XXXXXXXXXXXXXX:workgroup/workgroup_name_1'
     )
+    yield redshiftServerlessClient
 
 
 @pytest.fixture(scope='function')
@@ -103,27 +86,7 @@ def api_context_2(db, user2, group2):
 
 
 @pytest.fixture(scope='function')
-def connection1_serverless(db, user, group, env_fixture, mocker):
-    # autospec=True ensures methods called in the MockClient correspond to real client methods
-    mocker.patch.object(
-        RedshiftClient,
-        '__new__',
-        return_value=MockRedshiftClient(),
-        autospec=True,
-    )
-    mocker.patch.object(
-        RedshiftDataClient,
-        '__new__',
-        return_value=MockRedshiftDataClient(),
-        autospec=True,
-    )
-    mocker.patch.object(
-        RedshiftServerlessClient,
-        '__new__',
-        return_value=MockRedshiftServerlessClient(),
-        autospec=True,
-    )
-    set_context(RequestContext(db_engine=db, username=user.username, groups=[group.name], user_id=user.username))
+def connection1_serverless(db, user, group, env_fixture, patch_redshift_serverless, patch_redshift_data, api_context_1):
     connection = RedshiftConnectionService.create_redshift_connection(
         uri=env_fixture.environmentUri,
         admin_group=group.name,
@@ -138,7 +101,6 @@ def connection1_serverless(db, user, group, env_fixture, mocker):
             'secretArn': 'arn:aws:secretsmanager:*:111111111111:secret:secret-1',
         },
     )
-    dispose_context()
     yield connection
     set_context(RequestContext(db_engine=db, username=user.username, groups=[group.name], user_id=user.username))
     RedshiftConnectionService.delete_redshift_connection(uri=connection.connectionUri)
@@ -146,27 +108,7 @@ def connection1_serverless(db, user, group, env_fixture, mocker):
 
 
 @pytest.fixture(scope='function')
-def connection2_cluster(db, user, group, env_fixture, mocker):
-    # autospec=True ensures methods called in the MockClient correspond to real client methods
-    mocker.patch.object(
-        RedshiftClient,
-        '__new__',
-        return_value=MockRedshiftClient(),
-        autospec=True,
-    )
-    mocker.patch.object(
-        RedshiftDataClient,
-        '__new__',
-        return_value=MockRedshiftDataClient(),
-        autospec=True,
-    )
-    mocker.patch.object(
-        RedshiftServerlessClient,
-        '__new__',
-        return_value=MockRedshiftServerlessClient(),
-        autospec=True,
-    )
-    set_context(RequestContext(db_engine=db, username=user.username, groups=[group.name], user_id=user.username))
+def connection2_cluster(db, user, group, env_fixture, patch_redshift, patch_redshift_data, api_context_1):
     connection = RedshiftConnectionService.create_redshift_connection(
         uri=env_fixture.environmentUri,
         admin_group=group.name,
@@ -181,7 +123,6 @@ def connection2_cluster(db, user, group, env_fixture, mocker):
             'secretArn': 'arn:aws:secretsmanager:*:111111111111:secret:secret-2',
         },
     )
-    dispose_context()
     yield connection
     set_context(RequestContext(db_engine=db, username=user.username, groups=[group.name], user_id=user.username))
     RedshiftConnectionService.delete_redshift_connection(uri=connection.connectionUri)
@@ -189,8 +130,7 @@ def connection2_cluster(db, user, group, env_fixture, mocker):
 
 
 @pytest.fixture(scope='function')
-def imported_redshift_dataset_1_no_tables(db, user, group, env_fixture, connection1_serverless):
-    set_context(RequestContext(db_engine=db, username=user.username, groups=[group.name], user_id=user.username))
+def imported_redshift_dataset_1_no_tables(db, user, group, env_fixture, connection1_serverless, api_context_1):
     dataset = RedshiftDatasetService.import_redshift_dataset(
         uri=env_fixture.environmentUri,
         admin_group=group.name,
@@ -201,7 +141,6 @@ def imported_redshift_dataset_1_no_tables(db, user, group, env_fixture, connecti
             'schema': 'public',
         },
     )
-    dispose_context()
     yield dataset
     set_context(RequestContext(db_engine=db, username=user.username, groups=[group.name], user_id=user.username))
     RedshiftDatasetService.delete_redshift_dataset(uri=dataset.datasetUri)
@@ -209,8 +148,7 @@ def imported_redshift_dataset_1_no_tables(db, user, group, env_fixture, connecti
 
 
 @pytest.fixture(scope='function')
-def imported_redshift_dataset_2_with_tables(db, user, group, env_fixture, connection1_serverless):
-    set_context(RequestContext(db_engine=db, username=user.username, groups=[group.name], user_id=user.username))
+def imported_redshift_dataset_2_with_tables(db, user, group, env_fixture, connection1_serverless, api_context_1):
     dataset = RedshiftDatasetService.import_redshift_dataset(
         uri=env_fixture.environmentUri,
         admin_group=group.name,
@@ -222,7 +160,6 @@ def imported_redshift_dataset_2_with_tables(db, user, group, env_fixture, connec
             'tables': ['table1', 'table2'],
         },
     )
-    dispose_context()
     yield dataset
     set_context(RequestContext(db_engine=db, username=user.username, groups=[group.name], user_id=user.username))
     RedshiftDatasetService.delete_redshift_dataset(uri=dataset.datasetUri)
@@ -230,10 +167,8 @@ def imported_redshift_dataset_2_with_tables(db, user, group, env_fixture, connec
 
 
 @pytest.fixture(scope='function')
-def imported_dataset_2_table_1(db, user, group, env_fixture, imported_redshift_dataset_2_with_tables):
-    set_context(RequestContext(db_engine=db, username=user.username, groups=[group.name], user_id=user.username))
+def imported_dataset_2_table_1(db, user, group, env_fixture, imported_redshift_dataset_2_with_tables, api_context_1):
     tables = RedshiftDatasetService.list_redshift_dataset_tables(
         uri=imported_redshift_dataset_2_with_tables.datasetUri, filter={'term': 'table1'}
     )
-    dispose_context()
     yield tables['nodes'][0]

--- a/tests/modules/redshift_datasets/test_unit_redshift_connection_service.py
+++ b/tests/modules/redshift_datasets/test_unit_redshift_connection_service.py
@@ -5,9 +5,9 @@ from assertpy import assert_that
 from dataall.modules.redshift_datasets.services.redshift_connection_service import RedshiftConnectionService
 
 
-def test_create_redshift_connection_namespace_not_found(env_fixture, api_context_1, group, patch_redshift_serverless):
+def test_create_redshift_connection_namespace_not_found(env_fixture, api_context_1, group, mock_redshift_serverless):
     # Given a namespace that does not exist
-    patch_redshift_serverless.return_value.get_namespace_by_id.return_value = None
+    mock_redshift_serverless.return_value.get_namespace_by_id.return_value = None
 
     # Then
     assert_that(RedshiftConnectionService.create_redshift_connection).raises(Exception).when_called_with(
@@ -27,10 +27,10 @@ def test_create_redshift_connection_namespace_not_found(env_fixture, api_context
 
 
 def test_create_redshift_connection_workgroup_not_in_namespace(
-    env_fixture, api_context_1, group, patch_redshift_serverless
+    env_fixture, api_context_1, group, mock_redshift_serverless
 ):
     # Given a workgroup that is not in the namespace
-    patch_redshift_serverless.return_value.list_workgroups_in_namespace.return_value = []
+    mock_redshift_serverless.return_value.list_workgroups_in_namespace.return_value = []
 
     # Then
     assert_that(RedshiftConnectionService.create_redshift_connection).raises(Exception).when_called_with(
@@ -49,9 +49,9 @@ def test_create_redshift_connection_workgroup_not_in_namespace(
     ).contains('Redshift workgroup workgroup-id does not exist or is not associated to namespace not-existent-id')
 
 
-def test_create_redshift_connection_cluster_not_found(env_fixture, api_context_1, group, patch_redshift):
+def test_create_redshift_connection_cluster_not_found(env_fixture, api_context_1, group, mock_redshift):
     # Given a redshift cluster id that does not exist
-    patch_redshift.return_value.describe_cluster.return_value = False
+    mock_redshift.return_value.describe_cluster.return_value = False
 
     # Then
     assert_that(RedshiftConnectionService.create_redshift_connection).raises(Exception).when_called_with(
@@ -71,10 +71,10 @@ def test_create_redshift_connection_cluster_not_found(env_fixture, api_context_1
 
 
 def test_create_redshift_connection_database_not_found(
-    env_fixture, api_context_1, group, patch_redshift, patch_redshift_data
+    env_fixture, api_context_1, group, mock_redshift, mock_redshift_data
 ):
     # Given a redshift cluster id
-    patch_redshift_data.return_value.get_redshift_connection_database.side_effect = Exception
+    mock_redshift_data.return_value.get_redshift_connection_database.side_effect = Exception
 
     # Then
     assert_that(RedshiftConnectionService.create_redshift_connection).raises(Exception).when_called_with(
@@ -126,7 +126,7 @@ def test_get_redshift_connection_unauthorized(connection1_serverless, api_contex
     ).contains('UnauthorizedOperation', 'GET_REDSHIFT_CONNECTION', connection1_serverless.connectionUri)
 
 
-def test_delete_redshift_connection(api_context_1, env_fixture, group, patch_redshift_serverless, patch_redshift_data):
+def test_delete_redshift_connection(api_context_1, env_fixture, group, mock_redshift_serverless, mock_redshift_data):
     connection = RedshiftConnectionService.create_redshift_connection(
         uri=env_fixture.environmentUri,
         admin_group=group.name,
@@ -189,7 +189,7 @@ def test_list_environment_redshift_connections_unauthorized(
     ).contains('UnauthorizedOperation', 'LIST_ENVIRONMENT_REDSHIFT_CONNECTIONS', env_fixture.environmentUri)
 
 
-def test_list_connection_schemas(connection1_serverless, api_context_1, patch_redshift_data):
+def test_list_connection_schemas(connection1_serverless, api_context_1, mock_redshift_data):
     # When
     response = RedshiftConnectionService.list_connection_schemas(uri=connection1_serverless.connectionUri)
     assert_that(response).contains('public', 'dev')
@@ -202,7 +202,7 @@ def test_list_connection_schemas_unauthorized(connection1_serverless, api_contex
     ).contains('UnauthorizedOperation', 'GET_REDSHIFT_CONNECTION', connection1_serverless.connectionUri)
 
 
-def test_list_schema_tables(connection1_serverless, api_context_1, patch_redshift_data):
+def test_list_schema_tables(connection1_serverless, api_context_1, mock_redshift_data):
     # When
     response = RedshiftConnectionService.list_schema_tables(uri=connection1_serverless.connectionUri, schema='schema1')
     assert_that(response).is_length(4)

--- a/tests/modules/redshift_datasets/test_unit_redshift_connection_service.py
+++ b/tests/modules/redshift_datasets/test_unit_redshift_connection_service.py
@@ -1,15 +1,14 @@
+from unittest.mock import MagicMock
+
 from assertpy import assert_that
-from unittest.mock import MagicMock, patch
-from .conftest import MockRedshiftClient, MockRedshiftDataClient, MockRedshiftServerlessClient
+
 from dataall.modules.redshift_datasets.services.redshift_connection_service import RedshiftConnectionService
 
 
-def test_create_redshift_connection_namespace_not_found(env_fixture, api_context_1, group, mocker):
+def test_create_redshift_connection_namespace_not_found(env_fixture, api_context_1, group, patch_redshift_serverless):
     # Given a namespace that does not exist
-    mocker.patch(
-        'dataall.modules.redshift_datasets.aws.redshift_serverless.RedshiftServerlessClient.get_namespace_by_id',
-        return_value=None,
-    )
+    patch_redshift_serverless.return_value.get_namespace_by_id.return_value = None
+
     # Then
     assert_that(RedshiftConnectionService.create_redshift_connection).raises(Exception).when_called_with(
         uri=env_fixture.environmentUri,
@@ -27,15 +26,11 @@ def test_create_redshift_connection_namespace_not_found(env_fixture, api_context
     ).contains('Redshift namespaceId not-existent-id does not exist')
 
 
-def test_create_redshift_connection_workgroup_not_in_namespace(env_fixture, api_context_1, group, mocker):
-    mocker.patch(
-        'dataall.modules.redshift_datasets.aws.redshift_serverless.RedshiftServerlessClient.get_namespace_by_id',
-        return_value=MockRedshiftServerlessClient().get_namespace_by_id(),
-    )
-    mocker.patch(
-        'dataall.modules.redshift_datasets.aws.redshift_serverless.RedshiftServerlessClient.list_workgroups_in_namespace',
-        return_value=[],
-    )
+def test_create_redshift_connection_workgroup_not_in_namespace(
+    env_fixture, api_context_1, group, patch_redshift_serverless
+):
+    # Given a workgroup that is not in the namespace
+    patch_redshift_serverless.return_value.list_workgroups_in_namespace.return_value = []
 
     # Then
     assert_that(RedshiftConnectionService.create_redshift_connection).raises(Exception).when_called_with(
@@ -54,12 +49,9 @@ def test_create_redshift_connection_workgroup_not_in_namespace(env_fixture, api_
     ).contains('Redshift workgroup workgroup-id does not exist or is not associated to namespace not-existent-id')
 
 
-def test_create_redshift_connection_cluster_not_found(env_fixture, api_context_1, group, mocker):
+def test_create_redshift_connection_cluster_not_found(env_fixture, api_context_1, group, patch_redshift):
     # Given a redshift cluster id that does not exist
-    mocker.patch(
-        'dataall.modules.redshift_datasets.aws.redshift.RedshiftClient.describe_cluster',
-        return_value=False,
-    )
+    patch_redshift.return_value.describe_cluster.return_value = False
 
     # Then
     assert_that(RedshiftConnectionService.create_redshift_connection).raises(Exception).when_called_with(
@@ -78,21 +70,11 @@ def test_create_redshift_connection_cluster_not_found(env_fixture, api_context_1
     ).contains('Redshift cluster cluster-id does not exist or cannot be accessed with these parameters')
 
 
-def test_create_redshift_connection_database_not_found(env_fixture, api_context_1, group, mocker):
+def test_create_redshift_connection_database_not_found(
+    env_fixture, api_context_1, group, patch_redshift, patch_redshift_data
+):
     # Given a redshift cluster id
-    mock_redshift = MagicMock()
-    mocker.patch(
-        'dataall.modules.redshift_datasets.aws.redshift.RedshiftClient.describe_cluster',
-        return_value=mock_redshift,
-        autospec=True,
-    )
-    mock_redshift.describe_cluster.return_value = MockRedshiftClient().describe_cluster()
-    mock_redshift_data = MagicMock()
-    mocker.patch(
-        'dataall.modules.redshift_datasets.aws.redshift_data.RedshiftDataClient',
-        return_value=mock_redshift_data,
-    )
-    mock_redshift_data.get_redshift_connection_database.side_effect = Exception
+    patch_redshift_data.return_value.get_redshift_connection_database.side_effect = Exception
 
     # Then
     assert_that(RedshiftConnectionService.create_redshift_connection).raises(Exception).when_called_with(
@@ -127,7 +109,7 @@ def test_create_redshift_cluster_connection(connection2_cluster):
     assert_that(connection2_cluster.redshiftType).is_equal_to('cluster')
 
 
-def test_get_redshift_connection(connection1_serverless, api_context_1, patch_redshift):
+def test_get_redshift_connection(connection1_serverless, api_context_1):
     # When
     connection = RedshiftConnectionService.get_redshift_connection_by_uri(uri=connection1_serverless.connectionUri)
 
@@ -137,14 +119,14 @@ def test_get_redshift_connection(connection1_serverless, api_context_1, patch_re
     assert_that(connection.redshiftType).is_equal_to('serverless')
 
 
-def test_get_redshift_connection_unauthorized(connection1_serverless, api_context_2, patch_redshift):
+def test_get_redshift_connection_unauthorized(connection1_serverless, api_context_2):
     # When
     assert_that(RedshiftConnectionService.get_redshift_connection_by_uri).raises(Exception).when_called_with(
         uri=connection1_serverless.connectionUri
     ).contains('UnauthorizedOperation', 'GET_REDSHIFT_CONNECTION', connection1_serverless.connectionUri)
 
 
-def test_delete_redshift_connection(api_context_1, env_fixture, group, patch_redshift):
+def test_delete_redshift_connection(api_context_1, env_fixture, group, patch_redshift_serverless, patch_redshift_data):
     connection = RedshiftConnectionService.create_redshift_connection(
         uri=env_fixture.environmentUri,
         admin_group=group.name,
@@ -165,7 +147,7 @@ def test_delete_redshift_connection(api_context_1, env_fixture, group, patch_red
     assert_that(response).is_true()
 
 
-def test_delete_redshift_connection_unauthorized(connection1_serverless, api_context_2, patch_redshift):
+def test_delete_redshift_connection_unauthorized(connection1_serverless, api_context_2):
     # When
     assert_that(RedshiftConnectionService.delete_redshift_connection).raises(Exception).when_called_with(
         uri=connection1_serverless.connectionUri
@@ -207,10 +189,10 @@ def test_list_environment_redshift_connections_unauthorized(
     ).contains('UnauthorizedOperation', 'LIST_ENVIRONMENT_REDSHIFT_CONNECTIONS', env_fixture.environmentUri)
 
 
-def test_list_connection_schemas(connection1_serverless, api_context_1, patch_redshift):
+def test_list_connection_schemas(connection1_serverless, api_context_1, patch_redshift_data):
     # When
     response = RedshiftConnectionService.list_connection_schemas(uri=connection1_serverless.connectionUri)
-    assert_that(response).is_equal_to(MockRedshiftDataClient().list_redshift_schemas())
+    assert_that(response).contains('public', 'dev')
 
 
 def test_list_connection_schemas_unauthorized(connection1_serverless, api_context_2):
@@ -220,10 +202,10 @@ def test_list_connection_schemas_unauthorized(connection1_serverless, api_contex
     ).contains('UnauthorizedOperation', 'GET_REDSHIFT_CONNECTION', connection1_serverless.connectionUri)
 
 
-def test_list_schema_tables(connection1_serverless, api_context_1, patch_redshift):
+def test_list_schema_tables(connection1_serverless, api_context_1, patch_redshift_data):
     # When
     response = RedshiftConnectionService.list_schema_tables(uri=connection1_serverless.connectionUri, schema='schema1')
-    assert_that(response).is_equal_to(MockRedshiftDataClient().list_redshift_tables())
+    assert_that(response).is_length(4)
 
 
 def test_list_schema_tables_unauthorized(connection1_serverless, api_context_2):

--- a/tests/modules/redshift_datasets/test_unit_redshift_dataset_service.py
+++ b/tests/modules/redshift_datasets/test_unit_redshift_dataset_service.py
@@ -173,7 +173,7 @@ def test_list_redshift_schema_dataset_tables_unauthorized(imported_redshift_data
     ).contains('UnauthorizedOperation', 'GET_REDSHIFT_DATASET', imported_redshift_dataset_1_no_tables.datasetUri)
 
 
-def test_list_redshift_schema_dataset_tables(imported_redshift_dataset_1_no_tables, patch_redshift, api_context_1):
+def test_list_redshift_schema_dataset_tables(imported_redshift_dataset_1_no_tables, mock_redshift, api_context_1):
     # When
     tables = RedshiftDatasetService.list_redshift_schema_dataset_tables(
         uri=imported_redshift_dataset_1_no_tables.datasetUri

--- a/tests/modules/redshift_datasets/test_unit_redshift_dataset_service.py
+++ b/tests/modules/redshift_datasets/test_unit_redshift_dataset_service.py
@@ -1,6 +1,5 @@
 from assertpy import assert_that
 from dataall.modules.redshift_datasets.services.redshift_dataset_service import RedshiftDatasetService
-from .conftest import MockRedshiftDataClient
 
 
 def test_import_redshift_dataset_with_no_tables(imported_redshift_dataset_1_no_tables, api_context_1):
@@ -227,4 +226,4 @@ def test_list_redshift_dataset_table_columns(imported_dataset_2_table_1, api_con
     )
     # Then
     assert_that(response).contains_key('count', 'page', 'pages', 'nodes')
-    assert_that(response['nodes']).is_equal_to(MockRedshiftDataClient().list_redshift_table_columns())
+    assert_that(response['nodes']).is_length(4)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Use client factories in Redshift boto3 clients
- use single mock for the factory clients

### Relates
- #1424 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
