### PR TITLE
pass ShareableType instead of it's value and log exception details

### DIFF
--- a/backend/dataall/modules/shares_base/services/sharing_service.py
+++ b/backend/dataall/modules/shares_base/services/sharing_service.py
@@ -112,26 +112,26 @@ class SharingService:
                             if not success:
                                 share_successful = False
                         except Exception as e:
-                            log.error(f'Error occurred during sharing of {type.value}: {e}')
+                            log.exception(f'Error occurred during sharing of {type.value}')
                             ShareStatusRepository.update_share_item_status_batch(
                                 session,
                                 share_uri,
                                 old_status=ShareItemStatus.Share_Approved.value,
                                 new_status=ShareItemStatus.Share_Failed.value,
-                                share_item_type=processor.type.value,
+                                share_item_type=processor.type,
                             )
                             ShareStatusRepository.update_share_item_status_batch(
                                 session,
                                 share_uri,
                                 old_status=ShareItemStatus.Share_In_Progress.value,
                                 new_status=ShareItemStatus.Share_Failed.value,
-                                share_item_type=processor.type.value,
+                                share_item_type=processor.type,
                             )
                             share_successful = False
                 return share_successful
 
             except Exception as e:
-                log.error(f'Error occurred during share approval: {e}')
+                log.exception('Error occurred during share approval')
                 new_share_item_state = share_item_sm.run_transition(ShareItemActions.Failure.value)
                 share_item_sm.update_state(session, share_data.share.shareUri, new_share_item_state)
                 return False
@@ -373,7 +373,7 @@ class SharingService:
                 )
 
             except Exception as e:
-                log.error(f'Error occurred during share approval: {e}')
+                log.exception('Error occurred during share approval')
                 return False
 
     @staticmethod


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
in update_share_item_status_batch we pass `processor.type.value` but  `processor.type` is expected

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
