### PR TITLE
S3Bucket WRITE/MODIFY permissions

### DIFF
--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -811,7 +811,7 @@ class EnvironmentService:
             return None
 
     @staticmethod
-    def get_environment_group(session, group_uri, environment_uri):
+    def get_environment_group(session, group_uri, environment_uri) -> EnvironmentGroup:
         env_group = EnvironmentRepository.get_environment_group(session, group_uri, environment_uri)
         if not env_group:
             raise exceptions.ObjectNotFound('EnvironmentGroup', f'({group_uri},{environment_uri})')

--- a/backend/dataall/modules/s3_datasets_shares/aws/kms_client.py
+++ b/backend/dataall/modules/s3_datasets_shares/aws/kms_client.py
@@ -4,17 +4,20 @@ from dataall.base.aws.sts import SessionHelper
 from botocore.exceptions import ClientError
 from dataall.modules.s3_datasets_shares.aws.share_policy_verifier import SharePolicyVerifier
 
-
 log = logging.getLogger(__name__)
 
 DATAALL_BUCKET_KMS_DECRYPT_SID = 'DataAll-Bucket-KMS-Decrypt'
+DATAALL_BUCKET_KMS_ENCRYPT_SID = 'DataAll-Bucket-KMS-Encrypt'
 DATAALL_KMS_PIVOT_ROLE_PERMISSIONS_SID = 'KMSPivotRolePermissions'
 DATAALL_ACCESS_POINT_KMS_DECRYPT_SID = 'DataAll-Access-Point-KMS-Decrypt'
+DATAALL_ACCESS_POINT_KMS_ENCRYPT_SID = 'DataAll-Access-Point-KMS-Encrypt'
 
 DATAALL_KMS_SIDS = [
     DATAALL_BUCKET_KMS_DECRYPT_SID,
+    DATAALL_BUCKET_KMS_ENCRYPT_SID,
     DATAALL_KMS_PIVOT_ROLE_PERMISSIONS_SID,
     DATAALL_ACCESS_POINT_KMS_DECRYPT_SID,
+    DATAALL_ACCESS_POINT_KMS_ENCRYPT_SID,
 ]
 
 

--- a/backend/dataall/modules/s3_datasets_shares/aws/s3_client.py
+++ b/backend/dataall/modules/s3_datasets_shares/aws/s3_client.py
@@ -9,10 +9,18 @@ from dataall.modules.s3_datasets_shares.aws.share_policy_verifier import SharePo
 log = logging.getLogger(__name__)
 
 DATAALL_READ_ONLY_SID = 'DataAll-Bucket-ReadOnly'
+DATAALL_WRITE_ONLY_SID = 'DataAll-Bucket-WriteOnly'
+DATAALL_MODIFY_ONLY_SID = 'DataAll-Bucket-ModifyOnly'
 DATAALL_ALLOW_OWNER_SID = 'AllowAllToAdmin'
 DATAALL_DELEGATE_TO_ACCESS_POINT = 'DelegateAccessToAccessPoint'
 
-DATAALL_BUCKET_SIDS = [DATAALL_READ_ONLY_SID, DATAALL_ALLOW_OWNER_SID, DATAALL_DELEGATE_TO_ACCESS_POINT]
+DATAALL_BUCKET_SIDS = [
+    DATAALL_READ_ONLY_SID,
+    DATAALL_WRITE_ONLY_SID,
+    DATAALL_MODIFY_ONLY_SID,
+    DATAALL_ALLOW_OWNER_SID,
+    DATAALL_DELEGATE_TO_ACCESS_POINT,
+]
 
 
 class S3ControlClient:

--- a/backend/dataall/modules/s3_datasets_shares/aws/s3_client.py
+++ b/backend/dataall/modules/s3_datasets_shares/aws/s3_client.py
@@ -1,8 +1,8 @@
 import logging
+from typing import List
 
 from dataall.base.aws.sts import SessionHelper
 from botocore.exceptions import ClientError
-
 
 from dataall.modules.s3_datasets_shares.aws.share_policy_verifier import SharePolicyVerifier
 
@@ -88,6 +88,7 @@ class S3ControlClient:
         principal_id: str,
         access_point_arn: str,
         s3_prefix: str,
+        actions: List[str],
     ):
         policy = {
             'Version': '2012-10-17',
@@ -96,7 +97,7 @@ class S3ControlClient:
                     'Sid': f'{principal_id}0',
                     'Effect': 'Allow',
                     'Principal': {'AWS': '*'},
-                    'Action': 's3:ListBucket',
+                    'Action': ['s3:ListBucket'],
                     'Resource': f'{access_point_arn}',
                     'Condition': {'StringLike': {'s3:prefix': [f'{s3_prefix}/*'], 'aws:userId': [f'{principal_id}:*']}},
                 },
@@ -104,7 +105,7 @@ class S3ControlClient:
                     'Sid': f'{principal_id}1',
                     'Effect': 'Allow',
                     'Principal': {'AWS': '*'},
-                    'Action': 's3:GetObject',
+                    'Action': actions,
                     'Resource': [f'{access_point_arn}/object/{s3_prefix}/*'],
                     'Condition': {'StringLike': {'aws:userId': [f'{principal_id}:*']}},
                 },

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/lf_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/lf_share_manager.py
@@ -1,29 +1,69 @@
 import logging
 import time
 from datetime import datetime
-from dataall.core.environment.services.environment_service import EnvironmentService
-from dataall.modules.s3_datasets_shares.aws.glue_client import GlueClient
-from dataall.modules.s3_datasets_shares.aws.lakeformation_client import LakeFormationClient
-from dataall.base.aws.quicksight import QuicksightClient
+from enum import Enum, auto
+from typing import List
+
 from dataall.base.aws.iam import IAM
+from dataall.base.aws.quicksight import QuicksightClient
 from dataall.base.aws.sts import SessionHelper
 from dataall.base.db import exceptions
+from dataall.core.environment.services.environment_service import EnvironmentService
+from dataall.modules.s3_datasets.db.dataset_models import DatasetTable
+from dataall.modules.s3_datasets_shares.aws.glue_client import GlueClient
+from dataall.modules.s3_datasets_shares.aws.lakeformation_client import LakeFormationClient
+from dataall.modules.s3_datasets_shares.services.s3_share_alarm_service import S3ShareAlarmService
+from dataall.modules.shares_base.db.share_object_models import ShareObjectItem, ShareObjectItemDataFilter
 from dataall.modules.shares_base.db.share_object_repositories import ShareObjectRepository
 from dataall.modules.shares_base.db.share_object_state_machines import ShareItemSM
 from dataall.modules.shares_base.db.share_state_machines_repositories import ShareStatusRepository
