### PR TITLE
Increase access point creation buffer time and fix bug in share cross account if condition

### DIFF
--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
@@ -40,7 +40,8 @@ from dataall.modules.shares_base.services.sharing_service import ShareData
 
 logger = logging.getLogger(__name__)
 ACCESS_POINT_CREATION_TIME = 30
-ACCESS_POINT_CREATION_RETRIES = 5
+ACCESS_POINT_CREATION_RETRIES = 10
+ACCESS_POINT_BACKOFF_COEFFICIENT = 1.1  # every time increase retry delay by 10%
 
 
 class S3AccessPointShareManager:
@@ -447,12 +448,14 @@ class S3AccessPointShareManager:
             access_point_arn = s3_client.create_bucket_access_point(self.bucket_name, self.access_point_name)
             # Access point creation is slow
             retries = 1
+            sleep_coeff = 1
             while (
                 not s3_client.get_bucket_access_point_arn(self.access_point_name)
                 and retries < ACCESS_POINT_CREATION_RETRIES
             ):
                 logger.info('Waiting 30s for access point creation to complete..')
-                time.sleep(ACCESS_POINT_CREATION_TIME)
+                time.sleep(ACCESS_POINT_CREATION_TIME * sleep_coeff)
+                sleep_coeff = sleep_coeff * ACCESS_POINT_BACKOFF_COEFFICIENT
                 retries += 1
         existing_policy = s3_client.get_access_point_policy(self.access_point_name)
         # requester will use this role to access resources

--- a/backend/dataall/modules/s3_datasets_shares/services/share_processors/glue_table_share_processor.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_processors/glue_table_share_processor.py
@@ -153,7 +153,7 @@ class ProcessLakeFormationShare(SharesProcessorInterface):
                     manager.grant_principals_permissions_to_source_table(table, share_item, share_item_filter)
                     if manager.cross_account:
                         retries = 0
-                        retry_share_table = False
+                        retry_share_table = True
                         while retry_share_table and retries < 1:
                             (
                                 retry_share_table,


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Condition for RAM invitation acceptance is True (we have to try at least once)
- Increase number of retries for access point check + back off time is 10% more every time

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
