### PR TITLE
warn users when evaluating a non-readonly share request

### DIFF
--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -3,6 +3,7 @@ import {
   BlockOutlined,
   CheckCircleOutlined,
   DeleteOutlined,
+  Warning,
   RefreshRounded
 } from '@mui/icons-material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
@@ -18,6 +19,9 @@ import {
   Chip,
   Container,
   Divider,
+  Dialog,
+  DialogTitle,
+  DialogActions,
   Grid,
   Link,
   List,
@@ -28,6 +32,7 @@ import {
   TableHead,
   TableRow,
   Tooltip,
+  Stack,
   Typography
 } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -81,6 +86,8 @@ import { ShareSubmitModal } from '../components/ShareSubmitModal';
 import { UpdateExtensionReason } from '../components/ShareUpdateExtension';
 import CancelIcon from '@mui/icons-material/Close';
 
+const isReadOnlyShare = (share) => share.permissions.every((p) => p === 'Read');
+
 function ShareViewHeader(props) {
   const {
     share,
@@ -94,6 +101,7 @@ function ShareViewHeader(props) {
     loading
   } = props;
   const [accepting, setAccepting] = useState(false);
+  const [acceptingWarning, setAcceptingWarning] = useState(false);
   const [rejecting, setRejecting] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [cancellingExtension, setCancellingExtension] = useState(false);
@@ -359,7 +367,11 @@ function ShareViewHeader(props) {
                         color="success"
                         startIcon={<CheckCircleOutlined />}
                         sx={{ m: 1 }}
-                        onClick={handleApproveShare}
+                        onClick={async () =>
+                          isReadOnlyShare(share)
+                            ? handleApproveShare()
+                            : setAcceptingWarning(true)
+                        }
                         ref={anchorRef}
                         type="button"
                         variant="outlined"
@@ -377,6 +389,31 @@ function ShareViewHeader(props) {
                       >
                         Reject
                       </LoadingButton>
+                      <Dialog
+                        open={acceptingWarning}
+                        onClose={async () => setAcceptingWarning(false)}
+                      >
+                        <DialogTitle>
+                          Write or Modify permissions requested, do you want to
+                          proceed with the Approval?
+                        </DialogTitle>
+                        <DialogActions>
+                          <Button
+                            onClick={async () => {
+                              setAcceptingWarning(false);
+                              handleApproveShare();
+                            }}
+                          >
+                            Yes
+                          </Button>
+                          <Button
+                            onClick={async () => setAcceptingWarning(false)}
+                            autoFocus
+                          >
+                            No
+                          </Button>
+                        </DialogActions>
+                      </Dialog>
                     </>
                   )}
                   {share.status === 'Submitted_For_Extension' && (
@@ -1355,12 +1392,26 @@ const ShareView = () => {
                               padding: 2
                             }}
                           >
-                            <Typography
-                              color="textSecondary"
-                              variant="subtitle2"
+                            <Stack
+                              spacing={1}
+                              alignItems="center"
+                              direction="row"
                             >
-                              Permissions
-                            </Typography>
+                              <Typography
+                                color="textSecondary"
+                                variant="subtitle2"
+                              >
+                                Permissions
+                              </Typography>
+                              {!isReadOnlyShare(share) && (
+                                <Tooltip
+                                  title="non-readonly share request"
+                                  arrow
+                                >
+                                  <Warning color="warning" />
+                                </Tooltip>
+                              )}
+                            </Stack>
                             <Typography color="textPrimary" variant="body2">
                               {share.permissions.map((perm) => (
                                 <Chip label={perm} sx={{ marginRight: 1 }} />


### PR DESCRIPTION

### Feature or Bugfix
- Feature

### Detail
If and only if the request permissions include Write/Modify
* when then approver clicks on `Approve` they get a confirmation pop-up
  ![image](https://github.com/user-attachments/assets/11f9d27f-e518-481e-9a13-87dafd18b9d2)
* In the shareview page a warning triangle ⚠️ is added next to the `Permissions` row
  ![image](https://github.com/user-attachments/assets/9b07e0d3-e92f-498d-9415-533d3e2db1be)





### Relates
Solves #1566 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
