### PR TITLE
Query result download

### DIFF
--- a/backend/dataall/base/aws/s3_client.py
+++ b/backend/dataall/base/aws/s3_client.py
@@ -3,6 +3,7 @@ from botocore.config import Config
 
 from botocore.exceptions import ClientError
 import logging
+from dataall.base.db.exceptions import AWSResourceNotFound
 
 log = logging.getLogger(__name__)
 
@@ -32,4 +33,32 @@ class S3_client:
             return presigned_url
         except ClientError as e:
             log.error(f'Failed to get presigned URL due to: {e}')
+            raise e
+
+    @staticmethod
+    def object_exists(region, bucket, key) -> bool:
+        try:
+            S3_client.client(region, None).head_object(Bucket=bucket, Key=key)
+            return True
+        except ClientError as e:
+            log.error(f'Failed to check object existence due to: {e}')
+            if e.response['Error']['Code'] == '404':
+                return False
+            raise AWSResourceNotFound('s3_object_exists', f'Object {key} not found in bucket {bucket}')
+
+    @staticmethod
+    def put_object(region, bucket, key, body):
+        try:
+            S3_client.client(region, None).put_object(Bucket=bucket, Key=key, Body=body)
+        except ClientError as e:
+            log.error(f'Failed to put object due to: {e}')
+            raise e
+
+    @staticmethod
+    def get_object(region, bucket, key):
+        try:
+            response = S3_client.client(region, None).get_object(Bucket=bucket, Key=key)
+            return response['Body'].read().decode('utf-8')
+        except ClientError as e:
+            log.error(f'Failed to get object due to: {e}')
             raise e

--- a/backend/dataall/modules/worksheets/api/input_types.py
+++ b/backend/dataall/modules/worksheets/api/input_types.py
@@ -75,3 +75,14 @@ WorksheetChartConfigInput = gql.InputType(
         gql.Argument(name='measures', type=gql.ArrayType(gql.Ref('WorksheetMeasureInput'))),
     ],
 )
+
+
+WorksheetQueryResultDownloadUrlInput = gql.InputType(
+    name='WorksheetQueryResultDownloadUrlInput',
+    arguments=[
+        gql.Argument(name='athenaQueryId', type=gql.NonNullableType(gql.String)),
+        gql.Argument(name='fileFormat', type=gql.NonNullableType(gql.String)),
+        gql.Argument(name='environmentUri', type=gql.NonNullableType(gql.String)),
+        gql.Argument(name='worksheetUri', type=gql.NonNullableType(gql.String)),
+    ],
+)

--- a/backend/dataall/modules/worksheets/api/mutations.py
+++ b/backend/dataall/modules/worksheets/api/mutations.py
@@ -1,5 +1,10 @@
 from dataall.base.api import gql
-from dataall.modules.worksheets.api.resolvers import create_worksheet, delete_worksheet, update_worksheet
+from dataall.modules.worksheets.api.resolvers import (
+    create_worksheet,
+    delete_worksheet,
+    update_worksheet,
+    create_athena_query_result_download_url,
+)
 
 
 createWorksheet = gql.MutationField(
@@ -26,4 +31,13 @@ deleteWorksheet = gql.MutationField(
         gql.Argument(name='worksheetUri', type=gql.NonNullableType(gql.String)),
     ],
     type=gql.Boolean,
+)
+
+createWorksheetQueryResultDownloadUrl = gql.MutationField(
+    name='createWorksheetQueryResultDownloadUrl',
+    resolver=create_athena_query_result_download_url,
+    args=[
+        gql.Argument(name='input', type=gql.Ref('WorksheetQueryResultDownloadUrlInput')),
+    ],
+    type=gql.Ref('WorksheetQueryResult'),
 )

--- a/backend/dataall/modules/worksheets/api/resolvers.py
+++ b/backend/dataall/modules/worksheets/api/resolvers.py
@@ -4,6 +4,7 @@ from dataall.modules.worksheets.db.worksheet_models import Worksheet
 from dataall.modules.worksheets.db.worksheet_repositories import WorksheetRepository
 from dataall.modules.worksheets.services.worksheet_service import WorksheetService
 from dataall.base.api.context import Context
