### PR TITLE
Add VPC network integration tests + fix tags bug in networks

### DIFF
--- a/backend/dataall/core/vpc/api/__init__.py
+++ b/backend/dataall/core/vpc/api/__init__.py
@@ -1,3 +1,3 @@
-from . import input_types, queries, mutations, resolvers, types
+from . import input_types, mutations, resolvers, types
 
-__all__ = ['resolvers', 'types', 'input_types', 'queries', 'mutations']
+__all__ = ['resolvers', 'types', 'input_types', 'mutations']

--- a/backend/dataall/core/vpc/db/vpc_repositories.py
+++ b/backend/dataall/core/vpc/db/vpc_repositories.py
@@ -48,6 +48,7 @@ class VpcRepository:
                 or_(
                     Vpc.label.ilike('%' + term + '%'),
                     Vpc.VpcId.ilike('%' + term + '%'),
+                    Vpc.tags.contains(f'{{{term}}}'),
                 )
             )
         return query.order_by(Vpc.label)

--- a/backend/dataall/core/vpc/services/vpc_service.py
+++ b/backend/dataall/core/vpc/services/vpc_service.py
@@ -44,6 +44,7 @@ class VpcService:
                 owner=username,
                 label=data['label'],
                 name=data['label'],
+                tags=data.get('tags', []),
                 default=data.get('default', False),
             )
             VpcRepository.save_network(session, vpc)

--- a/tests_new/integration_tests/core/vpc/conftest.py
+++ b/tests_new/integration_tests/core/vpc/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+from integration_tests.core.vpc.queries import create_network, delete_network
+
+
+@pytest.fixture(scope='function')
+def network1(client1, group1, session_env1, session_id):
+    network = create_network(
+        client1,
+        name='testVpc1',
+        vpc_id='someId',
+        public_subnets=['testSubnet1'],
+        environment_uri=session_env1.environmentUri,
+        group=group1,
+        tags=[session_id],
+    )
+    yield network
+    delete_network(client1, vpc_uri=network.vpcUri)

--- a/tests_new/integration_tests/core/vpc/conftest.py
+++ b/tests_new/integration_tests/core/vpc/conftest.py
@@ -4,14 +4,18 @@ from integration_tests.core.vpc.queries import create_network, delete_network
 
 @pytest.fixture(scope='function')
 def network1(client1, group1, session_env1, session_id):
-    network = create_network(
-        client1,
-        name='testVpc1',
-        vpc_id='someId',
-        public_subnets=['testSubnet1'],
-        environment_uri=session_env1.environmentUri,
-        group=group1,
-        tags=[session_id],
-    )
-    yield network
-    delete_network(client1, vpc_uri=network.vpcUri)
+    network = None
+    try:
+        network = create_network(
+            client1,
+            name='testVpc1',
+            vpc_id='someId',
+            public_subnets=['testSubnet1'],
+            environment_uri=session_env1.environmentUri,
+            group=group1,
+            tags=[session_id],
+        )
+        yield network
+    finally:
+        if network:
+            delete_network(client1, vpc_uri=network.vpcUri)

