### PR TITLE
Add Redshift connection tooltips and info + restrict to DATA_USER connections for import Redshift Dataset

### DIFF
--- a/frontend/src/modules/Environments/components/EnvironmentRedshiftConnectionAddForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentRedshiftConnectionAddForm.js
@@ -256,11 +256,11 @@ export const EnvironmentRedshiftConnectionAddForm = (props) => {
                         variant="outlined"
                       >
                         {connectionOptions.map((r) => (
-                          <Tooltip title={r.info} placement="right-end">
-                            <MenuItem key={r.value} value={r.value}>
-                              {r.label}
-                            </MenuItem>
-                          </Tooltip>
+                          <MenuItem key={r.value} value={r.value}>
+                            <Tooltip title={r.info} placement="right-end">
+                              <div>{r.label}</div>
+                            </Tooltip>
+                          </MenuItem>
                         ))}
                       </TextField>
                     </CardContent>

--- a/frontend/src/modules/Environments/components/EnvironmentRedshiftConnectionAddForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentRedshiftConnectionAddForm.js
@@ -1,6 +1,8 @@
 import { GroupAddOutlined } from '@mui/icons-material';
 import { LoadingButton } from '@mui/lab';
 import {
+  Alert,
+  AlertTitle,
   Autocomplete,
   Box,
   CardContent,
@@ -10,6 +12,7 @@ import {
   Grid,
   MenuItem,
   TextField,
+  Tooltip,
   Typography
 } from '@mui/material';
 import { Formik } from 'formik';
@@ -30,8 +33,16 @@ export const EnvironmentRedshiftConnectionAddForm = (props) => {
   let { groupOptions, loadingGroups } = useFetchGroups(environment);
 
   const connectionOptions = [
-    { value: 'DATA_USER', label: 'Data User' },
-    { value: 'ADMIN', label: 'Admin' }
+    {
+      value: 'DATA_USER',
+      label: 'Data User',
+      info: 'Data users should have Redshift READ permissions to tables that will be imported in data.all'
+    },
+    {
+      value: 'ADMIN',
+      label: 'Admin',
+      info: 'Admin users should have enough permissions to MANAGE DATASHARES in the namespace.'
+    }
   ];
 
   const clusterOptions = [
@@ -104,9 +115,25 @@ export const EnvironmentRedshiftConnectionAddForm = (props) => {
           Add a Redshift connection to environment {environment.label}
         </Typography>
         <Typography align="center" color="textSecondary" variant="subtitle2">
-          The Redshift connection is owned by the selected Team. It is used to
-          import Redshift Datasets.
+          The Redshift connection contains the metadata to connect to Redshift
+          with a particular user.
         </Typography>
+      </Box>
+      <Box sx={{ p: 3 }}>
+        <Box sx={{ pl: 5, pr: 5 }}>
+          <Alert
+            severity="info"
+            variant="outlined"
+            sx={{ whiteSpace: 'pre-line' }}
+          >
+            <AlertTitle>Types of Connections</AlertTitle>- DATA USER: This
+            connection will be used by the data producers to import data. It is
+            required to import a Redshift Dataset.{'\n'}- ADMIN: This connection
+            will be used by data.all backend to manage data sharing. To create a
+            share request between 2 namespaces, an ADMIN connection in the
+            source and in the target namespaces are required.
+          </Alert>
+        </Box>
         <Box sx={{ p: 3 }}>
           <Formik
             initialValues={{
@@ -177,29 +204,6 @@ export const EnvironmentRedshiftConnectionAddForm = (props) => {
                     />
                   </CardContent>
                   <CardContent>
-                    <TextField
-                      fullWidth
-                      error={Boolean(
-                        touched.connectionType && errors.connectionType
-                      )}
-                      helperText={
-                        touched.connectionType && errors.connectionType
-                      }
-                      label="Connection type"
-                      name="connectionType"
-                      onChange={handleChange}
-                      select
-                      value={values.connectionType}
-                      variant="outlined"
-                    >
-                      {connectionOptions.map((r) => (
-                        <MenuItem key={r.value} value={r.value}>
-                          {r.label}
-                        </MenuItem>
-                      ))}
-                    </TextField>
-                  </CardContent>
-                  <CardContent>
                     <Autocomplete
                       id="SamlAdminGroupName"
                       disablePortal
@@ -235,6 +239,31 @@ export const EnvironmentRedshiftConnectionAddForm = (props) => {
                 </Box>
                 <Grid container spacing={3}>
                   <Grid item lg={6} md={6} xs={12}>
+                    <CardContent>
+                      <TextField
+                        fullWidth
+                        error={Boolean(
+                          touched.connectionType && errors.connectionType
+                        )}
+                        helperText={
+                          touched.connectionType && errors.connectionType
+                        }
+                        label="Connection type"
+                        name="connectionType"
+                        onChange={handleChange}
+                        select
+                        value={values.connectionType}
+                        variant="outlined"
+                      >
+                        {connectionOptions.map((r) => (
+                          <Tooltip title={r.info} placement="right-end">
+                            <MenuItem key={r.value} value={r.value}>
+                              {r.label}
+                            </MenuItem>
+                          </Tooltip>
+                        ))}
+                      </TextField>
+                    </CardContent>
                     <CardContent>
                       <TextField
                         fullWidth

--- a/frontend/src/modules/Environments/components/EnvironmentRedshiftConnectionAddForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentRedshiftConnectionAddForm.js
@@ -1,8 +1,8 @@
 import { GroupAddOutlined } from '@mui/icons-material';
+import InfoIcon from '@mui/icons-material/Info';
 import { LoadingButton } from '@mui/lab';
+import { styled } from '@mui/material/styles';
 import {
-  Alert,
-  AlertTitle,
   Autocomplete,
   Box,
   CardContent,
@@ -13,6 +13,8 @@ import {
   MenuItem,
   TextField,
   Tooltip,
+  TooltipProps,
+  tooltipClasses,
   Typography
 } from '@mui/material';
 import { Formik } from 'formik';
@@ -30,18 +32,26 @@ export const EnvironmentRedshiftConnectionAddForm = (props) => {
   const dispatch = useDispatch();
   const client = useClient();
 
+  const CustomWidthTooltip = styled(({ className, ...props }: TooltipProps) => (
+    <Tooltip {...props} classes={{ popper: className }} />
+  ))({
+    [`& .${tooltipClasses.tooltip}`]: {
+      maxWidth: 500
+    }
+  });
+
   let { groupOptions, loadingGroups } = useFetchGroups(environment);
 
   const connectionOptions = [
     {
       value: 'DATA_USER',
       label: 'Data User',
-      info: 'Data users should have Redshift READ permissions to tables that will be imported in data.all'
+      info: 'Data users connections are required to import Redshift Datasets. The Redshift user for the connection should have Redshift READ permissions to the tables that will be imported in data.all'
     },
     {
       value: 'ADMIN',
       label: 'Admin',
-      info: 'Admin users should have enough permissions to MANAGE DATASHARES in the namespace.'
+      info: 'Admin connections are used by data.all backend to manage data sharing requests. To create a share request between 2 namespaces, an ADMIN connection in the source and in the target namespaces are required. The Redshift user for the connection should have enough permissions to MANAGE DATASHARES in the namespace.'
     }
   ];
 
@@ -120,300 +130,282 @@ export const EnvironmentRedshiftConnectionAddForm = (props) => {
         </Typography>
       </Box>
       <Box sx={{ p: 3 }}>
-        <Box sx={{ pl: 5, pr: 5 }}>
-          <Alert
-            severity="info"
-            variant="outlined"
-            sx={{ whiteSpace: 'pre-line' }}
-          >
-            <AlertTitle>Types of Connections</AlertTitle>- DATA USER: This
-            connection will be used by the data producers to import data. It is
-            required to import a Redshift Dataset.{'\n'}- ADMIN: This connection
-            will be used by data.all backend to manage data sharing. To create a
-            share request between 2 namespaces, an ADMIN connection in the
-            source and in the target namespaces are required.
-          </Alert>
-        </Box>
-        <Box sx={{ p: 3 }}>
-          <Formik
-            initialValues={{
-              connectionName: '',
-              SamlAdminGroupName: '',
-              redshiftType: '',
-              clusterId: '',
-              nameSpaceId: '',
-              workgroup: '',
-              database: '',
-              redshiftUser: '',
-              secretArn: '',
-              connectionType: ''
-            }}
-            validationSchema={Yup.object().shape({
-              connectionName: Yup.string()
-                .max(255)
-                .required('*Connection Name is required'),
-              SamlAdminGroupName: Yup.string()
-                .max(255)
-                .required('*Owners Team is required'),
-              redshiftType: Yup.string()
-                .max(255)
-                .required('*Redshift type is required'),
-              clusterId: Yup.string().max(255),
-              nameSpaceId: Yup.string().max(255),
-              workgroup: Yup.string().max(255),
-              database: Yup.string().max(255).required('*Database is required'),
-              redshiftUser: Yup.string().max(255),
-              secretArn: Yup.string().max(255),
-              connectionType: Yup.string()
-                .max(255)
-                .required('*ConnectionType is required')
-            })}
-            onSubmit={async (
-              values,
-              { setErrors, setStatus, setSubmitting }
-            ) => {
-              await submit(values, setStatus, setSubmitting, setErrors);
-            }}
-          >
-            {({
-              errors,
-              handleChange,
-              handleSubmit,
-              isSubmitting,
-              setFieldValue,
-              touched,
-              values
-            }) => (
-              <form onSubmit={handleSubmit}>
+        <Formik
+          initialValues={{
+            connectionName: '',
+            SamlAdminGroupName: '',
+            redshiftType: '',
+            clusterId: '',
+            nameSpaceId: '',
+            workgroup: '',
+            database: '',
+            redshiftUser: '',
+            secretArn: '',
+            connectionType: ''
+          }}
+          validationSchema={Yup.object().shape({
+            connectionName: Yup.string()
+              .max(255)
+              .required('*Connection Name is required'),
+            SamlAdminGroupName: Yup.string()
+              .max(255)
+              .required('*Owners Team is required'),
+            redshiftType: Yup.string()
+              .max(255)
+              .required('*Redshift type is required'),
+            clusterId: Yup.string().max(255),
+            nameSpaceId: Yup.string().max(255),
+            workgroup: Yup.string().max(255),
+            database: Yup.string().max(255).required('*Database is required'),
+            redshiftUser: Yup.string().max(255),
+            secretArn: Yup.string().max(255),
+            connectionType: Yup.string()
+              .max(255)
+              .required('*ConnectionType is required')
+          })}
+          onSubmit={async (values, { setErrors, setStatus, setSubmitting }) => {
+            await submit(values, setStatus, setSubmitting, setErrors);
+          }}
+        >
+          {({
+            errors,
+            handleChange,
+            handleSubmit,
+            isSubmitting,
+            setFieldValue,
+            touched,
+            values
+          }) => (
+            <form onSubmit={handleSubmit}>
+              <Box>
+                <CardContent>
+                  <TextField
+                    error={Boolean(
+                      touched.connectionName && errors.connectionName
+                    )}
+                    fullWidth
+                    helperText={touched.connectionName && errors.connectionName}
+                    label="connection Name"
+                    placeholder="Name to identify your Connection in data.all"
+                    name="connectionName"
+                    onChange={handleChange}
+                    value={values.connectionName}
+                    variant="outlined"
+                  />
+                </CardContent>
+                <CardContent>
+                  <Autocomplete
+                    id="SamlAdminGroupName"
+                    disablePortal
+                    options={groupOptions.map((option) => option)}
+                    noOptionsText="No teams found for this environment"
+                    onChange={(event, value) => {
+                      if (value && value.value) {
+                        setFieldValue('SamlAdminGroupName', value.value);
+                      } else {
+                        setFieldValue('SamlAdminGroupName', '');
+                      }
+                    }}
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        fullWidth
+                        error={Boolean(
+                          touched.SamlAdminGroupName &&
+                            errors.SamlAdminGroupName
+                        )}
+                        helperText={
+                          touched.SamlAdminGroupName &&
+                          errors.SamlAdminGroupName
+                        }
+                        label="Team"
+                        name="SamlAdminGroupName"
+                        variant="outlined"
+                        value={values.SamlAdminGroupName}
+                      />
+                    )}
+                  />
+                </CardContent>
+              </Box>
+              <Grid container spacing={3}>
+                <Grid item lg={6} md={6} xs={12}>
+                  <CardContent>
+                    <TextField
+                      fullWidth
+                      error={Boolean(
+                        touched.connectionType && errors.connectionType
+                      )}
+                      helperText={
+                        touched.connectionType && errors.connectionType
+                      }
+                      label="Connection type"
+                      name="connectionType"
+                      onChange={handleChange}
+                      select
+                      value={values.connectionType}
+                      variant="outlined"
+                    >
+                      {connectionOptions.map((r) => (
+                        <MenuItem key={r.value} value={r.value}>
+                          <CustomWidthTooltip
+                            title={r.info}
+                            placement="right-end"
+                          >
+                            <Box display="flex" alignItems="center">
+                              <div>{r.label}</div>
+                              <InfoIcon
+                                fontSize="small"
+                                style={{ marginLeft: '8px' }}
+                              />
+                            </Box>
+                          </CustomWidthTooltip>
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  </CardContent>
+                  <CardContent>
+                    <TextField
+                      fullWidth
+                      error={Boolean(
+                        touched.redshiftType && errors.redshiftType
+                      )}
+                      helperText={touched.redshiftType && errors.redshiftType}
+                      label="Redshift type"
+                      name="redshiftType"
+                      onChange={handleChange}
+                      select
+                      value={values.redshiftType}
+                      variant="outlined"
+                    >
+                      {clusterOptions.map((r) => (
+                        <MenuItem key={r.value} value={r.value}>
+                          {r.label}
+                        </MenuItem>
+                      ))}
+                    </TextField>
+                  </CardContent>
+                </Grid>
+                <Grid item lg={6} md={6} xs={12}>
+                  {values.redshiftType === 'serverless' && (
+                    <Box>
+                      <CardContent>
+                        <TextField
+                          error={Boolean(
+                            touched.nameSpaceId && errors.nameSpaceId
+                          )}
+                          fullWidth
+                          helperText={touched.nameSpaceId && errors.nameSpaceId}
+                          label="Namespace Id"
+                          placeholder="Redshift Serverless Namespace Id"
+                          name="nameSpaceId"
+                          onChange={handleChange}
+                          value={values.nameSpaceId}
+                          variant="outlined"
+                        />
+                      </CardContent>
+                      <CardContent>
+                        <TextField
+                          error={Boolean(touched.workgroup && errors.workgroup)}
+                          fullWidth
+                          helperText={touched.workgroup && errors.workgroup}
+                          label="Workgroup"
+                          placeholder="Redshift Serverless Workgroup"
+                          name="workgroup"
+                          onChange={handleChange}
+                          value={values.workgroup}
+                          variant="outlined"
+                        />
+                      </CardContent>
+                    </Box>
+                  )}
+                  {values.redshiftType === 'cluster' && (
+                    <Box>
+                      <CardContent>
+                        <TextField
+                          error={Boolean(touched.clusterId && errors.clusterId)}
+                          fullWidth
+                          helperText={touched.clusterId && errors.clusterId}
+                          label="Cluster Id"
+                          placeholder="Redshift Provisioned Cluster Id"
+                          name="clusterId"
+                          onChange={handleChange}
+                          value={values.clusterId}
+                          variant="outlined"
+                        />
+                      </CardContent>
+                    </Box>
+                  )}
+                </Grid>
+              </Grid>
+              <CardContent>
+                <TextField
+                  error={Boolean(touched.database && errors.database)}
+                  fullWidth
+                  helperText={touched.database && errors.database}
+                  label="database"
+                  placeholder="Redshift database you will be connecting to"
+                  name="database"
+                  onChange={handleChange}
+                  value={values.database}
+                  variant="outlined"
+                />
+              </CardContent>
+              <CardContent>
+                <Typography color="textPrimary" variant="body2">
+                  You can choose to provide a Redshift user (for Provisioned
+                  Cluster) or a Secrets Manager secret.
+                </Typography>
+              </CardContent>
+              {values.redshiftType !== 'serverless' && (
                 <Box>
                   <CardContent>
                     <TextField
                       error={Boolean(
-                        touched.connectionName && errors.connectionName
+                        touched.redshiftUser && errors.redshiftUser
                       )}
                       fullWidth
-                      helperText={
-                        touched.connectionName && errors.connectionName
-                      }
-                      label="connection Name"
-                      placeholder="Name to identify your Connection in data.all"
-                      name="connectionName"
+                      helperText={touched.redshiftUser && errors.redshiftUser}
+                      label="Redshift User"
+                      placeholder="Redshift User"
+                      name="redshiftUser"
                       onChange={handleChange}
-                      value={values.connectionName}
+                      value={values.redshiftUser}
                       variant="outlined"
                     />
                   </CardContent>
-                  <CardContent>
-                    <Autocomplete
-                      id="SamlAdminGroupName"
-                      disablePortal
-                      options={groupOptions.map((option) => option)}
-                      noOptionsText="No teams found for this environment"
-                      onChange={(event, value) => {
-                        if (value && value.value) {
-                          setFieldValue('SamlAdminGroupName', value.value);
-                        } else {
-                          setFieldValue('SamlAdminGroupName', '');
-                        }
-                      }}
-                      renderInput={(params) => (
-                        <TextField
-                          {...params}
-                          fullWidth
-                          error={Boolean(
-                            touched.SamlAdminGroupName &&
-                              errors.SamlAdminGroupName
-                          )}
-                          helperText={
-                            touched.SamlAdminGroupName &&
-                            errors.SamlAdminGroupName
-                          }
-                          label="Team"
-                          name="SamlAdminGroupName"
-                          variant="outlined"
-                          value={values.SamlAdminGroupName}
-                        />
-                      )}
-                    />
-                  </CardContent>
+                  <Divider>OR</Divider>
                 </Box>
-                <Grid container spacing={3}>
-                  <Grid item lg={6} md={6} xs={12}>
-                    <CardContent>
-                      <TextField
-                        fullWidth
-                        error={Boolean(
-                          touched.connectionType && errors.connectionType
-                        )}
-                        helperText={
-                          touched.connectionType && errors.connectionType
-                        }
-                        label="Connection type"
-                        name="connectionType"
-                        onChange={handleChange}
-                        select
-                        value={values.connectionType}
-                        variant="outlined"
-                      >
-                        {connectionOptions.map((r) => (
-                          <MenuItem key={r.value} value={r.value}>
-                            <Tooltip title={r.info} placement="right-end">
-                              <div>{r.label}</div>
-                            </Tooltip>
-                          </MenuItem>
-                        ))}
-                      </TextField>
-                    </CardContent>
-                    <CardContent>
-                      <TextField
-                        fullWidth
-                        error={Boolean(
-                          touched.redshiftType && errors.redshiftType
-                        )}
-                        helperText={touched.redshiftType && errors.redshiftType}
-                        label="Redshift type"
-                        name="redshiftType"
-                        onChange={handleChange}
-                        select
-                        value={values.redshiftType}
-                        variant="outlined"
-                      >
-                        {clusterOptions.map((r) => (
-                          <MenuItem key={r.value} value={r.value}>
-                            {r.label}
-                          </MenuItem>
-                        ))}
-                      </TextField>
-                    </CardContent>
-                  </Grid>
-                  <Grid item lg={6} md={6} xs={12}>
-                    {values.redshiftType === 'serverless' && (
-                      <Box>
-                        <CardContent>
-                          <TextField
-                            error={Boolean(
-                              touched.nameSpaceId && errors.nameSpaceId
-                            )}
-                            fullWidth
-                            helperText={
-                              touched.nameSpaceId && errors.nameSpaceId
-                            }
-                            label="Namespace Id"
-                            placeholder="Redshift Serverless Namespace Id"
-                            name="nameSpaceId"
-                            onChange={handleChange}
-                            value={values.nameSpaceId}
-                            variant="outlined"
-                          />
-                        </CardContent>
-                        <CardContent>
-                          <TextField
-                            error={Boolean(
-                              touched.workgroup && errors.workgroup
-                            )}
-                            fullWidth
-                            helperText={touched.workgroup && errors.workgroup}
-                            label="Workgroup"
-                            placeholder="Redshift Serverless Workgroup"
-                            name="workgroup"
-                            onChange={handleChange}
-                            value={values.workgroup}
-                            variant="outlined"
-                          />
-                        </CardContent>
-                      </Box>
-                    )}
-                    {values.redshiftType === 'cluster' && (
-                      <Box>
-                        <CardContent>
-                          <TextField
-                            error={Boolean(
-                              touched.clusterId && errors.clusterId
-                            )}
-                            fullWidth
-                            helperText={touched.clusterId && errors.clusterId}
-                            label="Cluster Id"
-                            placeholder="Redshift Provisioned Cluster Id"
-                            name="clusterId"
-                            onChange={handleChange}
-                            value={values.clusterId}
-                            variant="outlined"
-                          />
-                        </CardContent>
-                      </Box>
-                    )}
-                  </Grid>
-                </Grid>
+              )}
+              <CardContent>
+                <TextField
+                  error={Boolean(touched.secretArn && errors.secretArn)}
+                  fullWidth
+                  helperText={touched.secretArn && errors.secretArn}
+                  label="Secrets Manager Secret Arn"
+                  placeholder="Secrets Manager Secret Arn with credentials to Redshift"
+                  name="secretArn"
+                  onChange={handleChange}
+                  value={values.secretArn}
+                  variant="outlined"
+                />
+              </CardContent>
+              <Box>
                 <CardContent>
-                  <TextField
-                    error={Boolean(touched.database && errors.database)}
+                  <LoadingButton
                     fullWidth
-                    helperText={touched.database && errors.database}
-                    label="database"
-                    placeholder="Redshift database you will be connecting to"
-                    name="database"
-                    onChange={handleChange}
-                    value={values.database}
-                    variant="outlined"
-                  />
+                    startIcon={<GroupAddOutlined fontSize="small" />}
+                    color="primary"
+                    disabled={isSubmitting}
+                    type="submit"
+                    variant="contained"
+                  >
+                    Add Connection
+                  </LoadingButton>
                 </CardContent>
-                <CardContent>
-                  <Typography color="textPrimary" variant="body2">
-                    You can choose to provide a Redshift user (for Provisioned
-                    Cluster) or a Secrets Manager secret.
-                  </Typography>
-                </CardContent>
-                {values.redshiftType !== 'serverless' && (
-                  <Box>
-                    <CardContent>
-                      <TextField
-                        error={Boolean(
-                          touched.redshiftUser && errors.redshiftUser
-                        )}
-                        fullWidth
-                        helperText={touched.redshiftUser && errors.redshiftUser}
-                        label="Redshift User"
-                        placeholder="Redshift User"
-                        name="redshiftUser"
-                        onChange={handleChange}
-                        value={values.redshiftUser}
-                        variant="outlined"
-                      />
-                    </CardContent>
-                    <Divider>OR</Divider>
-                  </Box>
-                )}
-                <CardContent>
-                  <TextField
-                    error={Boolean(touched.secretArn && errors.secretArn)}
-                    fullWidth
-                    helperText={touched.secretArn && errors.secretArn}
-                    label="Secrets Manager Secret Arn"
-                    placeholder="Secrets Manager Secret Arn with credentials to Redshift"
-                    name="secretArn"
-                    onChange={handleChange}
-                    value={values.secretArn}
-                    variant="outlined"
-                  />
-                </CardContent>
-                <Box>
-                  <CardContent>
-                    <LoadingButton
-                      fullWidth
-                      startIcon={<GroupAddOutlined fontSize="small" />}
-                      color="primary"
-                      disabled={isSubmitting}
-                      type="submit"
-                      variant="contained"
-                    >
-                      Add Connection
-                    </LoadingButton>
-                  </CardContent>
-                </Box>
-              </form>
-            )}
-          </Formik>
-        </Box>
+              </Box>
+            </form>
+          )}
+        </Formik>
       </Box>
     </Dialog>
   );

--- a/frontend/src/modules/Redshift_Datasets/views/RSDatasetImportForm.js
+++ b/frontend/src/modules/Redshift_Datasets/views/RSDatasetImportForm.js
@@ -125,7 +125,8 @@ const RSDatasetImportForm = (props) => {
           filter: {
             ...Defaults.selectListFilter,
             environmentUri: environmentUri,
-            groupUri: groupUri
+            groupUri: groupUri,
+            connectionType: 'DATA_USER'
           }
         })
       );


### PR DESCRIPTION
### Feature or Bugfix
- Feature: enhancement

### Detail
This feature is an enhancement suggested by Redshift experts on #955, which is well explained in #1562. 
This PR:
- adds more info and tooltips that explain details about Redshift Connections on the UI
- restricts the type of connection that can be used to import a dataset: ONLY DATA_USER CONNECTIONS CAN BE USED TO IMPORT DATASETS. It implements this logic both in the frontend and backend

FIRST VERSION:
<img width="1126" alt="image" src="https://github.com/user-attachments/assets/14bb5a85-9868-4e8d-b7aa-1c84feb2a681">

UPDATED:
![image](https://github.com/user-attachments/assets/1b199dba-d6ee-471f-9cd7-d74e70b8dd4b)


### Relates
#1562 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