+from dataall.modules.worksheets.services.worksheet_query_result_service import WorksheetQueryResultService
 
 
 def create_worksheet(context: Context, source, input: dict = None):
@@ -69,3 +70,10 @@ def run_sql_query(context: Context, source, environmentUri: str = None, workshee
 def delete_worksheet(context, source, worksheetUri: str = None):
     with context.engine.scoped_session() as session:
         return WorksheetService.delete_worksheet(session=session, uri=worksheetUri)
+
+
+def create_athena_query_result_download_url(context: Context, source, input: dict = None):
+    WorksheetQueryResultService.validate_input(input)
+
+    with context.engine.scoped_session() as session:
+        return WorksheetQueryResultService.download_sql_query_result(session=session, data=input)

--- a/backend/dataall/modules/worksheets/api/types.py
+++ b/backend/dataall/modules/worksheets/api/types.py
@@ -87,14 +87,16 @@ WorksheetQueryResult = gql.ObjectType(
     fields=[
         gql.Field(name='worksheetQueryResultUri', type=gql.ID),
         gql.Field(name='queryType', type=gql.NonNullableType(gql.String)),
-        gql.Field(name='sqlBody', type=gql.NonNullableType(gql.String)),
+        gql.Field(name='sqlBody', type=gql.String),
         gql.Field(name='AthenaQueryId', type=gql.NonNullableType(gql.String)),
         gql.Field(name='region', type=gql.NonNullableType(gql.String)),
         gql.Field(name='AwsAccountId', type=gql.NonNullableType(gql.String)),
-        gql.Field(name='AthenaOutputBucketName', type=gql.NonNullableType(gql.String)),
-        gql.Field(name='AthenaOutputKey', type=gql.NonNullableType(gql.String)),
-        gql.Field(name='timeElapsedInSecond', type=gql.NonNullableType(gql.Integer)),
+        gql.Field(name='ElapsedTimeInMs', type=gql.Integer),
         gql.Field(name='created', type=gql.NonNullableType(gql.String)),
+        gql.Field(name='downloadLink', type=gql.String),
+        gql.Field(name='OutputLocation', type=gql.String),
+        gql.Field(name='expiresIn', type=gql.AWSDateTime),
+        gql.Field(name='fileFormat', type=gql.String),
     ],
 )
 

--- a/backend/dataall/modules/worksheets/db/worksheet_models.py
+++ b/backend/dataall/modules/worksheets/db/worksheet_models.py
@@ -1,7 +1,7 @@
 import datetime
 import enum
 
-from sqlalchemy import Column, DateTime, Integer, Enum, String
+from sqlalchemy import Column, DateTime, Integer, Enum, String, BigInteger
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import query_expression
 
@@ -29,13 +29,21 @@ class WorksheetQueryResult(Base):
     __tablename__ = 'worksheet_query_result'
     worksheetUri = Column(String, nullable=False)
     AthenaQueryId = Column(String, primary_key=True)
-    status = Column(String, nullable=False)
+    status = Column(String, nullable=True)
     queryType = Column(Enum(QueryType), nullable=False, default=True)
-    sqlBody = Column(String, nullable=False)
+    sqlBody = Column(String, nullable=True)
     AwsAccountId = Column(String, nullable=False)
     region = Column(String, nullable=False)
     OutputLocation = Column(String, nullable=False)
     error = Column(String, nullable=True)
     ElapsedTimeInMs = Column(Integer, nullable=True)
-    DataScannedInBytes = Column(Integer, nullable=True)
+    DataScannedInBytes = Column(BigInteger, nullable=True)
     created = Column(DateTime, default=datetime.datetime.now)
+
+    downloadLink = Column(String, nullable=True)
+    expiresIn = Column(DateTime, nullable=True)
+    updated = Column(DateTime, nullable=False, onupdate=datetime.datetime.utcnow, default=datetime.datetime.utcnow)
+    fileFormat = Column(String, nullable=True)
+
+    def is_download_link_expired(self):
+        return self.expiresIn is None or self.expiresIn <= datetime.datetime.utcnow()

--- a/backend/dataall/modules/worksheets/db/worksheet_repositories.py
+++ b/backend/dataall/modules/worksheets/db/worksheet_repositories.py
@@ -53,3 +53,17 @@ class WorksheetRepository(EnvironmentResource):
             page=data.get('page', WorksheetRepository._DEFAULT_PAGE),
             page_size=data.get('pageSize', WorksheetRepository._DEFAULT_PAGE_SIZE),
         ).to_dict()
