### PR TITLE
Validate imported resource names  via NamingConventionService

### DIFF
--- a/backend/dataall/base/utils/naming_convention.py
+++ b/backend/dataall/base/utils/naming_convention.py
@@ -8,7 +8,7 @@ class NamingConventionPattern(Enum):
         'regex': '[^a-zA-Z0-9-]',
         'separator': '-',
         'max_length': 63,
-        'valid_external_regex': '^[a-z0-9][a-z0-9.-]{1,61}[' 'a-z0-9]$',
+        'valid_external_regex': '(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$',
     }
     KMS = {'regex': '[a-zA-Z0-9_-]+$', 'separator': '-', 'max_length': 63}
     IAM = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 63}  # Role names up to 64 chars
@@ -73,7 +73,7 @@ class NamingConventionService:
     def validate_imported_name(self):
         regex = NamingConventionPattern[self.service].value['regex']
         max_length = NamingConventionPattern[self.service].value['max_length']
-        valid_external_regex = NamingConventionPattern[self.service].value.get('valid_external_regex', regex)
+        valid_external_regex = NamingConventionPattern[self.service].value.get('valid_external_regex', '.*')
         if 'arn:aws:' in self.target_label:
             raise Exception('An error occurred (InvalidInput): name expected, arn-like string received')
         if not re.search(valid_external_regex, self.target_label):

--- a/backend/dataall/base/utils/naming_convention.py
+++ b/backend/dataall/base/utils/naming_convention.py
@@ -9,9 +9,8 @@ class NamingConventionPattern(Enum):
         'separator': '-',
         'max_length': 63,
         'valid_external_regex': '^[a-z0-9][a-z0-9.-]{1,61}[' 'a-z0-9]$',
-        'max_imported_length': 63,
     }
-    KMS = {'regex': '[a-zA-Z0-9/_-]+$', 'separator': '-', 'max_length': 63}
+    KMS = {'regex': '[a-zA-Z0-9_-]+$', 'separator': '-', 'max_length': 63}
     IAM = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 63}  # Role names up to 64 chars
     IAM_POLICY = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 128}  # Policy names up to 128 chars
     GLUE = {
@@ -75,14 +74,13 @@ class NamingConventionService:
         regex = NamingConventionPattern[self.service].value['regex']
         max_length = NamingConventionPattern[self.service].value['max_length']
         valid_external_regex = NamingConventionPattern[self.service].value.get('valid_external_regex', regex)
-        max_imported_length = NamingConventionPattern[self.service].value.get('max_length', max_length)
         if 'arn:aws:' in self.target_label:
             raise Exception('An error occurred (InvalidInput): name expected, arn-like string received')
         if not re.search(valid_external_regex, self.target_label):
             raise Exception(
                 f'An error occurred (InvalidInput): label value {self.target_label} must match the pattern {valid_external_regex}'
             )
-        elif len(self.target_label) > max_imported_length:
+        elif len(self.target_label) > max_length:
             raise Exception(
-                f'An error occurred (InvalidInput): label value {self.target_label} must be less than {max_imported_length} characters'
+                f'An error occurred (InvalidInput): label value {self.target_label} must be less than {max_length} characters'
             )

--- a/backend/dataall/base/utils/naming_convention.py
+++ b/backend/dataall/base/utils/naming_convention.py
@@ -10,7 +10,7 @@ class NamingConventionPattern(Enum):
         'max_length': 63,
         'valid_external_regex': '(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$',
     }
-    KMS = {'regex': '[a-zA-Z0-9_-]+$', 'separator': '-', 'max_length': 63, 'valid_external_regex': '[a-zA-Z0-9_-]+$'}
+    KMS = {'regex': '[^a-zA-Z0-9-]$', 'separator': '-', 'max_length': 63, 'valid_external_regex': '^[a-zA-Z0-9_-]+$'}
     IAM = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 63}  # Role names up to 64 chars
     IAM_POLICY = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 128}  # Policy names up to 128 chars
     GLUE = {

--- a/backend/dataall/base/utils/naming_convention.py
+++ b/backend/dataall/base/utils/naming_convention.py
@@ -14,7 +14,12 @@ class NamingConventionPattern(Enum):
     KMS = {'regex': '[a-zA-Z0-9/_-]+$', 'separator': '-', 'max_length': 63}
     IAM = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 63}  # Role names up to 64 chars
     IAM_POLICY = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 128}  # Policy names up to 128 chars
-    GLUE = {'regex': '[^a-zA-Z0-9_]', 'separator': '_', 'max_length': 240, 'valid_external_regex': '^[a-zA-Z0-9_]+$'}  # Limit 255 - 15 extra chars buffer
+    GLUE = {
+        'regex': '[^a-zA-Z0-9_]',
+        'separator': '_',
+        'max_length': 240,
+        'valid_external_regex': '^[a-zA-Z0-9_]+$',
+    }  # Limit 255 - 15 extra chars buffer
     GLUE_ETL = {'regex': '[^a-zA-Z0-9-]', 'separator': '-', 'max_length': 52}
     NOTEBOOK = {'regex': '[^a-zA-Z0-9-]', 'separator': '-', 'max_length': 63}
     MLSTUDIO_DOMAIN = {'regex': '[^a-zA-Z0-9-]', 'separator': '-', 'max_length': 63}

