### PR TITLE
fix importing sse encrypted buckets

### DIFF
--- a/backend/dataall/modules/s3_datasets/aws/s3_dataset_client.py
+++ b/backend/dataall/modules/s3_datasets/aws/s3_dataset_client.py
@@ -58,9 +58,12 @@ class S3DatasetClient:
             s3_encryption = encryption['SSEAlgorithm']
             # Format (using key id): arn:aws:kms:<region>:<account-ID>:key/<key-id>
             # (using alias): arn:aws:kms:<region>:<account-ID>:alias/<alias-name>
-            kms_key = encryption.get('KMSMasterKeyID')
-            kms_id = kms_key.split('/')[-1] if kms_key else None
-            kms_id_type = 'alias' if 'alias' in kms_key else 'key'
+            kms_key = encryption.get('KMSMasterKeyID', '')
+            kms_id = None
+            kms_id_type = None
+            if kms_key:
+                kms_id = kms_key.split('/')[-1]
+                kms_id_type = 'alias' if 'alias' in kms_key else 'key'
 
             return s3_encryption, kms_id_type, kms_id
 

--- a/tests/modules/s3_datasets/test_s3_dataset_client.py
+++ b/tests/modules/s3_datasets/test_s3_dataset_client.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from assertpy import assert_that
+
+from dataall.modules.s3_datasets.aws.s3_dataset_client import S3DatasetClient
+from dataall.modules.s3_datasets.db.dataset_models import S3Dataset
+
+
+@patch('dataall.modules.s3_datasets.aws.s3_dataset_client.SessionHelper', autospec=True)
+@pytest.mark.parametrize(
+    'bucket_encryption,expected',
+    [
+        (
+            {
+                'ServerSideEncryptionConfiguration': {
+                    'Rules': [
+                        {
+                            'ApplyServerSideEncryptionByDefault': {
+                                'SSEAlgorithm': 'aws:kms',
+                                'KMSMasterKeyID': 'arn:aws:kms:us-east-1:999999999999:alias/keyalias',
+                            },
+                            'BucketKeyEnabled': True,
+                        }
+                    ]
+                }
+            },
+            ('aws:kms', 'alias', 'keyalias'),
+        ),
+        (
+            {
+                'ServerSideEncryptionConfiguration': {
+                    'Rules': [
+                        {
+                            'ApplyServerSideEncryptionByDefault': {
+                                'SSEAlgorithm': 'aws:kms',
+                                'KMSMasterKeyID': 'arn:aws:kms:us-east-1:999999999999:key/123',
+                            },
+                            'BucketKeyEnabled': True,
+                        }
+                    ]
+                }
+            },
+            ('aws:kms', 'key', '123'),
+        ),
+        (
+            {
+                'ServerSideEncryptionConfiguration': {
+                    'Rules': [
+                        {'ApplyServerSideEncryptionByDefault': {'SSEAlgorithm': 'AES256'}, 'BucketKeyEnabled': True}
+                    ]
+                }
+            },
+            ('AES256', None, None),
+        ),
+    ],
+)
+def test_get_bucket_encryption(session_helper, bucket_encryption, expected):
+    session_helper.remote_session.return_value.client.return_value.get_bucket_encryption.return_value = (
+        bucket_encryption
+    )
+    dataset = MagicMock(spec=S3Dataset)
+    client = S3DatasetClient(dataset)
+    assert_that(client.get_bucket_encryption()).is_equal_to(expected)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Fix importing an SSE encrypted bucket which returns `argument of type 'NoneType' is not iterable`

### Relates
fixing issue introduced in #1499 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