+from dataall.modules.shares_base.services.share_manager_utils import ShareErrorFormatter
 from dataall.modules.shares_base.services.shares_enums import (
     ShareItemStatus,
     ShareObjectActions,
     ShareItemActions,
     ShareItemHealthStatus,
+    ShareObjectDataPermission,
 )
-from dataall.modules.s3_datasets.db.dataset_models import DatasetTable
-from dataall.modules.s3_datasets_shares.services.s3_share_alarm_service import S3ShareAlarmService
-from dataall.modules.shares_base.db.share_object_models import ShareObjectItem, ShareObjectItemDataFilter
-from dataall.modules.shares_base.services.share_manager_utils import ShareErrorFormatter
 from dataall.modules.shares_base.services.sharing_service import ShareData
 
 logger = logging.getLogger(__name__)
+
+
+class LfPermType(Enum):
+    Table = auto()
+    Database = auto()
+    ResourceLink = auto()
+    Filters = auto()
+
+
+PERM_TO_LF_PERMS = {
+    ShareObjectDataPermission.Read.value: {
+        LfPermType.Table: ['DESCRIBE', 'SELECT'],
+        LfPermType.Database: ['DESCRIBE'],
+        LfPermType.ResourceLink: ['DESCRIBE'],
+        LfPermType.Filters: ['SELECT'],
+    },
+    ShareObjectDataPermission.Write.value: {
+        LfPermType.Table: ['INSERT'],
+        LfPermType.Database: ['CREATE_TABLE'],
+        LfPermType.ResourceLink: ['DESCRIBE'],
+        LfPermType.Filters: ['SELECT'],
+    },
+    ShareObjectDataPermission.Modify.value: {
+        LfPermType.Table: ['ALTER', 'DROP', 'DELETE'],
+        LfPermType.Database: ['ALTER', 'DROP'],
+        LfPermType.ResourceLink: ['DESCRIBE'],
+        LfPermType.Filters: ['SELECT'],
+    },
+}
+
+
+def perms_to_lfperms(permissions: List[str], lf_perm_type: LfPermType) -> List[str]:
+    lfperms = set()
+    for p in permissions:
+        lfperms.update(PERM_TO_LF_PERMS[p][lf_perm_type])
+    return list(lfperms)
 
 
 class LFShareManager:
@@ -257,18 +297,22 @@ class LFShareManager:
 
     def check_principals_permissions_to_shared_database(self) -> None:
         """
-        Checks 'DESCRIBE' Lake Formation permissions to data.all PivotRole to the shared database in target account
+        Checks Lake Formation permissions to data.all PivotRole to the shared database in target account
         and add to db level errors if check fails
         :return: None
         """
         if not self.lf_client_in_target.check_permissions_to_database(
             principals=self.principals,
             database_name=self.shared_db_name,
-            permissions=['DESCRIBE'],
+            permissions=perms_to_lfperms(self.share.permissions, LfPermType.Database),
         ):
             self.db_level_errors.append(
                 ShareErrorFormatter.missing_permission_error_msg(
-                    self.principals, 'LF', ['DESCRIBE'], 'Glue DB', self.shared_db_name
+                    self.principals,
+                    'LF',
+                    perms_to_lfperms(self.share.permissions, LfPermType.Database),
+                    'Glue DB',
+                    self.shared_db_name,
                 )
             )
 
@@ -276,7 +320,7 @@ class LFShareManager:
         self, table: DatasetTable, share_item: ShareObjectItem, share_item_filter: ShareObjectItemDataFilter = None
     ) -> None:
         """
-        Checks 'DESCRIBE' 'SELECT' Lake Formation permissions to target principals to the original table in source account
+        Checks Lake Formation permissions to target principals to the original table in source account
         and add to tbl level errors if check fails
         :param table: DatasetTable
         :return: None
@@ -287,14 +331,14 @@ class LFShareManager:
                 database_name=self.source_database_name,
                 table_name=table.GlueTableName,
                 catalog_id=self.source_account_id,
-                permissions=['SELECT'],
+                permissions=perms_to_lfperms(self.share.permissions, LfPermType.Filters),
                 data_filters=share_item_filter.dataFilterNames,
             ):
                 self.tbl_level_errors.append(
                     ShareErrorFormatter.missing_permission_error_msg(
                         self.principals,
                         'LF',
-                        ['SELECT'],
+                        perms_to_lfperms(self.share.permissions, LfPermType.Filters),
                         'Glue Table with Filters',
                         f'{table.GlueDatabaseName}.{table.GlueTableName}, Filters:{share_item_filter.dataFilterNames}',
                     )
@@ -305,13 +349,13 @@ class LFShareManager:
                 database_name=self.source_database_name,
                 table_name=table.GlueTableName,
                 catalog_id=self.source_account_id,
-                permissions=['DESCRIBE', 'SELECT'],
+                permissions=perms_to_lfperms(self.share.permissions, LfPermType.Table),
             ):
                 self.tbl_level_errors.append(
                     ShareErrorFormatter.missing_permission_error_msg(
                         self.principals,
                         'LF',
-                        ['DESCRIBE', 'SELECT'],
+                        perms_to_lfperms(self.share.permissions, LfPermType.Table),
                         'Glue Table',
                         f'{table.GlueDatabaseName}.{table.GlueTableName}',
                     )
@@ -339,13 +383,13 @@ class LFShareManager:
 
     def grant_principals_database_permissions_to_shared_database(self) -> True:
         """
-        Grants 'DESCRIBE' Lake Formation permissions to share principals to the shared database in target account
+        Grants Lake Formation permissions to share principals to the shared database in target account
         :return: True if it is successful
         """
         self.lf_client_in_target.grant_permissions_to_database(
             principals=self.principals,
             database_name=self.shared_db_name,
-            permissions=['DESCRIBE'],
+            permissions=perms_to_lfperms(self.share.permissions, LfPermType.Database),
         )
         return True
 
@@ -353,7 +397,7 @@ class LFShareManager:
         self, table: DatasetTable, share_item: ShareObjectItem, share_item_filter: ShareObjectItemDataFilter = None
     ) -> True:
         """
