### PR TITLE
Issue1468: Submit request redirect

### DIFF
--- a/frontend/src/modules/Shared/Shares/ShareEditForm.js
+++ b/frontend/src/modules/Shared/Shares/ShareEditForm.js
@@ -278,9 +278,9 @@ export const ShareEditForm = (props) => {
       onApply();
     }
     const targetPath = `/console/shares/${share.shareUri}`;
-      if (location.pathname !== targetPath) {
-        navigate(targetPath);
-      }
+    if (location.pathname !== targetPath) {
+      navigate(targetPath);
+    }
   };
 
   const draftRequest = async () => {

--- a/frontend/src/modules/Shared/Shares/ShareEditForm.js
+++ b/frontend/src/modules/Shared/Shares/ShareEditForm.js
@@ -276,11 +276,11 @@ export const ShareEditForm = (props) => {
 
     if (onApply) {
       onApply();
-      const targetPath = `/console/shares/${share.shareUri}`;
+    }
+    const targetPath = `/console/shares/${share.shareUri}`;
       if (location.pathname !== targetPath) {
         navigate(targetPath);
       }
-    }
   };
 
   const draftRequest = async () => {

--- a/frontend/src/modules/Shared/Shares/ShareEditForm.js
+++ b/frontend/src/modules/Shared/Shares/ShareEditForm.js
@@ -26,7 +26,7 @@ import {
 import { SET_ERROR } from '../../../globalErrors';
 import { DeleteOutlined } from '@mui/icons-material';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 const ItemRow = (props) => {
   const {
@@ -214,6 +214,7 @@ export const ShareEditForm = (props) => {
     showViewShare
   } = props;
   const navigate = useNavigate();
+  const location = useLocation();
   const [sharedItems, setSharedItems] = useState(Defaults.pagedResponse);
   const [shareStatus, setShareStatus] = useState('');
   const [filter, setFilter] = useState(Defaults.filter);
@@ -275,6 +276,10 @@ export const ShareEditForm = (props) => {
 
     if (onApply) {
       onApply();
+      const targetPath = `/console/shares/${share.shareUri}`;
+      if (location.pathname !== targetPath) {
+        navigate(targetPath);
+      }
     }
   };
 


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Submit request redirects to share request page instead of catalog page

### Relates
- https://github.com/data-dot-all/dataall/issues/1468

### Testing
- Submit request button redirects to share page and not catalog anymore. 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