+
+    @staticmethod
+    def find_query_result_by_format(
+        session, worksheet_uri: str, athena_query_id: str, file_format: str
+    ) -> WorksheetQueryResult:
+        return (
+            session.query(WorksheetQueryResult)
+            .filter(
+                WorksheetQueryResult.worksheetUri == worksheet_uri,
+                WorksheetQueryResult.AthenaQueryId == athena_query_id,
+                WorksheetQueryResult.fileFormat == file_format,
+            )
+            .first()
+        )

--- a/backend/dataall/modules/worksheets/services/worksheet_query_result_service.py
+++ b/backend/dataall/modules/worksheets/services/worksheet_query_result_service.py
@@ -1,0 +1,139 @@
+import csv
+import io
+import os
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+from openpyxl import Workbook
+
+from dataall.base.aws.s3_client import S3_client
+from dataall.base.db import exceptions
+from dataall.core.environment.services.environment_service import EnvironmentService
+from dataall.modules.worksheets.db.worksheet_models import WorksheetQueryResult
+from dataall.modules.worksheets.db.worksheet_repositories import WorksheetRepository
+from dataall.modules.worksheets.services.worksheet_service import WorksheetService
+
+if TYPE_CHECKING:
+    try:
+        from sqlalchemy.orm import Session
+        from mypy_boto3_s3.client import S3Client
+    except ImportError:
+        print('skipping type checks as stubs are not installed')
+        S3Client = None
+        Session = None
+
+
+class WorksheetQueryResultService:
+    SupportedFormats = {'csv', 'xlsx'}
+
+    @staticmethod
+    def validate_input(data):
+        if not data:
+            raise exceptions.InvalidInput('data', data, 'input is required')
+        if not data.get('athenaQueryId'):
+            raise exceptions.RequiredParameter('athenaQueryId')
+        if not data.get('fileFormat'):
+            raise exceptions.RequiredParameter('fileFormat')
+        if data.get('fileFormat', '').lower() not in WorksheetQueryResultService.SupportedFormats:
+            raise exceptions.InvalidInput(
+                'fileFormat', data.get('fileFormat'), ', '.join(WorksheetQueryResultService.SupportedFormats)
+            )
+
+    @staticmethod
+    def get_output_bucket(session: 'Session', environment_uri: str) -> str:
+        environment = EnvironmentService.get_environment_by_uri(session, environment_uri)
+        bucket = environment.EnvironmentDefaultBucketName
+        return bucket
+
+    @staticmethod
+    def create_query_result(
+        environment_bucket: str, athena_workgroup: str, worksheet_uri: str, region: str, aws_account_id: str, data: dict
+    ) -> WorksheetQueryResult:
+        sql_query_result = WorksheetQueryResult(
+            worksheetUri=worksheet_uri,
+            AthenaQueryId=data.get('athenaQueryId'),
+            fileFormat=data.get('fileFormat'),
+            OutputLocation=f's3://{environment_bucket}/athenaqueries/{athena_workgroup}/',
+            region=region,
+            AwsAccountId=aws_account_id,
+            queryType='data',
+        )
+        return sql_query_result
+
+    @staticmethod
+    def get_file_key(
+        workgroup: str, query_id: str, file_format: str = 'csv', athena_queries_dir: str = 'athenaqueries'
+    ) -> str:
+        return f'{athena_queries_dir}/{workgroup}/{query_id}.{file_format}'
+
+    @staticmethod
+    def convert_csv_to_xlsx(csv_data) -> io.BytesIO:
+        wb = Workbook()
+        ws = wb.active
+        csv_reader = csv.reader(csv_data.splitlines())
+        for row in csv_reader:
+            ws.append(row)
+
+        excel_buffer = io.BytesIO()
+        wb.save(excel_buffer)
+        excel_buffer.seek(0)
+        return excel_buffer
+
+    @staticmethod
+    def handle_xlsx_format(output_bucket: str, file_key: str) -> bool:
+        aws_region_name = os.getenv('AWS_REGION_NAME', 'eu-west-1')
+        file_name, _ = file_key.split('.')
+        csv_data = S3_client.get_object(region=aws_region_name, bucket=output_bucket, key=f'{file_name}.csv')
+        excel_buffer = WorksheetQueryResultService.convert_csv_to_xlsx(csv_data)
+        S3_client.put_object(region=aws_region_name, bucket=output_bucket, key=file_key, body=excel_buffer)
+        return True
+
+    @staticmethod
+    def download_sql_query_result(session: 'Session', data: dict = None):
+        # # default timeout for the download link is 2 hours(in minutes)
+        default_timeout = os.getenv('QUERY_RESULT_TIMEOUT_MINUTES', 120)
+
+        environment = EnvironmentService.get_environment_by_uri(session, data.get('environmentUri'))
+        worksheet = WorksheetService.get_worksheet_by_uri(session, data.get('worksheetUri'))
+        env_group = EnvironmentService.get_environment_group(
+            session, worksheet.SamlAdminGroupName, environment.environmentUri
+        )
+        output_file_key = WorksheetQueryResultService.get_file_key(
+            env_group.environmentAthenaWorkGroup, data.get('athenaQueryId'), data.get('fileFormat')
+        )
+        sql_query_result = WorksheetRepository.find_query_result_by_format(
+            session, data.get('worksheetUri'), data.get('athenaQueryId'), data.get('fileFormat')
+        )
+        if data.get('fileFormat') == 'xlsx':
+            is_job_failed = WorksheetQueryResultService.handle_xlsx_format(
+                environment.EnvironmentDefaultBucketName, output_file_key
+            )
+            if is_job_failed:
+                raise ValueError('Error while preparing the xlsx file')
+
+        if not sql_query_result:
+            sql_query_result = WorksheetQueryResultService.create_query_result(
+                environment.EnvironmentDefaultBucketName,
+                env_group.environmentAthenaWorkGroup,
+                worksheet.worksheetUri,
+                environment.region,
+                environment.AwsAccountId,
+                data,
+            )
+        S3_client.object_exists(
+            region=environment.region, bucket=environment.EnvironmentDefaultBucketName, key=output_file_key
+        )
+        if sql_query_result.is_download_link_expired():
+            url = S3_client.get_presigned_url(
+                region=environment.region,
+                bucket=environment.EnvironmentDefaultBucketName,
+                key=output_file_key,
+                expire_minutes=default_timeout,
+            )
+            sql_query_result.downloadLink = url
+            sql_query_result.expiresIn = datetime.utcnow() + timedelta(seconds=default_timeout)
+
+        session.add(sql_query_result)
+        session.commit()
+
+        return sql_query_result