-        Grants 'DESCRIBE' 'SELECT' Lake Formation permissions to target principals to the original table in source account
+        Grants Lake Formation permissions to target principals to the original table in source account
         :param table: DatasetTable
         :return: True if it is successful
         """
@@ -363,7 +407,7 @@ class LFShareManager:
                 database_name=self.source_database_name,
                 table_name=table.GlueTableName,
                 catalog_id=self.source_account_id,
-                permissions=['SELECT'],
+                permissions=perms_to_lfperms(self.share.permissions, LfPermType.Filters),
                 data_filters=share_item_filter.dataFilterNames,
             )
         else:
@@ -372,9 +416,9 @@ class LFShareManager:
                 database_name=self.source_database_name,
                 table_name=table.GlueTableName,
                 catalog_id=self.source_account_id,
-                permissions=['DESCRIBE', 'SELECT'],
+                permissions=perms_to_lfperms(self.share.permissions, LfPermType.Table),
             )
-        time.sleep(2)
+            time.sleep(2)
         return True
 
     def check_if_exists_and_create_resource_link_table_in_shared_database(
@@ -397,7 +441,7 @@ class LFShareManager:
 
     def grant_principals_permissions_to_resource_link_table(self, resource_link_name: str) -> True:
         """
-        Grants 'DESCRIBE' Lake Formation permissions to share principals to the resource link table in target account
+        Grants Lake Formation permissions to share principals to the resource link table in target account
         :param table: DatasetTable
         :return: True if it is successful
         """
@@ -406,13 +450,13 @@ class LFShareManager:
             database_name=self.shared_db_name,
             table_name=resource_link_name,
             catalog_id=self.target_environment.AwsAccountId,
-            permissions=['DESCRIBE'],
+            permissions=perms_to_lfperms(self.share.permissions, LfPermType.ResourceLink),
         )
         return True
 
     def check_principals_permissions_to_resource_link_table(self, resource_link_name: str) -> None:
         """
-        Checks 'DESCRIBE' Lake Formation permissions to share principals to the resource link table in target account
+        Checks Lake Formation permissions to share principals to the resource link table in target account
         and add to tbl level errors if check fails
         :param table: DatasetTable
         :return: None
@@ -423,17 +467,21 @@ class LFShareManager:
             database_name=self.shared_db_name,
             table_name=resource_link_name,
             catalog_id=self.target_environment.AwsAccountId,
-            permissions=['DESCRIBE'],
+            permissions=perms_to_lfperms(self.share.permissions, LfPermType.Database),
         ):
             self.tbl_level_errors.append(
                 ShareErrorFormatter.missing_permission_error_msg(
-                    self.principals, 'LF', ['DESCRIBE'], 'Glue Table', f'{self.shared_db_name}.{resource_link_name}'
+                    self.principals,
+                    'LF',
+                    perms_to_lfperms(self.share.permissions, LfPermType.Database),
+                    'Glue Table',
+                    f'{self.shared_db_name}.{resource_link_name}',
                 )
             )
 
     def revoke_principals_permissions_to_resource_link_table(self, resource_link_name) -> True:
         """
-        Revokes 'DESCRIBE' Lake Formation permissions to share principals to the resource link table in target account
+        Revokes Lake Formation permissions to share principals to the resource link table in target account
         :param table: DatasetTable
         :return: True if it is successful
         """
@@ -443,7 +491,7 @@ class LFShareManager:
             database_name=self.shared_db_name,
             table_name=resource_link_name,
             catalog_id=self.target_environment.AwsAccountId,
-            permissions=['DESCRIBE'],
+            permissions=perms_to_lfperms(self.share.permissions, LfPermType.Database),
         )
         return True
 
@@ -503,13 +551,13 @@ class LFShareManager:
 
     def revoke_principals_database_permissions_to_shared_database(self) -> True:
         """
-        Revokes 'DESCRIBE' Lake Formation permissions to share principals to the shared database in target account
+        Revokes Lake Formation permissions to share principals to the shared database in target account
         :return: True if it is successful
         """
         self.lf_client_in_target.revoke_permissions_to_database(
             principals=self.principals,
             database_name=self.shared_db_name,
-            permissions=['DESCRIBE'],
+            permissions=perms_to_lfperms(self.share.permissions, LfPermType.Database),
         )
         return True
 
