### PR TITLE
retry for LF grant_permissions

### DIFF
--- a/backend/dataall/modules/s3_datasets_shares/aws/lakeformation_client.py
+++ b/backend/dataall/modules/s3_datasets_shares/aws/lakeformation_client.py
@@ -10,6 +10,10 @@ from dataall.base.aws.sts import SessionHelper
 log = logging.getLogger('aws:lakeformation')
 
 
+def _retry_if_concurrency_error(exception):
+    return 'ConcurrentModificationException' in str(exception)
+
+
 class LakeFormationClient:
     def __init__(self, account_id, region):
         self._session = SessionHelper.remote_session(accountid=account_id, region=region)
@@ -132,9 +136,6 @@ class LakeFormationClient:
                 check_resource=data_filter_resource,
             )
         return True
-
-    def _retry_if_concurrency_error(self, exception):
-        return isinstance(exception, self._client.exceptions.ConcurrentModificationException)
 
     @retry(
         retry_on_exception=_retry_if_concurrency_error,

--- a/backend/dataall/modules/s3_datasets_shares/aws/lakeformation_client.py
+++ b/backend/dataall/modules/s3_datasets_shares/aws/lakeformation_client.py
@@ -180,7 +180,8 @@ class LakeFormationClient:
                             time.sleep(2)
                             break
 
-                        except ClientError as e:
+                        except self._client.exceptions.exceptions.ConcurrentModificationException as e:
+                            log.info(f'ConcurrentModificationException occurred. Retry {retries}')
                             last_error = e
                             time.sleep(SLEEP_TIME * (BACKOFF_COEFF**retries))
                             retries += 1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,5 @@ PyYAML==6.0
 requests==2.32.2
 requests_aws4auth==1.1.1
 sqlalchemy==1.3.24
-starlette==0.36.3
 alembic==1.13.1
 retrying==1.3.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,4 @@ requests_aws4auth==1.1.1
 sqlalchemy==1.3.24
 starlette==0.36.3
 alembic==1.13.1
+retrying==1.3.4


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix


### Detail
- Add retries to grant_permissions boto3 call in lakeformation client
- timeout is increased by 10% every retry

### Relates
- #1572

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
