### PR TITLE
Upgrade rollup to non-vulnerable version 2.79.1 -> 3.29.5

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30451,14 +30451,16 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,7 +99,8 @@
     "fast-xml-parser": "4.4.1",
     "path-to-regexp": "0.1.10",
     "body-parser": "^1.20.3",
-    "send": "0.19.0"
+    "send": "0.19.0",
+    "rollup": "3.29.5"
   },
   "resolutions": {
     "react-redux": "^7.2.6",
@@ -118,7 +119,8 @@
     "fast-xml-parser": "4.4.1",
     "path-to-regexp": "0.1.10",
     "body-parser": "^1.20.3",
-    "send": "0.19.0"
+    "send": "0.19.0",
+    "rollup": "3.29.5"
   },
   "devDependencies": {
     "env-cmd": "^10.1.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -13295,10 +13295,10 @@ rollup-plugin-terser@^7.0.0:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-"rollup@^1.20.0 || ^2.0.0", rollup@^1.20.0||^2.0.0, rollup@^2.0.0, rollup@^2.43.1:
-  version "2.79.1"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz"
-  integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
+rollup@3.29.5:
+  version "3.29.5"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz"
+  integrity sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
### Feature or Bugfix
- Upgrade dependency

### Detail
Security vulnerability found in `rollup`  (well explained [here](https://github.com/advisories/GHSA-gcx4-mw62-g8wm)).
This PR upgrades the package to a non-vulnerable version

### Relates
- https://github.com/advisories/GHSA-gcx4-mw62-g8wm

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
