### PR TITLE
Updating logic to check if expiration is changed on the UI 

### DIFF
--- a/frontend/src/modules/Shared/Shares/ShareEditForm.js
+++ b/frontend/src/modules/Shared/Shares/ShareEditForm.js
@@ -267,10 +267,13 @@ export const ShareEditForm = (props) => {
       await updateRequestPurpose();
     }
 
-    if (
-      (shareExpiration && shareExpiration !== 0) ||
-      share.nonExpirable !== requestNonExpirableShare
-    ) {
+    const isExpirationUpdated =
+      (shareExpiration &&
+        shareExpiration !== 0 &&
+        share.shareExpirationPeriod !== shareExpiration) ||
+      share.nonExpirable !== requestNonExpirableShare;
+
+    if (isExpirationUpdated) {
       await updateShareExpiration();
     }
     if (
@@ -289,10 +292,13 @@ export const ShareEditForm = (props) => {
       await updateRequestPurpose();
     }
 
-    if (
-      (shareExpiration && shareExpiration !== 0) ||
-      share.nonExpirable !== requestNonExpirableShare
-    ) {
+    const isExpirationUpdated =
+      (shareExpiration &&
+        shareExpiration !== 0 &&
+        share.shareExpirationPeriod !== shareExpiration) ||
+      share.nonExpirable !== requestNonExpirableShare;
+
+    if (isExpirationUpdated) {
       await updateShareExpiration();
     }
 
@@ -358,10 +364,14 @@ export const ShareEditForm = (props) => {
     if (requestPurpose !== share.requestPurpose) {
       await updateRequestPurpose();
     }
-    if (
-      (shareExpiration && shareExpiration !== 0) ||
-      share.nonExpirable !== requestNonExpirableShare
-    ) {
+
+    const isExpirationUpdated =
+      (shareExpiration &&
+        shareExpiration !== 0 &&
+        share.shareExpirationPeriod !== shareExpiration) ||
+      share.nonExpirable !== requestNonExpirableShare;
+
+    if (isExpirationUpdated) {
       await updateShareExpiration();
     }
     if (onApply) {


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail

1. While revoking a share an error message pop-ups as shown below 
 
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/bbc85627-fa8e-4a9f-a4af-2b37cc90bb81">

This is not intended. This doesn't change the expiration period but is calling the updateShareExpiration function. 

### Relates

https://github.com/data-dot-all/dataall/issues/1083

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
  - Is the input sanitized? 
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization? N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users? N/A
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
