### PR TITLE
allow dbmigrations lambda to invoke any alembic command

### DIFF
--- a/backend/deployment_triggers/dbmigrations_handler.py
+++ b/backend/deployment_triggers/dbmigrations_handler.py
@@ -15,4 +15,7 @@ logger.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 def handler(event, context) -> None:
     alembic_cfg = Config('alembic.ini')
     alembic_cfg.set_main_option('script_location', './migrations')
-    command.upgrade(alembic_cfg, 'head')  # logging breaks after this command
+    event_command = event.get('command', 'upgrade')
+    event_args = event.get('args', {'revision': 'head'})
+    logger.info(f'calling alembic "{event_command}({event_args})"')
+    getattr(command, event_command)(config=alembic_cfg, **event_args)

--- a/backend/migrations/versions/b833ad41db68_maintenance_window_schema.py
+++ b/backend/migrations/versions/b833ad41db68_maintenance_window_schema.py
@@ -11,14 +11,17 @@ import os
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import Column, String, orm
+from sqlalchemy.ext.declarative import declarative_base
 
-from dataall.base.db import get_engine, has_table, Base
+from dataall.base.db import get_engine, has_table
 
 # revision identifiers, used by Alembic.
 revision = 'b833ad41db68'
 down_revision = '458572580709'
 branch_labels = None
 depends_on = None
+
+Base = declarative_base()
 
 
 class Maintenance(Base):


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
Currently if things get mixed up (in the db) due to migrations it's very hard to revert the situation (because db isn't exposed to the internet). We have 3 options
* Do it manually via SQL Editor
* Create an EC2 instance to use as a jump proxy
* Create a VPN

With this change we can now run any alembic command directly from the lambda by providing args as event data.

### Example usages

#### Manual downgrade 

Let's assume that you are working on a feature and have a new alembic revision locally, let's say `rev1`. 
Also you have already deployed that to your dev AWS account.
The upstream migrations history looks like `rev0`
The local migations history looks like this `rev0`->`rev1`.
A PR gets merged with an alembic migration `rev2` and is now changing the head from `rev0` to `rev2`.
Now the upstream migrations history looks like `rev0` -> `rev2`.
In order to merge you must rebase `main` and as solve this conflict, so the migrations history should look like this `rev0`->`rev2`->`rev1`.
Upon deployment you dev deployment thinks that is already on `rev1` and hence pipeline will not run any migrations and will skip the changes in `rev2`.

With this tool you can pass (before deployment of backend) as dbmigrations event payload the following which will downgrade the DB to `rev0`.
```
{
  "command": "downgrade",
  "args": {
    "revision": -1
  }
}
```
Then when normal upgade runs it will succesfully apply first `rev2` and then `rev1`.

#### Check history and current revision
It allows you to quickly look at the alembic history  and indicate the current revision of the db by passing the following as event contest...
```
{
  "command": "history",
  "args": {
    "indicate_current": true
  }
}
```



### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
