### PR TITLE
fix setting maintenance modes enum

### DIFF
--- a/frontend/src/modules/Maintenance/components/MaintenanceViewer.js
+++ b/frontend/src/modules/Maintenance/components/MaintenanceViewer.js
@@ -320,7 +320,7 @@ export const MaintenanceViewer = () => {
     if (maintenanceModesEnum['MaintenanceModes'].length > 0) {
       setMaintenanceModes(
         maintenanceModesEnum['MaintenanceModes'].map((elem) => {
-          return { label: elem.value, value: elem.name };
+          return { label: elem.value, value: elem.value };
         })
       );
     } else {


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- Fix small bug introduced in https://github.com/data-dot-all/dataall/pull/1435 when fetching enums specifically for `maintenanceModes`


### Relates


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
