### PR TITLE
hide access point consumer details if access points feature is disabled

### DIFF
--- a/frontend/src/modules/Shares/components/S3ConsumptionData.js
+++ b/frontend/src/modules/Shares/components/S3ConsumptionData.js
@@ -17,6 +17,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard/lib/Component';
 import { CopyAllOutlined } from '@mui/icons-material';
 import { useTheme } from '@mui/styles';
 import { useSnackbar } from 'notistack';
+import { isFeatureEnabled } from 'utils';
 
 export const S3ConsumptionData = (props) => {
   const { share } = props;
@@ -104,40 +105,42 @@ export const S3ConsumptionData = (props) => {
                 {`aws s3 ls s3://${consumptionData.s3bucketName}`}
               </Typography>
             </Box>
-            <Box sx={{ mt: 3 }}>
-              <Typography
-                display="inline"
-                color="textSecondary"
-                variant="subtitle2"
-              >
-                S3 Access Point name (Folder sharing):
-              </Typography>
-              <Typography
-                display="inline"
-                color="textPrimary"
-                variant="subtitle2"
-              >
-                {` ${consumptionData.s3AccessPointName || '-'}`}
-              </Typography>
-              <Typography color="textPrimary" variant="subtitle2">
-                <CopyToClipboard
-                  onCopy={() => copyNotification()}
-                  text={`aws s3 ls arn:aws:s3:${share.dataset.region}:${share.dataset.AwsAccountId}:accesspoint/${consumptionData.s3AccessPointName}/SHARED_FOLDER/`}
+            {isFeatureEnabled('s3_datasets', 'file_actions') && (
+              <Box sx={{ mt: 3 }}>
+                <Typography
+                  display="inline"
+                  color="textSecondary"
+                  variant="subtitle2"
                 >
-                  <IconButton>
-                    <CopyAllOutlined
-                      sx={{
-                        color:
-                          theme.palette.mode === 'dark'
-                            ? theme.palette.primary.contrastText
-                            : theme.palette.primary.main
-                      }}
-                    />
-                  </IconButton>
-                </CopyToClipboard>
-                {`aws s3 ls arn:aws:s3:${share.dataset.region}:${share.dataset.AwsAccountId}:accesspoint/${consumptionData.s3AccessPointName}/SHARED_FOLDER/`}
-              </Typography>
-            </Box>
+                  S3 Access Point name (Folder sharing):
+                </Typography>
+                <Typography
+                  display="inline"
+                  color="textPrimary"
+                  variant="subtitle2"
+                >
+                  {` ${consumptionData.s3AccessPointName || '-'}`}
+                </Typography>
+                <Typography color="textPrimary" variant="subtitle2">
+                  <CopyToClipboard
+                    onCopy={() => copyNotification()}
+                    text={`aws s3 ls arn:aws:s3:${share.dataset.region}:${share.dataset.AwsAccountId}:accesspoint/${consumptionData.s3AccessPointName}/SHARED_FOLDER/`}
+                  >
+                    <IconButton>
+                      <CopyAllOutlined
+                        sx={{
+                          color:
+                            theme.palette.mode === 'dark'
+                              ? theme.palette.primary.contrastText
+                              : theme.palette.primary.main
+                        }}
+                      />
+                    </IconButton>
+                  </CopyToClipboard>
+                  {`aws s3 ls arn:aws:s3:${share.dataset.region}:${share.dataset.AwsAccountId}:accesspoint/${consumptionData.s3AccessPointName}/SHARED_FOLDER/`}
+                </Typography>
+              </Box>
+            )}
             <Box sx={{ mt: 3 }}>
               <Typography
                 display="inline"


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Hide access point consumer details if access points feature is disabled

### Relates
https://github.com/data-dot-all/dataall/issues/1464

### Security
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
