### PR TITLE
Update baseline removing checkov exception for glue security config

### DIFF
--- a/.checkov.baseline
+++ b/.checkov.baseline
@@ -134,6 +134,12 @@
                     ]
                 },
                 {
+                    "resource": "AWS::Logs::LogGroup.ECSLogGroupshareexpirationtaskdev40CB15AF",
+                    "check_ids": [
+                        "CKV_AWS_158"
+                    ]
+                },
+                {
                     "resource": "AWS::Logs::LogGroup.ECSLogGroupsharemanagerdev49FFAB5E",
                     "check_ids": [
                         "CKV_AWS_158"
@@ -165,12 +171,6 @@
                 },
                 {
                     "resource": "AWS::Logs::LogGroup.ECSLogGrouptablessyncerdevAB12C7DE",
-                    "check_ids": [
-                        "CKV_AWS_158"
-                    ]
-                },
-                {
-                    "resource": "AWS::Logs::LogGroup.ECSLogGroupshareexpirationtaskdev40CB15AF",
                     "check_ids": [
                         "CKV_AWS_158"
                     ]
@@ -643,23 +643,6 @@
                     "check_ids": [
                         "CKV_AWS_18",
                         "CKV_AWS_21"
-                    ]
-                }
-            ]
-        },
-        {
-            "file": "/checkov_s3_dataset_synth.json",
-            "findings": [
-                {
-                    "resource": "AWS::Glue::Crawler.dhCrawler",
-                    "check_ids": [
-                        "CKV_AWS_195"
-                    ]
-                },
-                {
-                    "resource": "AWS::Glue::Job.DatasetGlueProfilingJob",
-                    "check_ids": [
-                        "CKV_AWS_195"
                     ]
                 }
             ]


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Enhancement

### Detail
- Update checkov baseline after #1434  PR to add security configs to glue resources

### Relates
- #1324 and #1434 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