@@ -541,7 +589,7 @@ class LFShareManager:
         self, table: DatasetTable, share_item: ShareObjectItem, share_item_filter: ShareObjectItemDataFilter = None
     ) -> True:
         """
-        Revokes 'SELECT' Lake Formation permissions to target principals to the original table in source account
+        Revokes Lake Formation permissions to target principals to the original table in source account
         If the table is not shared with any other team in the environment,
         it deletes resource_shares on RAM associated to revoked table
         :param table: DatasetTable
@@ -554,7 +602,7 @@ class LFShareManager:
                 database_name=self.source_database_name,
                 table_name=table.GlueTableName,
                 catalog_id=self.source_account_id,
-                permissions=['SELECT'],
+                permissions=perms_to_lfperms(self.share.permissions, LfPermType.Filters),
                 data_filters=share_item_filter.dataFilterNames,
             )
         else:
@@ -563,7 +611,7 @@ class LFShareManager:
                 database_name=self.source_database_name,
                 table_name=table.GlueTableName,
                 catalog_id=self.source_account_id,
-                permissions=['DESCRIBE', 'SELECT'],
+                permissions=perms_to_lfperms(self.share.permissions, LfPermType.Table),
             )
         return True
 

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/lf_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/lf_share_manager.py
@@ -467,13 +467,13 @@ class LFShareManager:
             database_name=self.shared_db_name,
             table_name=resource_link_name,
             catalog_id=self.target_environment.AwsAccountId,
-            permissions=perms_to_lfperms(self.share.permissions, LfPermType.Database),
+            permissions=perms_to_lfperms(self.share.permissions, LfPermType.ResourceLink),
         ):
             self.tbl_level_errors.append(
                 ShareErrorFormatter.missing_permission_error_msg(
                     self.principals,
                     'LF',
-                    perms_to_lfperms(self.share.permissions, LfPermType.Database),
+                    perms_to_lfperms(self.share.permissions, LfPermType.ResourceLink),
                     'Glue Table',
                     f'{self.shared_db_name}.{resource_link_name}',
                 )
@@ -491,7 +491,7 @@ class LFShareManager:
             database_name=self.shared_db_name,
             table_name=resource_link_name,
             catalog_id=self.target_environment.AwsAccountId,
-            permissions=perms_to_lfperms(self.share.permissions, LfPermType.Database),
+            permissions=perms_to_lfperms(self.share.permissions, LfPermType.ResourceLink),
         )
         return True
 

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/lf_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/lf_share_manager.py
@@ -60,10 +60,10 @@ PERM_TO_LF_PERMS = {
 
 
 def perms_to_lfperms(permissions: List[str], lf_perm_type: LfPermType) -> List[str]:
-    lfperms = set()
+    lfperms = list()
     for p in permissions:
-        lfperms.update(PERM_TO_LF_PERMS[p][lf_perm_type])
-    return list(lfperms)
+        lfperms.extend(PERM_TO_LF_PERMS[p][lf_perm_type])
+    return list(dict.fromkeys(lfperms))
 
 
 class LFShareManager:

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
@@ -525,7 +525,9 @@ class S3AccessPointShareManager:
         statements = {item.get('Sid', next(counter)): item for item in existing_policy.get('Statement', {})}
 
         for target_sid in perms_to_sids(self.share.permissions, SidType.KmsAccessPointPolicy):
-            if target_sid not in statements.keys() or target_requester_arn not in get_principal_list(statements):
+            if target_sid not in statements.keys() or target_requester_arn not in get_principal_list(
+                statements[target_sid]
+            ):
                 self.folder_errors.append(
                     ShareErrorFormatter.missing_permission_error_msg(
                         self.target_requester_IAMRoleName,

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_utils.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_utils.py
@@ -92,11 +92,11 @@ def perms_to_sids(permissions: List[str], sid_type: SidType) -> List[str]:
     """
     :return: unique SIDs
     """
-    return list(set([PERM_TO_SID[perm][sid_type] for perm in permissions]))
+    return list(dict.fromkeys([PERM_TO_SID[perm][sid_type] for perm in permissions]))
 
 
 def perms_to_actions(permissions: List[str], sid_type: SidType) -> List[str]:
-    actions = set()
+    actions = list()
     for sid in perms_to_sids(permissions, sid_type):
-        actions.update(SID_TO_ACTIONS[sid])
-    return list(actions)
+        actions.extend(SID_TO_ACTIONS[sid])
+    return list(dict.fromkeys(actions))

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_utils.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_utils.py
@@ -1,0 +1,95 @@
+from enum import Enum, auto
+from typing import List
+
+from dataall.modules.s3_datasets_shares.aws.kms_client import (
+    DATAALL_BUCKET_KMS_DECRYPT_SID,
+    DATAALL_BUCKET_KMS_ENCRYPT_SID,
+    DATAALL_KMS_PIVOT_ROLE_PERMISSIONS_SID,
+    DATAALL_ACCESS_POINT_KMS_DECRYPT_SID,
+    DATAALL_ACCESS_POINT_KMS_ENCRYPT_SID,
+)
+from dataall.modules.s3_datasets_shares.aws.s3_client import (
+    DATAALL_READ_ONLY_SID,
+    DATAALL_WRITE_ONLY_SID,
+    DATAALL_MODIFY_ONLY_SID,
+)
+from dataall.modules.shares_base.services.shares_enums import ShareObjectDataPermission
+
+SID_TO_ACTIONS = {
+    DATAALL_READ_ONLY_SID: ['s3:List*', 's3:GetObject'],
+    DATAALL_WRITE_ONLY_SID: ['s3:PutObject'],
+    DATAALL_MODIFY_ONLY_SID: ['s3:DeleteObject', 's3:DeleteObjects'],
+    DATAALL_BUCKET_KMS_DECRYPT_SID: ['kms:Decrypt'],
+    DATAALL_BUCKET_KMS_ENCRYPT_SID: ['kms:Encrypt', 'kms:ReEncrypt*', 'kms:GenerateDataKey*'],
+    DATAALL_ACCESS_POINT_KMS_DECRYPT_SID: ['kms:Decrypt'],
+    DATAALL_ACCESS_POINT_KMS_ENCRYPT_SID: ['kms:Encrypt', 'kms:ReEncrypt*', 'kms:GenerateDataKey*'],
+    DATAALL_KMS_PIVOT_ROLE_PERMISSIONS_SID: [
+        'kms:Decrypt',
+        'kms:Encrypt',
+        'kms:GenerateDataKey*',
+        'kms:PutKeyPolicy',
+        'kms:GetKeyPolicy',
+        'kms:ReEncrypt*',
+        'kms:TagResource',
+        'kms:UntagResource',
+        'kms:DescribeKey',
+        'kms:List*',
+    ],
+}
+
+
+class SidType(Enum):
+    BucketPolicy = auto()
+    KmsBucketPolicy = auto()
+    KmsAccessPointPolicy = auto()
+
+
+PERM_TO_SID = {
+    ShareObjectDataPermission.Read.value: {
+        SidType.BucketPolicy: DATAALL_READ_ONLY_SID,
+        SidType.KmsBucketPolicy: DATAALL_BUCKET_KMS_DECRYPT_SID,
+        SidType.KmsAccessPointPolicy: DATAALL_ACCESS_POINT_KMS_DECRYPT_SID,
+    },
+    ShareObjectDataPermission.Write.value: {
+        SidType.BucketPolicy: DATAALL_WRITE_ONLY_SID,
+        SidType.KmsBucketPolicy: DATAALL_BUCKET_KMS_ENCRYPT_SID,
+        SidType.KmsAccessPointPolicy: DATAALL_ACCESS_POINT_KMS_ENCRYPT_SID,
+    },
+    ShareObjectDataPermission.Modify.value: {
+        SidType.BucketPolicy: DATAALL_MODIFY_ONLY_SID,
+        SidType.KmsBucketPolicy: DATAALL_BUCKET_KMS_ENCRYPT_SID,
+        SidType.KmsAccessPointPolicy: DATAALL_ACCESS_POINT_KMS_ENCRYPT_SID,
+    },
+}
+
+
+def get_principal_list(statement):
+    principal_list = statement['Principal']['AWS']
+    if isinstance(principal_list, str):
+        principal_list = [principal_list]
+    return principal_list
+
+
+def add_target_arn_to_statement_principal(statement, target_requester_arn):
+    principal_list = get_principal_list(statement)
+    if f'{target_requester_arn}' not in principal_list:
+        principal_list.append(f'{target_requester_arn}')
+    statement['Principal']['AWS'] = principal_list
+    return statement
+
+
+def generate_policy_statement(target_sid, target_requester_arns, target_resources):
+    return {
+        'Sid': target_sid,
+        'Effect': 'Allow',
+        'Principal': {'AWS': target_requester_arns},
+        'Action': SID_TO_ACTIONS[target_sid],
+        'Resource': target_resources,
+    }
+
+
+def perms_to_sids(permissions: List[str], sid_type: SidType) -> List[str]:
+    """
+    :return: unique SIDs
+    """
+    return list(set([PERM_TO_SID[perm][sid_type] for perm in permissions]))

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_utils.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_utils.py
@@ -93,3 +93,10 @@ def perms_to_sids(permissions: List[str], sid_type: SidType) -> List[str]:
     :return: unique SIDs
     """
     return list(set([PERM_TO_SID[perm][sid_type] for perm in permissions]))