--- a/backend/dataall/base/utils/naming_convention.py
+++ b/backend/dataall/base/utils/naming_convention.py
@@ -10,7 +10,7 @@ class NamingConventionPattern(Enum):
         'max_length': 63,
         'valid_external_regex': '(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$',
     }
-    KMS = {'regex': '[a-zA-Z0-9_-]+$', 'separator': '-', 'max_length': 63}
+    KMS = {'regex': '[a-zA-Z0-9_-]+$', 'separator': '-', 'max_length': 63, 'valid_external_regex': '[a-zA-Z0-9_-]+$'}
     IAM = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 63}  # Role names up to 64 chars
     IAM_POLICY = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 128}  # Policy names up to 128 chars
     GLUE = {
@@ -71,7 +71,6 @@ class NamingConventionService:
             )
 
     def validate_imported_name(self):
-        regex = NamingConventionPattern[self.service].value['regex']
         max_length = NamingConventionPattern[self.service].value['max_length']
         valid_external_regex = NamingConventionPattern[self.service].value.get('valid_external_regex', '.*')
         if 'arn:aws:' in self.target_label:

--- a/backend/dataall/base/utils/naming_convention.py
+++ b/backend/dataall/base/utils/naming_convention.py
@@ -14,7 +14,7 @@ class NamingConventionPattern(Enum):
     KMS = {'regex': '[a-zA-Z0-9/_-]+$', 'separator': '-', 'max_length': 63}
     IAM = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 63}  # Role names up to 64 chars
     IAM_POLICY = {'regex': '[^a-zA-Z0-9-_]', 'separator': '-', 'max_length': 128}  # Policy names up to 128 chars
-    GLUE = {'regex': '[^a-zA-Z0-9_]', 'separator': '_', 'max_length': 240}  # Limit 255 - 15 extra chars buffer
+    GLUE = {'regex': '[^a-zA-Z0-9_]', 'separator': '_', 'max_length': 240, 'valid_external_regex': '^[a-zA-Z0-9_]+$'}  # Limit 255 - 15 extra chars buffer
     GLUE_ETL = {'regex': '[^a-zA-Z0-9-]', 'separator': '-', 'max_length': 52}
     NOTEBOOK = {'regex': '[^a-zA-Z0-9-]', 'separator': '-', 'max_length': 63}
     MLSTUDIO_DOMAIN = {'regex': '[^a-zA-Z0-9-]', 'separator': '-', 'max_length': 63}

--- a/backend/dataall/modules/s3_datasets/services/dataset_service.py
+++ b/backend/dataall/modules/s3_datasets/services/dataset_service.py
@@ -107,14 +107,15 @@ class DatasetService:
     @staticmethod
     def check_imported_resources(dataset: S3Dataset):
         # check that resource names are valid
-        NamingConventionService(
-            target_uri=dataset.datasetUri,
-            target_label=dataset.S3BucketName,
-            pattern=NamingConventionPattern.S3,
-            resource_prefix='',
-        ).validate_imported_name()
+        if dataset.S3BucketName:
+            NamingConventionService(
+                target_uri=dataset.datasetUri,
+                target_label=dataset.S3BucketName,
+                pattern=NamingConventionPattern.S3,
+                resource_prefix='',
+            ).validate_imported_name()
 
