### PR TITLE
Fix: Remove enums from i-tests for MFs

### DIFF
--- a/tests_new/integration_tests/modules/metadata_forms/conftest.py
+++ b/tests_new/integration_tests/modules/metadata_forms/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 from integration_tests.modules.metadata_forms.queries import create_metadata_form, delete_metadata_form
-from dataall.modules.metadata_forms.db.enums import MetadataFormVisibility
 
 
 @pytest.fixture(scope='session')
@@ -13,7 +12,7 @@ def metadata_form_1(client1, group1, session_id):
         input = {
             'name': 'MF Test 1',
             'description': 'first session test metadata form',
-            'visibility': MetadataFormVisibility.Global.value,
+            'visibility': 'Global',
             'SamlGroupName': group1,
             'homeEntity': None,
         }


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix


### Detail
- Make intergration tests for MFs backend-internals agnostic

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