--- a/tests_new/integration_tests/core/vpc/queries.py
+++ b/tests_new/integration_tests/core/vpc/queries.py
@@ -81,4 +81,4 @@ def list_environment_networks(client, environment_uri, term=''):
                 """,
     }
     response = client.query(query=query)
-    return response.data.listEnvironmentNetworks.items
+    return response.data.listEnvironmentNetworks

--- a/tests_new/integration_tests/core/vpc/queries.py
+++ b/tests_new/integration_tests/core/vpc/queries.py
@@ -1,0 +1,84 @@
+# TODO: This file will be replaced by using the SDK directly
+
+NETWORK_TYPE = """
+VpcId
+vpcUri
+environment {
+  environmentUri
+  label
+  AwsAccountId
+  region
+}
+label
+owner
+name
+description
+tags
+AwsAccountId
+region
+privateSubnetIds
+publicSubnetIds
+SamlGroupName
+default
+"""
+
+
+def create_network(client, name, environment_uri, group, vpc_id, public_subnets=[], private_subnets=[], tags=[]):
+    query = {
+        'operationName': 'createNetwork',
+        'variables': {
+            'input': {
+                'label': name,
+                'environmentUri': environment_uri,
+                'vpcId': vpc_id,
+                'publicSubnetIds': public_subnets,
+                'privateSubnetIds': private_subnets,
+                'SamlGroupName': group,
+                'description': 'Created for integration testing',
+                'tags': tags,
+            }
+        },
+        'query': f"""mutation createNetwork($input: NewVpcInput!) {{
+                      createNetwork(input: $input) {{
+                        {NETWORK_TYPE}
+                      }}
+                    }}
+                """,
+    }
+    response = client.query(query=query)
+    return response.data.createNetwork
+
+
+def delete_network(client, vpc_uri):
+    query = {
+        'operationName': 'deleteNetwork',
+        'variables': {'vpcUri': vpc_uri},
+        'query': """mutation deleteNetwork($vpcUri: String!) {
+                  deleteNetwork(vpcUri: $vpcUri)
+                }
+                """,
+    }
+    response = client.query(query=query)
+    return response.data.deleteNetwork
+
+
+def list_environment_networks(client, environment_uri, term=''):
+    query = {
+        'operationName': 'listEnvironmentNetworks',
+        'variables': {'environmentUri': environment_uri, 'filter': {'term': term}},
+        'query': f"""query listEnvironmentNetworks($environmentUri: String!, $filter: VpcFilter!) {{
+                  listEnvironmentNetworks(environmentUri: $environmentUri, filter: $filter) {{
+                    count
+                    page
+                    pages
+                    hasNext
+                    hasPrevious
+                    nodes {{
+                      {NETWORK_TYPE}
+                    }}
+                  }}
+                }}
+                """,
+    }
+    response = client.query(query=query)
+    return response.data.listEnvironmentNetworks.items

--- a/tests_new/integration_tests/core/vpc/test_vpc.py
+++ b/tests_new/integration_tests/core/vpc/test_vpc.py
@@ -5,7 +5,7 @@ from integration_tests.core.vpc.queries import create_network, delete_network, l
 
 
 def test_create_network(network1, session_id):
-    assert_that(network1).contains_entry(label='testVpc1', tags=[session_id], vpcId='someId')
+    assert_that(network1).contains_entry(label='testVpc1', tags=[session_id], VpcId='someId')
     assert_that(network1.vpcUri).is_not_none()
 
 
@@ -58,7 +58,7 @@ def test_delete_network_unauthorized(client2, network1):
 def test_list_environment_networks(client1, network1, session_env1, session_id):
     response = list_environment_networks(client1, environment_uri=session_env1.environmentUri, term=session_id)
     assert_that(response.count).is_equal_to(1)
-    assert_that(response.nodes[0]).contains_entry(label='testVpc1', vpcId='someId', vpcUri=network1.vpcUri)
+    assert_that(response.nodes[0]).contains_entry(label='testVpc1', VpcId='someId', vpcUri=network1.vpcUri)
 
 
 def test_list_environment_networks_unauthorized(client2, network1, session_env1):

--- a/tests_new/integration_tests/core/vpc/test_vpc.py
+++ b/tests_new/integration_tests/core/vpc/test_vpc.py
@@ -1,0 +1,68 @@
+from assertpy import assert_that
+
+from integration_tests.errors import GqlError
+from integration_tests.core.vpc.queries import create_network, delete_network, list_environment_networks
+
+
+def test_create_network(network1, session_id):
+    assert_that(network1).contains_entry(label='testVpc1', tags=[session_id], vpcId='someId')
+    assert_that(network1.vpcUri).is_not_none()
+
+
+def test_create_network_unauthorized(client2, group2, session_env1, session_id):
+    assert_that(create_network).raises(GqlError).when_called_with(
+        client2,
+        name='testVpc2',
+        vpc_id='someId2',
+        public_subnets=['testSubnet2'],
+        environment_uri=session_env1.environmentUri,
+        group=group2,
+        tags=[session_id],
+    ).contains('UnauthorizedOperation', 'CREATE_NETWORK', session_env1.environmentUri)
+
+
+def test_create_duplicated_network_invalid(client1, group1, session_env1, session_id, network1):
+    assert_that(create_network).raises(GqlError).when_called_with(
+        client1,
+        name='testVpcDuplicated2',
+        vpc_id='someId',
+        public_subnets=['testSubnet1'],
+        environment_uri=session_env1.environmentUri,
+        group=group1,
+        tags=[session_id],
+    ).contains('ResourceAlreadyExists', 'CREATE_NETWORK', 'someId')
+
+
+def test_delete_network(client1, group1, session_env1, session_id):
+    response = create_network(
+        client1,
+        name='testVpcDelete',
+        vpc_id='someIdDelete',
+        public_subnets=['testSubnet1'],
+        environment_uri=session_env1.environmentUri,
+        group=group1,
+        tags=[session_id],
+    )
+    assert_that(response.vpcUri).is_not_none()
+    response = delete_network(client1, vpc_uri=response.vpcUri)
+    assert_that(response).is_true()
+
+
+def test_delete_network_unauthorized(client2, network1):
+    assert_that(delete_network).raises(GqlError).when_called_with(
+        client2,
+        vpc_uri=network1.vpcUri,
+    ).contains('UnauthorizedOperation', 'DELETE_NETWORK', network1.vpcUri)
+
+
+def test_list_environment_networks(client1, network1, session_env1, session_id):
+    response = list_environment_networks(client1, environment_uri=session_env1.environmentUri, term=session_id)
+    assert_that(response.count).is_equal_to(1)
+    assert_that(response.nodes[0]).contains_entry(label='testVpc1', vpcId='someId', vpcUri=network1.vpcUri)
+
+
+def test_list_environment_networks_unauthorized(client2, network1, session_env1):
+    assert_that(list_environment_networks).raises(GqlError).when_called_with(
+        client2,
+        environment_uri=session_env1.environmentUri,
+    ).contains('UnauthorizedOperation', 'LIST_ENVIRONMENT_NETWORKS', session_env1.environmentUri)


### PR DESCRIPTION
### Feature or Bugfix
- Feature: testing
- Bugfix

### Detail
Implement tests for Networksapi calls (inside core/vpc + listEnvironmentNetworks) as part of https://github.com/data-dot-all/dataall/issues/1220

++ It also fixes a small bug on networks - tags were not correctly saved in the database!

### Relates
- #1220 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