--- a/backend/migrations/versions/d1d6da1b2d67_add_columns_worksheet_query_result_model.py
+++ b/backend/migrations/versions/d1d6da1b2d67_add_columns_worksheet_query_result_model.py
@@ -1,0 +1,37 @@
+"""add_columns_worksheet_query_result_model
+
+Revision ID: d1d6da1b2d67
+Revises: d274e756f0ae
+Create Date: 2024-09-10 14:34:31.492186
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd1d6da1b2d67'
+down_revision = 'd274e756f0ae'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('worksheet_query_result', 'status', nullable=True)
+    op.alter_column('worksheet_query_result', 'sqlBody', nullable=True)
+    op.alter_column('worksheet_query_result', 'DataScannedInBytes', type_=sa.BigInteger(), nullable=True)
+    op.add_column('worksheet_query_result', sa.Column('downloadLink', sa.String(), nullable=True))
+    op.add_column('worksheet_query_result', sa.Column('expiresIn', sa.DateTime(), nullable=True))
+    op.add_column('worksheet_query_result', sa.Column('updated', sa.DateTime(), nullable=False))
+    op.add_column('worksheet_query_result', sa.Column('fileFormat', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('worksheet_query_result', 'fileFormat')
+    op.drop_column('worksheet_query_result', 'updated')
+    op.drop_column('worksheet_query_result', 'expiresIn')
+    op.drop_column('worksheet_query_result', 'downloadLink')
+    op.alter_column('worksheet_query_result', 'DataScannedInBytes', type_=sa.Integer(), nullable=True)
+    op.alter_column('worksheet_query_result', 'sqlBody', nullable=False)
+    op.alter_column('worksheet_query_result', 'status', nullable=False)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ requests_aws4auth==1.1.1
 sqlalchemy==1.3.24
 starlette==0.36.3
 alembic==1.13.1
+openpyxl==3.1.5

--- a/frontend/src/modules/Worksheets/components/WorksheetResult.js
+++ b/frontend/src/modules/Worksheets/components/WorksheetResult.js
@@ -12,12 +12,66 @@ import {
   TableRow
 } from '@mui/material';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { FaBars } from 'react-icons/fa';
 import * as ReactIf from 'react-if';
 import { Scrollbar } from 'design';
 
-export const WorksheetResult = ({ results, loading }) => {
+import Stack from '@mui/material/Stack';
+import Radio from '@mui/material/Radio';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import { Download } from '@mui/icons-material';
+import { LoadingButton } from '@mui/lab';
+import {
+  useClient
+} from 'services';
+import {
+  createWorksheetQueryResultDownloadUrl
+} from '../services';
+import { SET_ERROR, useDispatch } from 'globalErrors';
+
+export const WorksheetResult = ({ results, loading, currentEnv, athenaQueryId, worksheetUri }) => {
+  const [runningDownloadQuery, setRunningDownloadQuery] = useState(false);
+  const [fileType, setFileType] = useState('csv');
+  const client = useClient();
+  const dispatch = useDispatch();
+
+  const handleChange = (event) => {
+    setFileType(event.target.value);
+  };
+
+  const downloadFile = useCallback(async () => {
+    try {
+      setRunningDownloadQuery(true);
+      const response = await client.query(
+        createWorksheetQueryResultDownloadUrl({
+          fileFormat: fileType,
+          environmentUri: currentEnv.environmentUri,
+          athenaQueryId: athenaQueryId,
+          worksheetUri: worksheetUri
+        })
+      );
+
+      if (!response.errors) {
+        const link = document.createElement('a');
+        link.href = response.data.createWorksheetQueryResultDownloadUrl.downloadLink;
+        // Append to html link element page
+        document.body.appendChild(link);
+        // Start download
+        link.click();
+        // Clean up and remove the link
+        link.parentNode.removeChild(link);
+      } else {
+        dispatch({ type: SET_ERROR, error: response.errors[0].message });
+      }
+    } catch (e) {
+      dispatch({ type: SET_ERROR, error: e.message });
+    } finally {
+      setRunningDownloadQuery(false);
+    }
+  }, [client, dispatch, currentEnv, athenaQueryId, fileType])
+
   if (loading) {
     return <CircularProgress />;
   }
@@ -33,6 +87,34 @@ export const WorksheetResult = ({ results, loading }) => {
               <Box>
                 <FaBars /> Query Results
               </Box>
+            }
+            action={
+              <>
+                <Stack direction="row" spacing={2}>
+                  <RadioGroup
+                    row
+                    aria-labelledby="demo-row-radio-buttons-group-label"
+                    name="row-radio-buttons-group"
+                    value={fileType}
+                    onChange={handleChange}
+                  >
+                    <FormControlLabel value="csv" control={<Radio />} label="CSV" />
+                    <FormControlLabel value="xlsx" control={<Radio />} label="XLSX" />
+                  </RadioGroup>
+
+                  <LoadingButton
+                    loading={runningDownloadQuery}
+                    color="primary"
+                    onClick={downloadFile}
+                    startIcon={<Download fontSize="small" />}
+                    sx={{ m: 1 }}
+                    variant="contained"
+                  >
+                    Download
+                  </LoadingButton>
+                </Stack>
+
+              </>
             }
           />
           <Divider />

--- a/frontend/src/modules/Worksheets/services/createWorksheetQueryResultDownloadUrl.js
+++ b/frontend/src/modules/Worksheets/services/createWorksheetQueryResultDownloadUrl.js
@@ -1,0 +1,40 @@
+import { gql } from 'apollo-boost';
+
+export const createWorksheetQueryResultDownloadUrl = ({
+  fileFormat,
+  environmentUri,
+  athenaQueryId,
+  worksheetUri
+}) => ({
+  variables: {
+    fileFormat,
+    environmentUri,
+    athenaQueryId,
+    worksheetUri
+  },
+  query: gql`
+    mutation CreateWorksheetQueryResultDownloadUrl(
+      $fileFormat: String!
+      $environmentUri: String!
+      $athenaQueryId: String!
+      $worksheetUri: String!
+    ) {
+      createWorksheetQueryResultDownloadUrl(
+        input: {
+          fileFormat: $fileFormat
+          environmentUri: $environmentUri
+          athenaQueryId: $athenaQueryId
+          worksheetUri: $worksheetUri
+        }
+      ) {
+        downloadLink
+        AthenaQueryId
+        expiresIn
+        fileFormat
+        OutputLocation
+      }
+    }
+  `
+});
+
+

--- a/frontend/src/modules/Worksheets/services/index.js
+++ b/frontend/src/modules/Worksheets/services/index.js
@@ -6,3 +6,4 @@ export * from './listWorksheets';
 export * from './runAthenaSqlQuery';
 export * from './updateWorksheet';
 export * from './listSharedDatasetTableColumns';
+export * from './createWorksheetQueryResultDownloadUrl';

--- a/frontend/src/modules/Worksheets/services/runAthenaSqlQuery.js
+++ b/frontend/src/modules/Worksheets/services/runAthenaSqlQuery.js
@@ -21,6 +21,7 @@ export const runAthenaSqlQuery = ({
         worksheetUri: $worksheetUri
         sqlQuery: $sqlQuery
       ) {
+        AthenaQueryId
         rows {
           cells {
             columnName

--- a/frontend/src/modules/Worksheets/views/WorksheetView.js
+++ b/frontend/src/modules/Worksheets/views/WorksheetView.js
@@ -76,6 +76,8 @@ const WorksheetView = () => {
   const [runningQuery, setRunningQuery] = useState(false);
   const [isEditWorksheetOpen, setIsEditWorksheetOpen] = useState(null);
   const [isDeleteWorksheetOpen, setIsDeleteWorksheetOpen] = useState(null);
+  const [athenaQueryId, setAthenaQueryId] = useState();
+
   const handleEditWorksheetModalOpen = () => {
     setIsEditWorksheetOpen(true);
   };
@@ -291,6 +293,7 @@ const WorksheetView = () => {
       );
       if (!response.errors) {
         const athenaResults = response.data.runAthenaSqlQuery;
+        setAthenaQueryId(response.data.runAthenaSqlQuery.AthenaQueryId);
         setResults({
           rows: athenaResults.rows.map((c, index) => ({ ...c, id: index })),
           columns: athenaResults.columns.map((c, index) => ({
@@ -636,7 +639,13 @@ const WorksheetView = () => {
           </Box>
           <Divider />
           <Box sx={{ p: 2 }}>
-            <WorksheetResult results={results} loading={runningQuery} />
+            <WorksheetResult
+              results={results}
+              loading={runningQuery}
+              currentEnv={currentEnv}
+              athenaQueryId={athenaQueryId}
+              worksheetUri={worksheet.worksheetUri}
+            />
           </Box>
         </Box>
       </Box>

--- a/tests/modules/worksheets/test_worksheet.py
+++ b/tests/modules/worksheets/test_worksheet.py
@@ -1,5 +1,9 @@
 import pytest
 
+from unittest.mock import MagicMock
+
+from future.backports.datetime import datetime
+
 from dataall.modules.worksheets.api.resolvers import WorksheetRole
 
 
@@ -28,6 +32,38 @@ def worksheet(client, tenant, group):
         tags=[group.name],
     )
     return response.data.createWorksheet
+
+
+@pytest.fixture(scope='module', autouse=True)
+def mock_s3_client(module_mocker):
+    s3_client = MagicMock()
+    module_mocker.patch('dataall.modules.worksheets.services.worksheet_query_result_service.S3_client', s3_client)
+
+    # s3_client.client.return_value = s3_client
+
+    s3_client().object_exists.return_value = True
+    s3_client().put_object.return_value = None
+    s3_client().get_object.return_value = '123,123,123'
+    s3_client.get_presigned_url.return_value = 'https://s3.amazonaws.com/file/123.csv'
+    yield s3_client
+
+
+# @pytest.fixture(scope='module')
+# def dataset1(
+#     module_mocker,
+#     org_fixture: Organization,
+#     env_fixture: Environment,
+#     dataset: typing.Callable,
+#     group,
+# ) -> S3Dataset:
+#     kms_client = MagicMock()
+#     module_mocker.patch('dataall.modules.s3_datasets.services.dataset_service.KmsClient', kms_client)
+#
+#     kms_client().get_key_id.return_value = mocked_key_id
+#
+#     d = dataset(org=org_fixture, env=env_fixture, name='dataset1', owner=env_fixture.owner, group=group.name)
+#     print(d)
+#     yield d
 
 
 def test_create_worksheet(client, worksheet):
@@ -145,3 +181,36 @@ def test_update_worksheet(client, worksheet, group):
     )
 
     assert response.data.updateWorksheet.label == 'change label'
+
+
+def test_create_query_download_url(client, worksheet, env_fixture):
+    response = client.query(
+        """
+        mutation CreateWorksheetQueryResultDownloadUrl($input:WorksheetQueryResultDownloadUrlInput){
+            createWorksheetQueryResultDownloadUrl(input:$input){
+                queryType
+                sqlBody
+                AthenaQueryId
+                region
+                AwsAccountId
+                ElapsedTimeInMs
+                created
+                downloadLink
+                OutputLocation
+                expiresIn
+                fileFormat
+            }
+        }
+        """,
+        input={
+            'worksheetUri': worksheet.worksheetUri,
+            'athenaQueryId': '123',
+            'fileFormat': 'csv',
+            'environmentUri': env_fixture.environmentUri,
+        },
+    )
+
+    expires_in = datetime.strptime(response.data.createWorksheetQueryResultDownloadUrl.created, '%Y-%m-%d %H:%M:%S.%f')
+    assert response.data.createWorksheetQueryResultDownloadUrl.downloadLink is not None
+    assert response.data.createWorksheetQueryResultDownloadUrl.fileFormat == 'csv'
+    assert expires_in > datetime.utcnow()


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature


### Detail
- teamA in environmentA has a team IAM role roleA and a workgroup wgA created by data.all
- in Worksheets data.all uses that team IAM role and workgroup to run the query
- the results are stored in the workgroup S3 location = environment S3 bucket/ athenaQueries / teamAFolder/
- Create the presigned url for the csv present under the s3 location with 2 hours of expiration
- Storing presigned urls generated in database so that can be reused in future


### Relates
- https://github.com/data-dot-all/dataall/issues/293
- https://github.com/data-dot-all/dataall/issues/360
- https://github.com/data-dot-all/dataall/issues/1342

### Testcase

- [x]  tests/modules/worksheets/test_worksheet.py/test_create_query_download_url

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? - Yes
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries? - Yes
  - Have you ensured no `eval` or similar functions are used? - Yes
- Does this PR introduce any functionality or component that requires authorization? - Yes
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms? - Yes
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? - N/A
  - Do you use a standard proven implementations? - Yes
  - Are the used keys controlled by the customer? Where are they stored? - N/A
- Are you introducing any new policies/roles/users? 
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