-        if dataset.importedGlueDatabase:
+        if dataset.importedGlueDatabase and dataset.GlueDatabaseName:
             NamingConventionService(
                 target_uri=dataset.datasetUri,
                 target_label=dataset.GlueDatabaseName,

--- a/backend/dataall/modules/s3_datasets/services/dataset_service.py
+++ b/backend/dataall/modules/s3_datasets/services/dataset_service.py
@@ -142,7 +142,6 @@ class DatasetService:
                 target_uri=dataset.datasetUri,
                 target_label=kms_alias,
                 pattern=NamingConventionPattern.KMS,
-                resource_prefix='',
             ).validate_imported_name()
 
             key_exists = KmsClient(account_id=dataset.AwsAccountId, region=dataset.region).check_key_exists(

--- a/backend/dataall/modules/s3_datasets/services/dataset_service.py
+++ b/backend/dataall/modules/s3_datasets/services/dataset_service.py
@@ -5,7 +5,7 @@ from typing import List
 from dataall.core.resource_lock.db.resource_lock_repositories import ResourceLockRepository
 from dataall.base.aws.quicksight import QuicksightClient
 from dataall.base.db import exceptions
-from dataall.base.utils.naming_convention import NamingConventionPattern
+from dataall.base.utils.naming_convention import NamingConventionPattern, NamingConventionService
 from dataall.core.permissions.services.resource_policy_service import ResourcePolicyService
 from dataall.core.permissions.services.tenant_policy_service import TenantPolicyService
 from dataall.core.stacks.services.stack_service import StackService
@@ -106,19 +106,29 @@ class DatasetService:
 
     @staticmethod
     def check_imported_resources(dataset: S3Dataset):
+        # check that resource names are valid
+        NamingConventionService(
+            target_uri=dataset.datasetUri,
+            target_label=dataset.S3BucketName,
+            pattern=NamingConventionPattern.S3,
+            resource_prefix='',
+        ).validate_imported_name()
+
+        if dataset.importedGlueDatabase:
+            NamingConventionService(
+                target_uri=dataset.datasetUri,
+                target_label=dataset.GlueDatabaseName,
+                pattern=NamingConventionPattern.GLUE,
+                resource_prefix='',
+            ).validate_imported_name()
+
         with get_context().db_engine.scoped_session() as session:
             if DatasetBucketRepository.get_dataset_bucket_by_name(session, dataset.S3BucketName):
                 raise exceptions.ResourceAlreadyExists(
                     action=IMPORT_DATASET,
                     message=f'Dataset with bucket {dataset.S3BucketName} already exists',
                 )
-        if dataset.importedGlueDatabase:
-            if len(dataset.GlueDatabaseName) > NamingConventionPattern.GLUE.value.get('max_length'):
-                raise exceptions.InvalidInput(
-                    param_name='GlueDatabaseName',
-                    param_value=dataset.GlueDatabaseName,
-                    constraint=f"less than {NamingConventionPattern.GLUE.value.get('max_length')} characters",
-                )
+
         kms_alias = dataset.KmsAlias
 
         s3_encryption, kms_id_type, kms_id = S3DatasetClient(dataset).get_bucket_encryption()
@@ -129,6 +139,12 @@ class DatasetService:
                     param_value=dataset.KmsAlias,
                     constraint=f'empty, Bucket {dataset.S3BucketName} is encrypted with AWS managed key (SSE-S3). KmsAlias {kms_alias} should NOT be provided as input parameter.',
                 )
+            NamingConventionService(
+                target_uri=dataset.datasetUri,
+                target_label=kms_alias,
+                pattern=NamingConventionPattern.KMS,
+                resource_prefix='',
+            ).validate_imported_name()
 
             key_exists = KmsClient(account_id=dataset.AwsAccountId, region=dataset.region).check_key_exists(
                 key_alias=f'alias/{kms_alias}'

--- a/backend/dataall/modules/s3_datasets/services/dataset_service.py
+++ b/backend/dataall/modules/s3_datasets/services/dataset_service.py
@@ -105,7 +105,7 @@ class DatasetService:
         return True
 
     @staticmethod
-    def check_imported_resources(dataset: S3Dataset, data: dict):
+    def check_imported_resources(dataset: S3Dataset, data: dict = {}):
         # check that resource names are valid
         if dataset.S3BucketName:
             NamingConventionService(

--- a/backend/dataall/modules/s3_datasets/services/dataset_service.py
+++ b/backend/dataall/modules/s3_datasets/services/dataset_service.py
@@ -114,7 +114,7 @@ class DatasetService:
                 pattern=NamingConventionPattern.S3,
             ).validate_imported_name()
 
-        if dataset.importedGlueDatabase and dataset.GlueDatabaseName:
+        if dataset.importedGlueDatabase:
             NamingConventionService(
                 target_uri=dataset.datasetUri,
                 target_label=data.get('glueDatabaseName', 'undefined'),

--- a/tests/modules/s3_datasets/test_import_dataset_check_unit.py
+++ b/tests/modules/s3_datasets/test_import_dataset_check_unit.py
@@ -13,7 +13,7 @@ def test_s3_managed_bucket_import(mock_aws_client, api_context_1):
 
     mock_encryption_bucket(mock_aws_client, 'AES256', None)
 
-    assert DatasetService.check_imported_resources(dataset, {})
+    assert DatasetService.check_imported_resources(dataset)
 
 
 def test_s3_managed_bucket_but_bucket_encrypted_with_kms(mock_aws_client, api_context_1):

--- a/tests/modules/s3_datasets/test_import_dataset_check_unit.py
+++ b/tests/modules/s3_datasets/test_import_dataset_check_unit.py
@@ -13,7 +13,7 @@ def test_s3_managed_bucket_import(mock_aws_client, api_context_1):
 
     mock_encryption_bucket(mock_aws_client, 'AES256', None)
 
-    assert DatasetService.check_imported_resources(dataset)
+    assert DatasetService.check_imported_resources(dataset, {})
 
 
 def test_s3_managed_bucket_but_bucket_encrypted_with_kms(mock_aws_client, api_context_1):


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Refactoring

### Detail
- new properties in NamingConventionPattern: valid_external_regex, max_imported_length. If not defined, internal regex and max_length will be used
- function validate_imported_name is used for resources that are created outside data.all: e.g. s3, kms-aliases and glue tables for imported datasets

### Relates
- #1304 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
