### PR TITLE
Save data filter perms before backfilling

### DIFF
--- a/backend/migrations/versions/9efe5f7c69a1_add_data_filters_table.py
+++ b/backend/migrations/versions/9efe5f7c69a1_add_data_filters_table.py
@@ -12,6 +12,8 @@ from sqlalchemy import Column, String, DateTime, Enum, ForeignKey, orm
 from sqlalchemy.dialects import postgresql
 from dataall.base.db import Resource, utils
 from dataall.core.permissions.services.resource_policy_service import ResourcePolicyService
+from dataall.core.permissions.services.permission_service import PermissionService
+from dataall.core.permissions.api.enums import PermissionType
 from dataall.modules.s3_datasets.services.dataset_permissions import DATASET_TABLE_DATA_FILTERS, DATASET_TABLE_READ
 from dataall.modules.datasets_base.services.datasets_enums import DatasetTypes
 from sqlalchemy.ext.declarative import declarative_base
@@ -94,6 +96,13 @@ def upgrade():
     bind = op.get_bind()
     session = orm.Session(bind=bind)
     print('Adding DATASET_TABLE_DATA_FILTERS permissions for all s3 dataset tables...')
+    for perm in DATASET_TABLE_DATA_FILTERS:
+        PermissionService.save_permission(
+            session,
+            name=perm,
+            description=perm,
+            permission_type=PermissionType.RESOURCE.name,
+        )
     s3_datasets: [S3Dataset] = session.query(S3Dataset).all()
     for dataset in s3_datasets:
         dataset_tables = session.query(DatasetTable).filter(DatasetTable.datasetUri == dataset.datasetUri).all()


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Fix data filter migration to save permissions before associating with existing S3 dataset tables


### Relates


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
