### PR TITLE
Modifying Regex for fixing redirection not working when visitin s3-datasets

### DIFF
--- a/frontend/src/authentication/components/AuthGuard.js
+++ b/frontend/src/authentication/components/AuthGuard.js
@@ -1,20 +1,18 @@
 import PropTypes from 'prop-types';
 import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import { Login } from '../views/Login';
 import { useAuth } from '../hooks';
 import {
   RegexToValidateWindowPathName,
   WindowPathLengthThreshold
 } from 'utils';
-import { useNavigate } from 'react-router';
 
 export const AuthGuard = (props) => {
   const { children } = props;
   const auth = useAuth();
   const location = useLocation();
   const [requestedLocation, setRequestedLocation] = useState(null);
-  const navigate = useNavigate();
 
   if (!auth.isAuthenticated) {
     if (location.pathname !== requestedLocation) {
@@ -35,7 +33,7 @@ export const AuthGuard = (props) => {
 
   if (requestedLocation && location.pathname !== requestedLocation) {
     setRequestedLocation(null);
-    navigate(requestedLocation);
+    return <Navigate to={requestedLocation} />;
   }
 
   // When session storage contained path is not same as the current location.pathname ( usually after authentication )
@@ -46,15 +44,13 @@ export const AuthGuard = (props) => {
   ) {
     const windowPathLocation = sessionStorage.getItem('window-location');
     sessionStorage.removeItem('window-location');
-
     // Check if the window-location only contains alphanumeric and / in it and its not tampered
     if (!RegexToValidateWindowPathName.test(windowPathLocation))
       return <>{children}</>;
     // A guardrail to limit the string of the pathname to a certain characters
     if (windowPathLocation.length > WindowPathLengthThreshold)
       return <>{children}</>;
-
-    navigate(windowPathLocation, { replace: true });
+    return <Navigate to={windowPathLocation} replace={true} />;
   } else {
     sessionStorage.removeItem('window-location');
   }

--- a/frontend/src/authentication/components/AuthGuard.js
+++ b/frontend/src/authentication/components/AuthGuard.js
@@ -1,18 +1,20 @@
 import PropTypes from 'prop-types';
 import { useState } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { Login } from '../views/Login';
 import { useAuth } from '../hooks';
 import {
   RegexToValidateWindowPathName,
   WindowPathLengthThreshold
 } from 'utils';
+import { useNavigate } from 'react-router';
 
 export const AuthGuard = (props) => {
   const { children } = props;
   const auth = useAuth();
   const location = useLocation();
   const [requestedLocation, setRequestedLocation] = useState(null);
+  const navigate = useNavigate();
 
   if (!auth.isAuthenticated) {
     if (location.pathname !== requestedLocation) {
@@ -33,7 +35,7 @@ export const AuthGuard = (props) => {
 
   if (requestedLocation && location.pathname !== requestedLocation) {
     setRequestedLocation(null);
-    return <Navigate to={requestedLocation} />;
+    navigate(requestedLocation);
   }
 
   // When session storage contained path is not same as the current location.pathname ( usually after authentication )
@@ -44,13 +46,15 @@ export const AuthGuard = (props) => {
   ) {
     const windowPathLocation = sessionStorage.getItem('window-location');
     sessionStorage.removeItem('window-location');
+
     // Check if the window-location only contains alphanumeric and / in it and its not tampered
     if (!RegexToValidateWindowPathName.test(windowPathLocation))
       return <>{children}</>;
     // A guardrail to limit the string of the pathname to a certain characters
     if (windowPathLocation.length > WindowPathLengthThreshold)
       return <>{children}</>;
-    return <Navigate to={windowPathLocation} replace={true} />;
+
+    navigate(windowPathLocation, { replace: true });
   } else {
     sessionStorage.removeItem('window-location');
   }

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -26,5 +26,5 @@ export const AwsRegions = [
   { name: 'AWS GovCloud (US)', code: 'us-gov-west-1' }
 ];
 
-export const RegexToValidateWindowPathName = /^[a-zA-Z0-9/]*$/;
+export const RegexToValidateWindowPathName = /^[a-zA-Z0-9/-]*$/;
 export const WindowPathLengthThreshold = 50;


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix


### Detail

After changes in the names of the URL link to /s3-datasets from /datasets, the redirection is not working when the user logs into data.all with an initial link pointing to the s3-dataset. 

### Relates
- https://github.com/data-dot-all/dataall/issues/1497

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