+
+
+def perms_to_actions(permissions: List[str], sid_type: SidType) -> List[str]:
+    actions = set()
+    for sid in perms_to_sids(permissions, sid_type):
+        actions.update(SID_TO_ACTIONS[sid])
+    return list(actions)

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_utils.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_utils.py
@@ -18,7 +18,7 @@ from dataall.modules.shares_base.services.shares_enums import ShareObjectDataPer
 SID_TO_ACTIONS = {
     DATAALL_READ_ONLY_SID: ['s3:List*', 's3:GetObject'],
     DATAALL_WRITE_ONLY_SID: ['s3:PutObject'],
-    DATAALL_MODIFY_ONLY_SID: ['s3:DeleteObject', 's3:DeleteObjects'],
+    DATAALL_MODIFY_ONLY_SID: ['s3:DeleteObject'],
     DATAALL_BUCKET_KMS_DECRYPT_SID: ['kms:Decrypt'],
     DATAALL_BUCKET_KMS_ENCRYPT_SID: ['kms:Encrypt', 'kms:ReEncrypt*', 'kms:GenerateDataKey*'],
     DATAALL_ACCESS_POINT_KMS_DECRYPT_SID: ['kms:Decrypt'],

--- a/backend/dataall/modules/shares_base/api/input_types.py
+++ b/backend/dataall/modules/shares_base/api/input_types.py
@@ -1,6 +1,5 @@
 from dataall.base.api.constants import SortDirection, gql
-from dataall.modules.shares_base.services.shares_enums import ShareableType, ShareSortField
-
+from dataall.modules.shares_base.services.shares_enums import ShareableType, ShareSortField, ShareObjectDataPermission
 
 NewShareObjectInput = gql.InputType(
     name='NewShareObjectInput',
@@ -12,9 +11,9 @@ NewShareObjectInput = gql.InputType(
         gql.Argument(name='principalType', type=gql.NonNullableType(gql.String)),
         gql.Argument(name='requestPurpose', type=gql.String),
         gql.Argument(name='attachMissingPolicies', type=gql.Boolean),
+        gql.Argument(name='permissions', type=gql.ArrayType(ShareObjectDataPermission.toGraphQLEnum())),
     ],
 )
-
 
 AddSharedItemInput = gql.InputType(
     name='AddSharedItemInput',
@@ -24,7 +23,6 @@ AddSharedItemInput = gql.InputType(
     ],
 )
 
-
 ShareItemSelectorInput = gql.InputType(
     name='ShareItemSelectorInput',
     arguments=[
@@ -32,7 +30,6 @@ ShareItemSelectorInput = gql.InputType(
         gql.Argument(name='itemUris', type=gql.NonNullableType(gql.ArrayType(gql.String))),
     ],
 )
-
 
 ShareSortCriteria = gql.InputType(
     name='ShareSortCriteria',
@@ -56,7 +53,6 @@ ShareObjectFilter = gql.InputType(
         gql.Argument('share_iam_roles', gql.ArrayType(gql.String)),
     ],
 )
-
 
 ShareableObjectFilter = gql.InputType(
     name='ShareableObjectFilter',

--- a/backend/dataall/modules/shares_base/api/resolvers.py
+++ b/backend/dataall/modules/shares_base/api/resolvers.py
@@ -32,6 +32,8 @@ class RequestValidator:
             raise RequiredParameter('principalType')
         if not data.get('groupUri'):
             raise RequiredParameter('groupUri')
+        if len(data.get('permissions', [])) == 0:
+            raise RequiredParameter('permissions')
 
     @staticmethod
     def validate_item_selector_input(data):
@@ -88,6 +90,7 @@ def create_share_object(
         principal_type=input['principalType'],
         requestPurpose=input.get('requestPurpose'),
         attachMissingPolicies=input.get('attachMissingPolicies', False),
+        permissions=input.get('permissions'),
     )
 
 

--- a/backend/dataall/modules/shares_base/api/types.py
+++ b/backend/dataall/modules/shares_base/api/types.py
@@ -3,6 +3,7 @@ from dataall.modules.shares_base.services.shares_enums import (
     ShareableType,
     PrincipalType,
     ShareItemHealthStatus,
+    ShareObjectDataPermission,
 )
 from dataall.modules.shares_base.api.resolvers import (
     resolve_dataset,
@@ -15,7 +16,6 @@ from dataall.modules.shares_base.api.resolvers import (
     resolve_can_view_logs,
 )
 from dataall.core.environment.api.resolvers import resolve_environment
-
 
 ShareItem = gql.ObjectType(
     name='ShareItem',
@@ -59,7 +59,6 @@ NotSharedItem = gql.ObjectType(
     ],
 )
 
-
 NotSharedItemsSearchResult = gql.ObjectType(
     name='NotSharedItemsSearchResult',
     fields=[
@@ -74,7 +73,6 @@ NotSharedItemsSearchResult = gql.ObjectType(
         gql.Field(name='nodes', type=gql.ArrayType(NotSharedItem)),
     ],
 )
-
 
 SharedItemSearchResult = gql.ObjectType(
     name='SharedItemSearchResult',
@@ -163,9 +161,9 @@ ShareObject = gql.ObjectType(
             type=gql.Ref('ShareObjectPermission'),
             resolver=resolve_user_role,
         ),
+        gql.Field('permissions', gql.ArrayType(ShareObjectDataPermission.toGraphQLEnum())),
     ],
 )
-
 
 ShareSearchResult = gql.ObjectType(
     name='ShareSearchResult',
@@ -200,7 +198,6 @@ EnvironmentPublishedItem = gql.ObjectType(
     ],
 )
 
-
 EnvironmentPublishedItemSearchResults = gql.ObjectType(
     name='EnvironmentPublishedItemSearchResults',
     fields=[
@@ -224,7 +221,6 @@ Principal = gql.ObjectType(
         gql.Field(name='environmentName', type=gql.String),
     ],
 )
-
 
 PrincipalSearchResult = gql.ObjectType(
     name='PrincipalSearchResult',

--- a/backend/dataall/modules/shares_base/db/share_object_models.py
+++ b/backend/dataall/modules/shares_base/db/share_object_models.py
@@ -39,6 +39,7 @@ class ShareObject(Base):
     rejectPurpose = Column(String, nullable=True)
     userRoleForShareObject = query_expression()
     existingSharedItems = query_expression()
+    permissions = Column(ARRAY(String), nullable=False)
 
 
 class ShareObjectItem(Base):

--- a/backend/dataall/modules/shares_base/services/share_object_service.py
+++ b/backend/dataall/modules/shares_base/services/share_object_service.py
@@ -1,28 +1,24 @@
-import os
+import logging
+from typing import List
 
-from dataall.core.permissions.services.resource_policy_service import ResourcePolicyService
-from dataall.core.tasks.service_handlers import Worker
+from dataall.base.aws.iam import IAM
 from dataall.base.context import get_context
+from dataall.base.db.exceptions import UnauthorizedOperation, InvalidInput
 from dataall.core.activity.db.activity_models import Activity
-from dataall.core.environment.db.environment_models import EnvironmentGroup, ConsumptionRole
 from dataall.core.environment.services.environment_service import EnvironmentService
 from dataall.core.environment.services.managed_iam_policies import PolicyManager
+from dataall.core.permissions.services.resource_policy_service import ResourcePolicyService
 from dataall.core.tasks.db.task_models import Task
-from dataall.base.db.exceptions import UnauthorizedOperation
-from dataall.modules.shares_base.services.shares_enums import (
-    ShareObjectActions,
-    ShareableType,
-    ShareItemStatus,
-    ShareObjectStatus,
-    PrincipalType,
-)
+from dataall.core.tasks.service_handlers import Worker
+from dataall.modules.datasets_base.db.dataset_models import DatasetBase
+from dataall.modules.datasets_base.db.dataset_repositories import DatasetBaseRepository
 from dataall.modules.shares_base.db.share_object_models import ShareObjectItem, ShareObject
 from dataall.modules.shares_base.db.share_object_repositories import ShareObjectRepository
-from dataall.modules.shares_base.db.share_state_machines_repositories import ShareStatusRepository
 from dataall.modules.shares_base.db.share_object_state_machines import (
     ShareObjectSM,
     ShareItemSM,
 )
+from dataall.modules.shares_base.db.share_state_machines_repositories import ShareStatusRepository
 from dataall.modules.shares_base.services.share_exceptions import ShareItemsFound, PrincipalRoleNotFound
 from dataall.modules.shares_base.services.share_notification_service import ShareNotificationService
 from dataall.modules.shares_base.services.share_permissions import (
@@ -36,11 +32,13 @@ from dataall.modules.shares_base.services.share_permissions import (
     GET_SHARE_OBJECT,
 )
 from dataall.modules.shares_base.services.share_processor_manager import ShareProcessorManager
-from dataall.modules.datasets_base.db.dataset_repositories import DatasetBaseRepository
-from dataall.modules.datasets_base.db.dataset_models import DatasetBase
-from dataall.base.aws.iam import IAM
-
-import logging
+from dataall.modules.shares_base.services.shares_enums import (
+    ShareObjectActions,
+    ShareItemStatus,
+    ShareObjectStatus,
+    PrincipalType,
+    ShareObjectDataPermission,
+)
 
 log = logging.getLogger(__name__)
 
@@ -74,6 +72,7 @@ class ShareObjectService:
         principal_type,
         requestPurpose,
         attachMissingPolicies,
+        permissions: List[str],
     ):
         context = get_context()
         with context.db_engine.scoped_session() as session:
@@ -100,18 +99,19 @@ class ShareObjectService:
 
             if principal_type in [PrincipalType.ConsumptionRole.value, PrincipalType.Group.value]:
                 if principal_type == PrincipalType.ConsumptionRole.value:
-                    consumption_role: ConsumptionRole = EnvironmentService.get_environment_consumption_role(
+                    consumption_role = EnvironmentService.get_environment_consumption_role(
                         session, principal_id, environment.environmentUri
                     )
+                    principal_role_arn = consumption_role.IAMRoleArn
                     principal_role_name = consumption_role.IAMRoleName
                     managed = consumption_role.dataallManaged
-
                 else:
-                    env_group: EnvironmentGroup = EnvironmentService.get_environment_group(
-                        session, group_uri, environment.environmentUri
-                    )
+                    env_group = EnvironmentService.get_environment_group(session, group_uri, environment.environmentUri)
+                    principal_role_arn = env_group.environmentIAMRoleArn
                     principal_role_name = env_group.environmentIAMRoleName
                     managed = True
+
+                cls._validate_role_in_same_account(dataset.AwsAccountId, principal_role_arn, permissions)
 
                 share_policy_manager = PolicyManager(
                     role_name=principal_role_name,
@@ -159,6 +159,7 @@ class ShareObjectService:
                     principalRoleName=principal_role_name,
                     status=ShareObjectStatus.Draft.value,
                     requestPurpose=requestPurpose,
+                    permissions=permissions,
                 )
                 ShareObjectRepository.save_and_commit(session, share)
 
@@ -453,4 +454,20 @@ class ShareObjectService:
             raise UnauthorizedOperation(
                 action=CREATE_SHARE_OBJECT,
                 message=f'Team: {share_object_group} is not a member of the environment {environment_uri}',
+            )
+
+    @staticmethod
+    def _validate_role_in_same_account(aws_account_id, principal_role_arn, permissions):
+        """
+        raise if aws_account_id and role_arn are not in the same account permissions are WRITE/MODIFY
+
+        :param aws_account_id:
+        :param principal_role_arn:
+        :param permissions:
+        """
+        if f':{aws_account_id}:' not in principal_role_arn and permissions != [ShareObjectDataPermission.Read.value]:
+            raise InvalidInput(
+                'Principal Role',
+                principal_role_arn,
+                f'be in the same {aws_account_id=} when WRITE/MODIFY permissions are specified',
             )

--- a/backend/dataall/modules/shares_base/services/shares_enums.py
+++ b/backend/dataall/modules/shares_base/services/shares_enums.py
@@ -16,6 +16,12 @@ class ShareObjectPermission(GraphQLEnumMapper):
     NoPermission = '000'
 
 
+class ShareObjectDataPermission(GraphQLEnumMapper):
+    Read = 'Read'
+    Write = 'Write'
+    Modify = 'Modify'
+
+
 class ShareObjectStatus(GraphQLEnumMapper):
     Deleted = 'Deleted'
     Approved = 'Approved'

--- a/backend/migrations/versions/c215903b780c_add_share_object_permissions.py
+++ b/backend/migrations/versions/c215903b780c_add_share_object_permissions.py
@@ -1,0 +1,27 @@
+"""add_share_object_permissions
+
+Revision ID: c215903b780c
+Revises: 9efe5f7c69a1
+Create Date: 2024-08-08 16:19:25.731721
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'c215903b780c'
+down_revision = '9efe5f7c69a1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'share_object', sa.Column('permissions', postgresql.ARRAY(sa.String()), nullable=False, server_default='{Read}')
+    )
+
+
+def downgrade():
+    op.drop_column('share_object', 'permissions')

--- a/frontend/src/modules/Catalog/components/RequestAccessModal.js
+++ b/frontend/src/modules/Catalog/components/RequestAccessModal.js
@@ -1,7 +1,7 @@
 import SendIcon from '@mui/icons-material/Send';
 import { LoadingButton } from '@mui/lab';
-import Autocomplete from '@mui/lab/Autocomplete';
 import {
+  Autocomplete,
   Box,
   Button,
   CardContent,
@@ -27,6 +27,7 @@ import {
   listValidEnvironments,
   requestDashboardShare,
   getConsumptionRolePolicies,
+  fetchEnums,
   useClient
 } from 'services';
 import { ShareEditForm } from '../../Shared/Shares/ShareEditForm';
@@ -51,6 +52,20 @@ export const RequestAccessModal = (props) => {
   const [share, setShare] = useState(false);
   const [loading, setLoading] = useState(false);
   const [alreadyExisted, setAlreadyExisted] = useState(false);
+  const [dataPermsEnum, setDataPermsEnum] = useState([]);
+
+  const fetchDataPermsEnum = useCallback(async () => {
+    const backendEnumName = 'ShareObjectDataPermission';
+    const backendEnumData = (await fetchEnums(client, [backendEnumName]))[
+      backendEnumName
+    ];
+    if (backendEnumData) setDataPermsEnum(backendEnumData.map((e) => e.value));
+    else
+      dispatch({
+        type: SET_ERROR,
+        error: `Could not fetch enum: ${backendEnumName}`
+      });
+  }, [client, dispatch]);
 
   const fetchEnvironments = useCallback(async () => {
     setStep(0);
@@ -78,7 +93,7 @@ export const RequestAccessModal = (props) => {
       setLoadingEnvs(false);
       stopLoader();
     }
-  }, [client, dispatch]);
+  }, [client, dispatch, stopLoader]);
 
   const fetchShareObject = async (shareUri) => {
     const response = await client.query(getShareObject({ shareUri: shareUri }));
@@ -177,8 +192,16 @@ export const RequestAccessModal = (props) => {
       fetchEnvironments().catch((e) =>
         dispatch({ type: SET_ERROR, error: e.message })
       );
+      fetchDataPermsEnum();
     }
-  }, [client, open, fetchEnvironments, dispatch]);
+  }, [
+    client,
+    open,
+    stopLoader,
+    fetchEnvironments,
+    fetchDataPermsEnum,
+    dispatch
+  ]);
 
   const formDatasetRequestObject = (inputObject) => {
     return {
@@ -212,7 +235,8 @@ export const RequestAccessModal = (props) => {
       principalId: principal,
       principalType: type,
       requestPurpose: values.comment,
-      attachMissingPolicies: values.attachMissingPolicies
+      attachMissingPolicies: values.attachMissingPolicies,
+      permissions: values.permissions
     };
 
     if (hit.resourceKind === 'dataset') {
@@ -303,7 +327,8 @@ export const RequestAccessModal = (props) => {
               initialValues={{
                 environmentUri: '',
                 comment: '',
-                attachMissingPolicies: false
+                attachMissingPolicies: false,
+                permissions: [dataPermsEnum[0]]
               }}
               validationSchema={Yup.object().shape({
                 environmentUri: Yup.string().required(
@@ -481,6 +506,27 @@ export const RequestAccessModal = (props) => {
                               )}
                             </Box>
                           )}
+                        </CardContent>
+                        <CardContent>
+                          <Autocomplete
+                            multiple
+                            disablePortal
+                            fullWidth
+                            options={dataPermsEnum}
+                            getOptionLabel={(option) => option}
+                            defaultValue={values.permissions}
+                            onChange={(e, value) =>
+                              setFieldValue('permissions', value)
+                            }
+                            renderInput={(params) => (
+                              <TextField
+                                {...params}
+                                fullWidth
+                                variant="outlined"
+                                label="Permissions"
+                              />
+                            )}
+                          />
                         </CardContent>
                         <CardContent>
                           {loadingRoles ? (

--- a/frontend/src/modules/Shares/services/getShareObject.js
+++ b/frontend/src/modules/Shares/services/getShareObject.js
@@ -16,6 +16,7 @@ export const getShareObject = ({ shareUri, filter }) => ({
         rejectPurpose
         userRoleForShareObject
         canViewLogs
+        permissions
         principal {
           principalName
           principalType

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -15,6 +15,7 @@ import {
   Card,
   CardContent,
   CardHeader,
+  Chip,
   Container,
   Divider,
   Grid,
@@ -1113,6 +1114,26 @@ const ShareView = () => {
                             </Typography>
                             <Typography color="textPrimary" variant="body2">
                               {share.principal.environmentName || '-'}
+                            </Typography>
+                          </ListItem>
+                          <ListItem
+                            disableGutters
+                            divider
+                            sx={{
+                              justifyContent: 'space-between',
+                              padding: 2
+                            }}
+                          >
+                            <Typography
+                              color="textSecondary"
+                              variant="subtitle2"
+                            >
+                              Permissions
+                            </Typography>
+                            <Typography color="textPrimary" variant="body2">
+                              {share.permissions.map((perm) => (
+                                <Chip label={perm} sx={{ marginRight: 1 }} />
+                              ))}
                             </Typography>
                           </ListItem>
                           <ListItem

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,7 +192,7 @@ def mock_aws_client(module_mocker):
     # there can be other mocker clients
     module_mocker.patch('dataall.modules.s3_datasets.aws.s3_dataset_client.SessionHelper', session_helper)
 
-    module_mocker.patch('dataall.modules.s3_datasets_shares.aws.kms_client.SessionHelper', session_helper)
+    module_mocker.patch('dataall.modules.s3_datasets.aws.kms_dataset_client.SessionHelper', session_helper)
 
     module_mocker.patch('dataall.base.aws.sts.SessionHelper', session_helper)
 

--- a/tests/modules/redshift_datasets_shares/conftest.py
+++ b/tests/modules/redshift_datasets_shares/conftest.py
@@ -3,7 +3,7 @@ from dataall.base.context import set_context, dispose_context, RequestContext
 from dataall.modules.shares_base.services.sharing_service import ShareData
 from dataall.modules.shares_base.services.share_object_service import ShareObjectService
 from dataall.modules.shares_base.db.share_object_repositories import ShareObjectRepository
-from dataall.modules.shares_base.services.shares_enums import ShareItemStatus
+from dataall.modules.shares_base.services.shares_enums import ShareItemStatus, ShareObjectDataPermission
 from dataall.modules.shares_base.services.share_item_service import ShareItemService
 from dataall.modules.redshift_datasets.services.redshift_connection_service import RedshiftConnectionService
 from dataall.modules.redshift_datasets.services.redshift_dataset_service import RedshiftDatasetService
@@ -232,6 +232,7 @@ def redshift_share_request_cross_account(db, user2, group2, env_fixture_2, targe
         principal_type='Redshift_Role',
         requestPurpose=None,
         attachMissingPolicies=False,
+        permissions=[ShareObjectDataPermission.Read.value],
     )
     dispose_context()
     yield share
@@ -253,6 +254,7 @@ def redshift_share_request_2_same_account(
         principal_type='Redshift_Role',
         requestPurpose=None,
         attachMissingPolicies=False,
+        permissions=[ShareObjectDataPermission.Read.value],
     )
     dispose_context()
     yield share

--- a/tests/modules/s3_datasets/tasks/test_dataset_subscriptions.py
+++ b/tests/modules/s3_datasets/tasks/test_dataset_subscriptions.py
@@ -9,6 +9,7 @@ from dataall.modules.shares_base.services.shares_enums import (
     ShareItemStatus,
     ShareableType,
     PrincipalType,
+    ShareObjectDataPermission,
 )
 from dataall.modules.shares_base.db.share_object_models import ShareObjectItem, ShareObject
 from dataall.modules.s3_datasets.db.dataset_models import DatasetTable, S3Dataset
@@ -73,6 +74,7 @@ def share(
             principalRoleName='uri-group2',
             principalType=PrincipalType.Group.value,
             status=ShareObjectStatus.Approved.value,
+            permissions=[ShareObjectDataPermission.Read.value],
         )
         session.add(share)
         session.commit()

--- a/tests/modules/s3_datasets_shares/conftest.py
+++ b/tests/modules/s3_datasets_shares/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from dataall.core.environment.db.environment_models import Environment, EnvironmentGroup
 from dataall.core.organizations.db.organization_models import Organization
 from dataall.core.permissions.services.resource_policy_service import ResourcePolicyService
-from dataall.modules.shares_base.services.shares_enums import ShareableType, PrincipalType
+from dataall.modules.shares_base.services.shares_enums import ShareableType, PrincipalType, ShareObjectDataPermission
 from dataall.modules.shares_base.db.share_object_models import ShareObject, ShareObjectItem
 from dataall.modules.shares_base.services.share_permissions import SHARE_OBJECT_REQUESTER, SHARE_OBJECT_APPROVER
 from dataall.modules.datasets_base.services.datasets_enums import ConfidentialityClassification
@@ -396,7 +396,12 @@ def share_item(db):
 @pytest.fixture(scope='module')
 def share(db):
     def factory(
-        dataset: S3Dataset, environment: Environment, env_group: EnvironmentGroup, owner: str, status: str
+        dataset: S3Dataset,
+        environment: Environment,
+        env_group: EnvironmentGroup,
+        owner: str,
+        status: str,
+        permissions=[ShareObjectDataPermission.Read.value],
     ) -> ShareObject:
         with db.scoped_session() as session:
             share = ShareObject(
@@ -408,6 +413,7 @@ def share(db):
                 principalType=PrincipalType.Group.value,
                 principalRoleName=env_group.environmentIAMRoleName,
                 status=status,
+                permissions=[permissions],
             )
             session.add(share)
             session.commit()

--- a/tests/modules/s3_datasets_shares/tasks/conftest.py
+++ b/tests/modules/s3_datasets_shares/tasks/conftest.py
@@ -7,6 +7,7 @@ from dataall.modules.shares_base.services.shares_enums import (
     ShareItemStatus,
     ShareObjectStatus,
     PrincipalType,
+    ShareObjectDataPermission,
 )
 from dataall.modules.shares_base.db.share_object_models import ShareObjectItem, ShareObject, ShareObjectItemDataFilter
 from dataall.modules.s3_datasets.db.dataset_models import (
@@ -138,6 +139,7 @@ def share(db):
                 principalRoleName=env_group.environmentIAMRoleName,
                 status=ShareObjectStatus.Approved.value,
                 groupUri=env_group.groupUri,
+                permissions=[ShareObjectDataPermission.Read.value],
             )
             session.add(share)
             session.commit()


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
Adding support for requesting WRITE/MODIFY permissions for an S3Bucket

### Testing
Tested in local and dev delpoyment

### Relates
#1332 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
