### PR TITLE
Run reapply automatically if Share Verifier Task detects Unhealthy Shared Items

### DIFF
--- a/backend/dataall/modules/s3_datasets_shares/__init__.py
+++ b/backend/dataall/modules/s3_datasets_shares/__init__.py
@@ -34,21 +34,34 @@ class S3DatasetsSharesApiModuleInterface(ModuleInterface):
         )
         from dataall.modules.shares_base.services.shares_enums import ShareableType
         from dataall.modules.s3_datasets.db.dataset_models import DatasetTable, DatasetBucket, DatasetStorageLocation
+        from dataall.modules.s3_datasets_shares.services.share_processors.glue_table_share_processor import (
+            ProcessLakeFormationShare,
+        )
+        from dataall.modules.s3_datasets_shares.services.share_processors.s3_bucket_share_processor import (
+            ProcessS3BucketShare,
+        )
+        from dataall.modules.s3_datasets_shares.services.share_processors.s3_access_point_share_processor import (
+            ProcessS3AccessPointShare,
+        )
 
         EnvironmentResourceManager.register(S3ShareEnvironmentResource())
         DatasetService.register(S3ShareDatasetService())
         DatasetListService.register(S3ShareDatasetService())
 
         ShareProcessorManager.register_processor(
-            ShareProcessorDefinition(ShareableType.Table, None, DatasetTable, DatasetTable.tableUri)
+            ShareProcessorDefinition(
+                ShareableType.Table, ProcessLakeFormationShare, DatasetTable, DatasetTable.tableUri
+            )
         )
         ShareProcessorManager.register_processor(
-            ShareProcessorDefinition(ShareableType.S3Bucket, None, DatasetBucket, DatasetBucket.bucketUri)
+            ShareProcessorDefinition(
+                ShareableType.S3Bucket, ProcessS3BucketShare, DatasetBucket, DatasetBucket.bucketUri
+            )
         )
         ShareProcessorManager.register_processor(
             ShareProcessorDefinition(
                 ShareableType.StorageLocation,
-                None,
+                ProcessS3AccessPointShare,
                 DatasetStorageLocation,
                 DatasetStorageLocation.locationUri,
             )

--- a/backend/dataall/modules/shares_base/tasks/share_verifier_task.py
+++ b/backend/dataall/modules/shares_base/tasks/share_verifier_task.py
@@ -5,7 +5,7 @@ from dataall.modules.shares_base.db.share_object_repositories import ShareObject
 from dataall.modules.shares_base.db.share_object_models import ShareObject
 from dataall.modules.shares_base.services.shares_enums import ShareItemStatus
 from dataall.modules.shares_base.services.sharing_service import SharingService
-from dataall.modules.shares_base.tasks.share_reapplier_task import EcsBulkShareRepplyService
+from dataall.core.stacks.aws.ecs import Ecs
 
 from dataall.base.db import get_engine
 
@@ -39,9 +39,18 @@ def verify_shares(engine):
         return processed_share_objects
 
 
+def trigger_reapply_task():
+    Ecs.run_ecs_task(
+        task_definition_param='ecs/task_def_arn/share_reapplier',
+        container_name_param='ecs/container/share_reapplier',
+        context=[],
+    )
+
+
 if __name__ == '__main__':
     load_modules(modes={ImportMode.SHARES_TASK})
     ENVNAME = os.environ.get('envname', 'local')
     ENGINE = get_engine(envname=ENVNAME)
-    verify_shares(engine=ENGINE)
-    EcsBulkShareRepplyService.process_reapply_shares(ENGINE)
+    processed_shares = verify_shares(engine=ENGINE)
+    log.info(f'Finished verifying {len(processed_shares)} shares, triggering reapply...')
+    trigger_reapply_task()

--- a/backend/dataall/modules/shares_base/tasks/share_verifier_task.py
+++ b/backend/dataall/modules/shares_base/tasks/share_verifier_task.py
@@ -5,6 +5,8 @@ from dataall.modules.shares_base.db.share_object_repositories import ShareObject
 from dataall.modules.shares_base.db.share_object_models import ShareObject
 from dataall.modules.shares_base.services.shares_enums import ShareItemStatus
 from dataall.modules.shares_base.services.sharing_service import SharingService
+from dataall.modules.shares_base.tasks.share_reapplier_task import EcsBulkShareRepplyService
+
 from dataall.base.db import get_engine
 
 from dataall.base.loader import load_modules, ImportMode
@@ -42,3 +44,4 @@ if __name__ == '__main__':
     ENVNAME = os.environ.get('envname', 'local')
     ENGINE = get_engine(envname=ENVNAME)
     verify_shares(engine=ENGINE)
+    EcsBulkShareRepplyService.process_reapply_shares(ENGINE)


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature/Enhancement 

### Detail
- After the scheduled task verifies all share objects --> automatically re-apply the unhealthy share items found in data.all


### Relates
- https://github.com/data-dot-all/dataall/issues/1285

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
