### PR TITLE
Increase CodeBuild timeout for integration tests

### DIFF
--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -1,9 +1,8 @@
-import os
 import re
 import uuid
 from typing import List
 
-from aws_cdk import Stack, Tags, RemovalPolicy
+from aws_cdk import Stack, Tags, RemovalPolicy, Duration
 from aws_cdk import aws_codebuild as codebuild
 from aws_cdk import aws_codecommit as codecommit
 from aws_cdk import aws_ec2 as ec2
@@ -11,7 +10,6 @@ from aws_cdk import aws_iam as iam
 from aws_cdk import aws_kms as kms
 from aws_cdk import aws_s3 as s3
 from aws_cdk import pipelines
-from aws_cdk.aws_codebuild import BuildEnvironmentVariable, BuildEnvironmentVariableType
 from aws_cdk.pipelines import CodePipelineSource
 
 from .albfront_stage import AlbFrontStage
@@ -538,6 +536,7 @@ class PipelineStack(Stack):
                     role=self.baseline_codebuild_role.without_policy_updates(),
                     vpc=self.vpc,
                     security_groups=[self.codebuild_sg],
+                    timeout=Duration.hours(36),
                 ),
                 pipelines.CodeBuildStep(
                     id='UploadCodeToS3',


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
We are adding more and more integration tests to be executed in a CodeBuild stage of the CICD pipeline. There are cases in which the test execution might take longer than the CodeBuild default time of 1h. This PR increases the timeout period to 36hours

### Relates
- #1220 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
