### PR TITLE
Add bucket versioning

### DIFF
--- a/.checkov.baseline
+++ b/.checkov.baseline
@@ -365,8 +365,7 @@
                 {
                     "resource": "AWS::S3::Bucket.dataalldevfrontend64065639",
                     "check_ids": [
-                        "CKV_AWS_18",
-                        "CKV_AWS_21"
+                        "CKV_AWS_18"
                     ]
                 },
                 {
@@ -378,8 +377,7 @@
                 {
                     "resource": "AWS::S3::Bucket.dataalldevuserguide5964DC13",
                     "check_ids": [
-                        "CKV_AWS_18",
-                        "CKV_AWS_21"
+                        "CKV_AWS_18"
                     ]
                 }
             ]
@@ -445,12 +443,6 @@
                     ]
                 },
                 {
-                    "resource": "AWS::IAM::Policy.dataallmaincdkpipelinePipelineRoleDefaultPolicy98FFDB2A",
-                    "check_ids": [
-                        "CKV_AWS_111"
-                    ]
-                },
-                {
                     "resource": "AWS::Lambda::Function.CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
                     "check_ids": [
                         "CKV_AWS_115",
@@ -459,10 +451,9 @@
                     ]
                 },
                 {
-                    "resource": "AWS::S3::Bucket.dataallmaincdkpipelinePipelineArtifactsBucketF1C6C602",
+                    "resource": "AWS::S3::Bucket.pipelineartifactsbucketE44F7DE9",
                     "check_ids": [
-                        "CKV_AWS_18",
-                        "CKV_AWS_21"
+                        "CKV_AWS_18"
                     ]
                 },
                 {

--- a/.checkov.baseline
+++ b/.checkov.baseline
@@ -624,16 +624,9 @@
                     ]
                 },
                 {
-                    "resource": "AWS::KMS::Key.thistableArtifactsBucketEncryptionKey127159D3",
+                    "resource": "AWS::S3::Bucket.thistableartifactsbucketDB1C8C64",
                     "check_ids": [
-                        "CKV_AWS_7"
-                    ]
-                },
-                {
-                    "resource": "AWS::S3::Bucket.thistableArtifactsBucket145BFFDF",
-                    "check_ids": [
-                        "CKV_AWS_18",
-                        "CKV_AWS_21"
+                        "CKV_AWS_18"
                     ]
                 }
             ]

--- a/backend/dataall/modules/datapipelines/cdk/datapipelines_pipeline.py
+++ b/backend/dataall/modules/datapipelines/cdk/datapipelines_pipeline.py
@@ -76,7 +76,7 @@ class PipelineStack(Stack):
         artifact_bucket_key = kms.Key(
             self,
             f'{artifact_bucket_base_name}-key',
-            removal_policy=RemovalPolicy.RETAIN,
+            removal_policy=RemovalPolicy.DESTROY,
             alias=f'{artifact_bucket_base_name}-key',
             enable_key_rotation=True,
         )
@@ -85,7 +85,7 @@ class PipelineStack(Stack):
             f'{artifact_bucket_base_name}-bucket',
             bucket_name=f'{artifact_bucket_base_name}-bucket',
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
-            removal_policy=RemovalPolicy.RETAIN,
+            removal_policy=RemovalPolicy.DESTROY,
             versioned=True,
             encryption_key=artifact_bucket_key,
             enforce_ssl=True,

--- a/deploy/stacks/cloudfront.py
+++ b/deploy/stacks/cloudfront.py
@@ -96,6 +96,7 @@ class CloudfrontDistro(pyNestedClass):
             removal_policy=RemovalPolicy.DESTROY,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             enforce_ssl=True,
+            versioned=True,
             object_ownership=s3.ObjectOwnership.OBJECT_WRITER,
         )
 
@@ -385,6 +386,7 @@ class CloudfrontDistro(pyNestedClass):
             removal_policy=RemovalPolicy.DESTROY,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             enforce_ssl=True,
+            versioned=True,
             object_ownership=s3.ObjectOwnership.OBJECT_WRITER,
         )
 

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -124,7 +124,7 @@ class PipelineStack(Stack):
             f'{self.artifact_bucket_name}-key',
             removal_policy=RemovalPolicy.DESTROY,
             alias=f'{self.artifact_bucket_name}-key',
-            enable_key_rotation=True
+            enable_key_rotation=True,
         )
         self.artifact_bucket = s3.Bucket(
             self,
@@ -137,9 +137,6 @@ class PipelineStack(Stack):
             enforce_ssl=True,
             auto_delete_objects=True,
         )
-        tooling_account_cdk_principal = iam.ArnPrincipal(f'arn:aws:iam::{self.account}:role/cdk-hnb659fds-deploy-role-{self.account}-{self.region}')
-        self.artifact_bucket_key.grant_decrypt(tooling_account_cdk_principal)
-        self.artifact_bucket.grant_read(tooling_account_cdk_principal)
 
         if self.source == 'codestar_connection':
             source = CodePipelineSource.connection(
@@ -195,10 +192,6 @@ class PipelineStack(Stack):
         target_envs = target_envs or [{'envname': 'dev', 'account': self.account, 'region': self.region}]
 
         for target_env in target_envs:
-            target_env_cdk_principal = iam.ArnPrincipal(f'arn:aws:iam::{self.account}:role/cdk-hnb659fds-deploy-role-{self.account}-{self.region}')
-            self.artifact_bucket_key.grant_decrypt(target_env_cdk_principal)
-            self.artifact_bucket.grant_read(target_env_cdk_principal)
-
             self.pipeline_bucket.grant_read(iam.AccountPrincipal(target_env['account']))
 
             backend_stage = self.set_backend_stage(target_env, repository_name)


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Enhancement


### Detail
- Add bucket versioning to any bucket that does not have
    - Pipeline Artifacts Bucket
    - CloudFront FE Bucket
    - Cloudfront User Guide Bucket

### Relates
N/A

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
