### PR TITLE
don't import dataall from integtest

### DIFF
--- a/tests_new/integration_tests/aws_clients/iam.py
+++ b/tests_new/integration_tests/aws_clients/iam.py
@@ -4,8 +4,6 @@ import os
 
 import boto3
 
-from dataall.base.aws.parameter_store import ParameterStoreManager
-
 log = logging.getLogger(__name__)
 
 

--- a/tests_new/integration_tests/modules/share_base/conftest.py
+++ b/tests_new/integration_tests/modules/share_base/conftest.py
@@ -2,7 +2,6 @@ import pytest
 
 from tests_new.integration_tests.aws_clients.iam import IAMClient
 from tests_new.integration_tests.core.environment.queries import add_consumption_role, remove_consumption_role
-from dataall.modules.shares_base.services.shares_enums import PrincipalType
 from tests_new.integration_tests.modules.share_base.queries import (
     create_share_object,
     delete_share_object,
@@ -10,7 +9,6 @@ from tests_new.integration_tests.modules.share_base.queries import (
     revoke_share_items,
 )
 from tests_new.integration_tests.modules.share_base.utils import check_share_ready
-from dataall.modules.shares_base.services.shares_enums import ShareItemStatus
 
 test_cons_role_name = 'dataall-test-ShareTestConsumptionRole'
 
@@ -18,10 +16,10 @@ test_cons_role_name = 'dataall-test-ShareTestConsumptionRole'
 def revoke_all_possible(client, shareUri):
     share = get_share_object(client, shareUri, {'isShared': True})
     statuses_can_delete = [
-        ShareItemStatus.PendingApproval.value,
-        ShareItemStatus.Revoke_Succeeded.value,
-        ShareItemStatus.Share_Failed.value,
-        ShareItemStatus.Share_Rejected.value,
+        'PendingApproval',
+        'Revoke_Succeeded',
+        'Share_Failed',
+        'Share_Rejected',
     ]
 
     shareItemUris = [item.shareItemUri for item in share['items'].nodes if item.status not in statuses_can_delete]
@@ -71,7 +69,7 @@ def session_share_1(
         environmentUri=session_cross_acc_env_1.environmentUri,
         groupUri=group5,
         principalId=group5,
-        principalType=PrincipalType.Group.value,
+        principalType='Group',
         requestPurpose='test create share object',
         attachMissingPolicies=True,
         permissions=['Read'],
@@ -97,7 +95,7 @@ def session_share_2(
         environmentUri=session_cross_acc_env_1.environmentUri,
         groupUri=group5,
         principalId=group5,
-        principalType=PrincipalType.Group.value,
+        principalType='Group',
         requestPurpose='test create share object',
         attachMissingPolicies=True,
         permissions=['Read'],
@@ -125,7 +123,7 @@ def session_share_consrole_1(
         environmentUri=session_cross_acc_env_1.environmentUri,
         groupUri=group5,
         principalId=consumption_role_1.consumptionRoleUri,
-        principalType=PrincipalType.ConsumptionRole.value,
+        principalType='ConsumptionRole',
         requestPurpose='test create share object',
         attachMissingPolicies=True,
         permissions=['Read'],
@@ -152,7 +150,7 @@ def session_share_consrole_2(
         environmentUri=session_cross_acc_env_1.environmentUri,
         groupUri=group5,
         principalId=consumption_role_1.consumptionRoleUri,
-        principalType=PrincipalType.ConsumptionRole.value,
+        principalType='ConsumptionRole',
         requestPurpose='test create share object',
         attachMissingPolicies=True,
         permissions=['Read'],

--- a/tests_new/integration_tests/modules/share_base/test_new_crossacc_s3_share.py
+++ b/tests_new/integration_tests/modules/share_base/test_new_crossacc_s3_share.py
@@ -27,8 +27,8 @@ from tests_new.integration_tests.modules.share_base.utils import (
 )
 
 ALL_S3_SHARABLE_TYPES_NAMES = [
-    'DatasetTable',
-    'DatasetStorageLocation',
+    'Table',
+    'StorageLocation',
     'S3Bucket',
 ]
 
@@ -234,7 +234,7 @@ def test_check_item_access(client5, session_cross_acc_env_1_aws_client, share_pa
         )
 
     for item in items:
-        if item.itemType == 'DatasetTable':
+        if item.itemType == 'Table':
             # nosemgrep-next-line:noexec
             query = 'SELECT * FROM {}.{}'.format(glue_db, item.itemName)
             state = athena_client.execute_query(query, workgroup, athena_workgroup_output_location)
@@ -242,7 +242,7 @@ def test_check_item_access(client5, session_cross_acc_env_1_aws_client, share_pa
         elif item.itemType == 'S3Bucket':
             assert_that(s3_client.bucket_exists(item.itemName)).is_not_none()
             assert_that(s3_client.list_bucket_objects(item.itemName)).is_not_none()
-        elif item.itemType == 'DatasetStorageLocation':
+        elif item.itemType == 'StorageLocation':
             folder = get_folder(client5, item.itemUri)
             assert_that(
                 s3_client.list_accesspoint_folder_objects(access_point_arn, folder.S3Prefix + '/')

--- a/tests_new/integration_tests/modules/share_base/test_new_crossacc_s3_share.py
+++ b/tests_new/integration_tests/modules/share_base/test_new_crossacc_s3_share.py
@@ -1,15 +1,9 @@
 import pytest
 from assertpy import assert_that
 
-from tests_new.integration_tests.modules.s3_datasets.queries import get_folder
 from tests_new.integration_tests.aws_clients.athena import AthenaClient
-from dataall.modules.shares_base.services.shares_enums import (
-    ShareItemStatus,
-    ShareObjectStatus,
-    ShareItemHealthStatus,
-    ShareableType,
-)
 from tests_new.integration_tests.modules.s3_datasets.aws_clients import S3Client
+from tests_new.integration_tests.modules.s3_datasets.queries import get_folder
 from tests_new.integration_tests.modules.share_base.conftest import clean_up_share
 from tests_new.integration_tests.modules.share_base.queries import (
     create_share_object,
@@ -33,9 +27,9 @@ from tests_new.integration_tests.modules.share_base.utils import (
 )
 
 ALL_S3_SHARABLE_TYPES_NAMES = [
-    ShareableType.Table.name,
-    ShareableType.StorageLocation.name,
-    ShareableType.S3Bucket.name,
+    'DatasetTable',
+    'DatasetStorageLocation',
+    'S3Bucket',
 ]
 
 
@@ -52,7 +46,7 @@ def test_create_and_delete_share_object(client5, session_cross_acc_env_1, sessio
         attachMissingPolicies=True,
         permissions=['Read'],
     )
-    assert_that(share.status).is_equal_to(ShareObjectStatus.Draft.value)
+    assert_that(share.status).is_equal_to('Draft')
     delete_share_object(client5, share.shareUri)
 
 
@@ -104,7 +98,7 @@ def test_add_share_items(client5, session_cross_acc_env_1, session_s3_dataset1, 
     items = updated_share['items'].nodes
     assert_that(items).is_length(1)
     assert_that(items[0].shareItemUri).is_equal_to(share_item_uri)
-    assert_that(items[0].status).is_equal_to(ShareItemStatus.PendingApproval.value)
+    assert_that(items[0].status).is_equal_to('PendingApproval')
 
     clean_up_share(client5, share.shareUri)
 
@@ -134,7 +128,7 @@ def test_reject_share(client1, client5, session_cross_acc_env_1, session_s3_data
 
     reject_share_object(client1, share.shareUri)
     updated_share = get_share_object(client1, share.shareUri)
-    assert_that(updated_share.status).is_equal_to(ShareObjectStatus.Rejected.value)
+    assert_that(updated_share.status).is_equal_to('Rejected')
 
     change_request_purpose = update_share_reject_reason(client1, share.shareUri, 'new purpose')
     assert_that(change_request_purpose).is_true()
@@ -163,9 +157,9 @@ def test_submit_object(client5, share_params_all):
     submit_share_object(client5, share.shareUri)
     updated_share = get_share_object(client5, share.shareUri)
     if dataset.autoApprovalEnabled:
-        assert_that(updated_share.status).is_equal_to(ShareObjectStatus.Approved.value)
+        assert_that(updated_share.status).is_equal_to('Approved')
     else:
-        assert_that(updated_share.status).is_equal_to(ShareObjectStatus.Submitted.value)
+        assert_that(updated_share.status).is_equal_to('Submitted')
 
 
 @pytest.mark.dependency(name='share_approved', depends=['share_submitted'])
@@ -174,9 +168,9 @@ def test_approve_share(client1, share_params_main):
     approve_share_object(client1, share.shareUri)
 
     updated_share = get_share_object(client1, share.shareUri, {'isShared': True})
-    assert_that(updated_share.status).is_equal_to(ShareObjectStatus.Approved.value)
+    assert_that(updated_share.status).is_equal_to('Approved')
     items = updated_share['items'].nodes
-    assert_that(items).extracting('status').contains_only(ShareItemStatus.Share_Approved.value)
+    assert_that(items).extracting('status').contains_only('Share_Approved')
 
 
 @pytest.mark.dependency(name='share_succeeded', depends=['share_approved'])
@@ -186,10 +180,10 @@ def test_share_succeeded(client1, share_params_main):
     updated_share = get_share_object(client1, share.shareUri, {'isShared': True})
     items = updated_share['items'].nodes
 
-    assert_that(updated_share.status).is_equal_to(ShareObjectStatus.Processed.value)
+    assert_that(updated_share.status).is_equal_to('Processed')
     for item in items:
-        assert_that(item.status).is_equal_to(ShareItemStatus.Share_Succeeded.value)
-        assert_that(item.healthStatus).is_equal_to(ShareItemHealthStatus.Healthy.value)
+        assert_that(item.status).is_equal_to('Share_Succeeded')
+        assert_that(item.healthStatus).is_equal_to('Healthy')
     assert_that(items).extracting('itemType').contains(*ALL_S3_SHARABLE_TYPES_NAMES)
 
 
@@ -203,8 +197,8 @@ def test_verify_share_items(client1, share_params_main):
     check_share_items_verified(client1, share.shareUri)
     updated_share = get_share_object(client1, share.shareUri, {'isShared': True})
     items = updated_share['items'].nodes
-    assert_that(items).extracting('status').contains_only(ShareItemStatus.Share_Succeeded.value)
-    assert_that(items).extracting('healthStatus').contains_only(ShareItemHealthStatus.Healthy.value)
+    assert_that(items).extracting('status').contains_only('Share_Succeeded')
+    assert_that(items).extracting('healthStatus').contains_only('Healthy')
     assert_that(items).extracting('lastVerificationTime').does_not_contain(*times)
 
 
@@ -240,15 +234,15 @@ def test_check_item_access(client5, session_cross_acc_env_1_aws_client, share_pa
         )
 
     for item in items:
-        if item.itemType == ShareableType.Table.name:
+        if item.itemType == 'DatasetTable':
             # nosemgrep-next-line:noexec
             query = 'SELECT * FROM {}.{}'.format(glue_db, item.itemName)
             state = athena_client.execute_query(query, workgroup, athena_workgroup_output_location)
             assert_that(state).is_equal_to('SUCCEEDED')
-        elif item.itemType == ShareableType.S3Bucket.name:
+        elif item.itemType == 'S3Bucket':
             assert_that(s3_client.bucket_exists(item.itemName)).is_not_none()
             assert_that(s3_client.list_bucket_objects(item.itemName)).is_not_none()
-        elif item.itemType == ShareableType.StorageLocation.name:
+        elif item.itemType == 'DatasetStorageLocation':
             folder = get_folder(client5, item.itemUri)
             assert_that(
                 s3_client.list_accesspoint_folder_objects(access_point_arn, folder.S3Prefix + '/')
@@ -266,10 +260,10 @@ def test_revoke_share(client1, share_params_main):
     revoke_share_items(client1, share.shareUri, shareItemUris)
 
     updated_share = get_share_object(client1, share.shareUri, {'isShared': True})
-    assert_that(updated_share.status).is_equal_to(ShareObjectStatus.Revoked.value)
+    assert_that(updated_share.status).is_equal_to('Revoked')
     items = updated_share['items'].nodes
 
-    assert_that(items).extracting('status').contains_only(ShareItemStatus.Revoke_Approved.value)
+    assert_that(items).extracting('status').contains_only('Revoke_Approved')
     assert_that(items).extracting('itemType').contains(*ALL_S3_SHARABLE_TYPES_NAMES)
 
 
@@ -280,6 +274,6 @@ def test_revoke_succeeded(client1, share_params_main):
     updated_share = get_share_object(client1, share.shareUri, {'isShared': True})
     items = updated_share['items'].nodes
 
-    assert_that(updated_share.status).is_equal_to(ShareObjectStatus.Processed.value)
-    assert_that(items).extracting('status').contains_only(ShareItemStatus.Revoke_Succeeded.value)
+    assert_that(updated_share.status).is_equal_to('Processed')
+    assert_that(items).extracting('status').contains_only('Revoke_Succeeded')
     assert_that(items).extracting('itemType').contains(*ALL_S3_SHARABLE_TYPES_NAMES)

--- a/tests_new/integration_tests/modules/share_base/utils.py
+++ b/tests_new/integration_tests/modules/share_base/utils.py
@@ -1,30 +1,26 @@
 import json
-import re
 
 import boto3
 
 from tests_new.integration_tests.aws_clients.sts import StsClient
+from tests_new.integration_tests.core.environment.queries import get_environment_access_token
 from tests_new.integration_tests.modules.share_base.queries import get_share_object
 from tests_new.integration_tests.utils import poller
-from dataall.modules.shares_base.services.shares_enums import ShareObjectStatus, ShareItemHealthStatus
-from tests_new.integration_tests.core.environment.queries import get_environment_access_token
 
 
 def is_share_in_progress(share):
     return share.status in [
-        ShareObjectStatus.Share_In_Progress.value,
-        ShareObjectStatus.Revoke_In_Progress.value,
-        ShareObjectStatus.Approved.value,
-        ShareObjectStatus.Revoked.value,
+        'Share_In_Progress',
+        'Revoke_In_Progress',
+        'Approved',
+        'Revoked',
     ]
 
 
 def is_all_items_verified(share):
     items = share['items'].nodes
     statuses = [item.healthStatus for item in items]
-    return not (
-        ShareItemHealthStatus.PendingVerify.value in statuses or ShareItemHealthStatus.PendingReApply.value in statuses
-    )
+    return not ('PendingVerify' in statuses or 'PendingReApply' in statuses)
 
 
 @poller(check_success=lambda share: not is_share_in_progress(share), timeout=600)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
We shouldn't be importing data.all code into integ tests.
1. Integ tests are yet another client that don't and shouldn't know anything about data.all svc internals
2. By doing this we need to install the entire dependency tree of the backend (i.e currently tests are failing because ariadne dep is missing.
    ```
    /root/.pyenv/versions/3.11.9/lib/python3.11/importlib/__init__.py:126: in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
    <frozen importlib._bootstrap>:1204: in _gcd_import
        ???
    <frozen importlib._bootstrap>:1176: in _find_and_load
        ???
    <frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
        ???
    <frozen importlib._bootstrap>:690: in _load_unlocked
        ???
    env/lib/python3.11/site-packages/_pytest/assertion/rewrite.py:172: in exec_module
        exec(co, module.__dict__)
    tests_new/integration_tests/modules/share_base/conftest.py:3: in <module>
        from tests_new.integration_tests.aws_clients.iam import IAMClient
    tests_new/integration_tests/aws_clients/iam.py:7: in <module>
        from dataall.base.aws.parameter_store import ParameterStoreManager
    backend/dataall/__init__.py:1: in <module>
        from . import core, version
    backend/dataall/core/__init__.py:3: in <module>
        from dataall.core import permissions, stacks, groups, environment, organizations, tasks, vpc, resource_lock
    backend/dataall/core/permissions/__init__.py:1: in <module>
        from dataall.core.permissions import api
    backend/dataall/core/permissions/api/__init__.py:1: in <module>
        from dataall.core.permissions.api import input_types, queries, resolvers, types, mutations
    backend/dataall/core/permissions/api/input_types.py:1: in <module>
        from dataall.base.api import gql
    backend/dataall/base/api/__init__.py:3: in <module>
        from ariadne import (
    E   ModuleNotFoundError: No module named 'ariadne'
    ```
3. Initialisation of data.all is convoluted and there are actions (i.e accessing Params) being done at import time

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
