### PR TITLE
fix table share revoke with no filters

### DIFF
--- a/backend/dataall/modules/s3_datasets_shares/db/s3_share_object_repositories.py
+++ b/backend/dataall/modules/s3_datasets_shares/db/s3_share_object_repositories.py
@@ -177,6 +177,7 @@ class S3ShareObjectRepository:
                     ShareObjectItem.itemType == ShareableType.Table.value,
                     ShareObjectItem.shareItemUri != share_item_uri,
                     ShareObjectItem.status.in_(share_item_shared_states),
+                    ShareObjectItem.attachedDataFilterUri.is_(None),
                 )
             )
         )

--- a/backend/dataall/modules/s3_datasets_shares/services/share_processors/glue_table_share_processor.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_processors/glue_table_share_processor.py
@@ -22,7 +22,7 @@ from dataall.modules.shares_base.db.share_object_item_repositories import ShareO
 from dataall.modules.shares_base.db.share_state_machines_repositories import ShareStatusRepository
 from dataall.modules.s3_datasets_shares.db.s3_share_object_repositories import S3ShareObjectRepository
 from dataall.modules.shares_base.db.share_object_state_machines import ShareItemSM
-from dataall.modules.shares_base.services.share_manager_utils import ShareErrorFormatter
+from dataall.modules.s3_datasets_shares.services.share_managers.share_manager_utils import ShareErrorFormatter
 
 from dataall.modules.shares_base.services.sharing_service import ShareData
 from dataall.modules.shares_base.services.share_processor_manager import SharesProcessorInterface
@@ -286,7 +286,6 @@ class ProcessLakeFormationShare(SharesProcessorInterface):
                                     self.share_data.target_environment.environmentUri,
                                     share_item.itemUri,
                                     share_item.shareItemUri,
-                                    share_item_filter.dataFilterUris if share_item_filter else None,
                                 )
                                 else True
                             )


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Fix check other shares with no filters when revoking table share

### Relates


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
