### PR TITLE
Add Stacks and KeyValueTags integration tests

### DIFF
--- a/tests_new/integration_tests/core/stack/conftest.py
+++ b/tests_new/integration_tests/core/stack/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+
+from integration_tests.core.stack.queries import update_key_value_tags
+
+
+@pytest.fixture(scope='function')
+def environment_tags_1(client1, session_env1, session_id):
+    tags = None
+    try:
+        tags = update_key_value_tags(
+            client1,
+            input={
+                'targetUri': session_env1.environmentUri,
+                'targetType': 'environment',
+                'tags': [
+                    {'key': 'key1', 'value': session_id, 'cascade': False},
+                    {'key': 'key2', 'value': session_id, 'cascade': True},
+                ],
+            },
+        )
+        yield tags
+    finally:
+        if tags:
+            update_key_value_tags(
+                client1,
+                input={
+                    'targetUri': session_env1.environmentUri,
+                    'targetType': 'environment',
+                    'tags': [],
+                },
+            )

--- a/tests_new/integration_tests/core/stack/queries.py
+++ b/tests_new/integration_tests/core/stack/queries.py
@@ -56,3 +56,68 @@ def get_stack(client, env_uri, stack_uri, target_uri, target_type):
     }
     response = client.query(query=query)
     return response.data.getStack
+
+
+def get_stack_logs(client, target_uri, target_type):
+    query = {
+        'operationName': 'getStackLogs',
+        'variables': {
+            'targetUri': target_uri,
+            'targetType': target_type,
+        },
+        'query': """
+                query getStackLogs($targetUri: String!, $targetType: String!) {
+                  getStackLogs(targetUri: $targetUri, targetType: $targetType) {
+                    message
+                    timestamp
+                  }
+                }
+                """,
+    }
+    response = client.query(query=query)
+    return response.data.getStackLogs
+
+
+def list_key_value_tags(client, target_uri, target_type):
+    query = {
+        'operationName': 'listKeyValueTags',
+        'variables': {
+            'targetUri': target_uri,
+            'targetType': target_type,
+        },
+        'query': """
+                query listKeyValueTags($targetUri: String!, $targetType: String!) {
+                  listKeyValueTags(targetUri: $targetUri, targetType: $targetType) {
+                    tagUri
+                    targetUri
+                    targetType
+                    key
+                    value
+                    cascade
+                  }
+                }
+                """,
+    }
+    response = client.query(query=query)
+    return response.data.listKeyValueTags
+
+
+def update_key_value_tags(client, input):
+    query = {
+        'operationName': 'updateKeyValueTags',
+        'variables': {'input': input},
+        'query': """
+                mutation updateKeyValueTags($input: UpdateKeyValueTagsInput!) {
+                  updateKeyValueTags(input: $input) {
+                    tagUri
+                    targetUri
+                    targetType
+                    key
+                    value
+                    cascade
+                  }
+                }
+                """,
+    }
+    response = client.query(query=query)
+    return response.data.updateKeyValueTags

--- a/tests_new/integration_tests/core/stack/test_stack.py
+++ b/tests_new/integration_tests/core/stack/test_stack.py
@@ -1,0 +1,102 @@
+from assertpy import assert_that
+
+from integration_tests.core.stack.queries import get_stack_logs, list_key_value_tags, update_key_value_tags
+from integration_tests.errors import GqlError
+
+import pytest
+
+
+##  test_update_stack and test_get_stack are not needed as they are
+##  tested in each module that uses stacks (e.g. integration_tests.core.environment.test_environment.test_persistent_env_update)
+
+
+def test_get_env_stack_logs(client1, session_env1):
+    response = get_stack_logs(client1, target_uri=session_env1.environmentUri, target_type='environment')
+    assert_that(response).is_not_empty()
+
+
+def test_get_env_stack_logs_unauthorized(client2, session_env1):
+    assert_that(get_stack_logs).raises(GqlError).when_called_with(
+        client=client2,
+        target_uri=session_env1.environmentUri,
+        target_type='environment',
+    ).contains(
+        'UnauthorizedOperation',
+        'GET_ENVIRONMENT',
+        session_env1.environmentUri,
+    )
+
+
+def test_update_list_key_value_tags_add_tag(client1, session_env1, session_id):
+    # Test add tag on environment without tags
+    response = update_key_value_tags(
+        client1,
+        input={
+            'targetUri': session_env1.environmentUri,
+            'targetType': 'environment',
+            'tags': [
+                {'key': 'key1', 'value': session_id, 'cascade': False},
+                {'key': 'key2', 'value': session_id, 'cascade': True},
+            ],
+        },
+    )
+    assert_that(len(response)).is_equal_to(2)
+    assert_that(response[0]).contains_entry(key='key1', value=session_id, cascade=False)
+    assert_that(response[1]).contains_entry(key='key2', value=session_id, cascade=True)
+    # Test list tags after add
+    response = list_key_value_tags(client1, target_uri=session_env1.environmentUri, target_type='environment')
+    assert_that(len(response)).is_equal_to(2)
+    assert_that(response[0]).contains_entry(key='key1', value=session_id, cascade=False)
+    assert_that(response[1]).contains_entry(key='key2', value=session_id, cascade=True)
+
+
+def test_update_list_key_value_tags_add_tag_unauthorized(client2, session_env1, session_id):
+    assert_that(update_key_value_tags).raises(GqlError).when_called_with(
+        client=client2,
+        input={
+            'targetUri': session_env1.environmentUri,
+            'targetType': 'environment',
+            'tags': [
+                {'key': 'key1U', 'value': session_id, 'cascade': False},
+                {'key': 'key2U', 'value': session_id, 'cascade': True},
+            ],
+        },
+    ).contains(
+        'UnauthorizedOperation',
+        'UPDATE_ENVIRONMENT',
+        session_env1.environmentUri,
+    )
+
+
+def test_update_list_key_value_tags_add_tag_invalid_input(client1, session_env1, session_id):
+    assert_that(update_key_value_tags).raises(GqlError).when_called_with(
+        client=client1,
+        input={
+            'targetUri': session_env1.environmentUri,
+            'targetType': 'environment',
+            'tags': [
+                {'key': 'keyDuplicated', 'value': session_id, 'cascade': False},
+                {'key': 'keyDuplicated', 'value': session_id, 'cascade': True},
+            ],
+        },
+    ).contains(
+        'UnauthorizedOperation',
+        'SAVE_KEY_VALUE_TAGS',
+        'Duplicate tag keys found',
+    )
+
+
+def test_update_list_key_value_tags_delete_tags(client1, session_env1, session_id):
+    # Test delete tag
+    response = update_key_value_tags(
+        client1,
+        input={
+            'targetUri': session_env1.environmentUri,
+            'targetType': 'environment',
+            'tags': [],
+        },
+    )
+    assert_that(response).is_equal_to([])
+    # Test list tags after delete
+    response = list_key_value_tags(client1, target_uri=session_env1.environmentUri, target_type='environment')
+    assert_that(response).is_equal_to([])


### PR DESCRIPTION
### Feature or Bugfix
Implement tests for Stacks and KeyValueTags api calls (inside core/stacks) as part of https://github.com/data-dot-all/dataall/issues/1220

### Detail

### Relates
- #1220 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
