### PR TITLE
Fix history of alembic migration scripts data filters vs metadata forms

### DIFF
--- a/backend/migrations/versions/9efe5f7c69a1_add_data_filters_table.py
+++ b/backend/migrations/versions/9efe5f7c69a1_add_data_filters_table.py
@@ -1,7 +1,7 @@
 """add_data_filters_table
 
 Revision ID: 9efe5f7c69a1
-Revises: b2ca24b72ca4
+Revises: afcfc928c640
 Create Date: 2024-07-17 11:05:26.077658
 
 """
@@ -18,7 +18,7 @@ from sqlalchemy.ext.declarative import declarative_base
 
 # revision identifiers, used by Alembic.
 revision = '9efe5f7c69a1'
-down_revision = 'b2ca24b72ca4'
+down_revision = 'afcfc928c640'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Given 2 pull requests that were tested but approved&merged at different points in time the alembic migration scripts run into a history mismatch because the migrations sequence ended up with 2 heads.

<img width="739" alt="image" src="https://github.com/user-attachments/assets/0f311f46-63e1-494a-a153-e4836ec8dd53">


`add_data_filters_table` should be executed after `mf_field_description`. This PR updates the down revision of `add_data_filters_table` accordingly to end up with:


<img width="618" alt="image" src="https://github.com/user-attachments/assets/929d746a-c3f6-4985-8df7-d61f0f84de85">



### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
