### PR TITLE
Make log query period configurable

### DIFF
--- a/backend/dataall/core/stacks/api/resolvers.py
+++ b/backend/dataall/core/stacks/api/resolvers.py
@@ -68,7 +68,7 @@ def get_stack_logs(context: Context, source, targetUri: str = None, targetType: 
     query = StackService.get_stack_logs(target_uri=targetUri, target_type=targetType)
     envname = os.getenv('envname', 'local')
     log_group_name = f"/{Parameter().get_parameter(env=envname, path='resourcePrefix')}/{envname}/ecs/cdkproxy"
-    log_query_period_days = config.config.get_property('core.log_query_period_days', 1)
+    log_query_period_days = config.get_property('core.log_query_period_days', 1)
 
     results = CloudWatch.run_query(
         query=query,

--- a/backend/dataall/core/stacks/api/resolvers.py
+++ b/backend/dataall/core/stacks/api/resolvers.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 
+from dataall.base.config import config
 from dataall.base.api.context import Context
 from dataall.core.environment.services.environment_service import EnvironmentService
 from dataall.core.stacks.services.keyvaluetag_service import KeyValueTagService
@@ -67,10 +68,12 @@ def get_stack_logs(context: Context, source, targetUri: str = None, targetType: 
     query = StackService.get_stack_logs(target_uri=targetUri, target_type=targetType)
     envname = os.getenv('envname', 'local')
     log_group_name = f"/{Parameter().get_parameter(env=envname, path='resourcePrefix')}/{envname}/ecs/cdkproxy"
+    log_query_period_days = config.config.get_property('core.log_query_period_days', 1)
+
     results = CloudWatch.run_query(
         query=query,
         log_group_name=log_group_name,
-        days=1,
+        days=log_query_period_days,
     )
     log.info(f'Running Logs query {query} for log_group_name={log_group_name}')
     return results

--- a/config.json
+++ b/config.json
@@ -70,6 +70,7 @@
             "env_aws_actions": true,
             "cdk_pivot_role_multiple_environments_same_account": false,
             "enable_quicksight_monitoring": false
-        }
+        },
+        "log_query_period_days": 1
     }
 }

--- a/frontend/src/modules/Shares/components/ShareLogs.js
+++ b/frontend/src/modules/Shares/components/ShareLogs.js
@@ -82,7 +82,7 @@ export const ShareLogs = (props) => {
                       value={
                         logs.length > 0
                           ? logs.join('\n')
-                          : 'No logs available for the last 24 hours. Logs may take few minutes after the share is processed...'
+                          : 'No logs available. Logs may take few minutes after the share is processed...'
                       }
                       options={{ minimap: { enabled: false } }}
                       theme="vs-dark"


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- log query period for shares and stacks are set in config.json
- if not set, log query period is 1 day

### Relates
- #1502 #1502
### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
