### PR TITLE
Fix wrong environment in the verification of redshift role

### DIFF
--- a/backend/dataall/modules/redshift_datasets_shares/services/redshift_table_share_validator.py
+++ b/backend/dataall/modules/redshift_datasets_shares/services/redshift_table_share_validator.py
@@ -48,7 +48,7 @@ class RedshiftTableValidator(SharesValidatorInterface):
 
     @staticmethod
     def validate_share_object_submit(session, dataset, share) -> bool:
-        environment = EnvironmentService.get_environment_by_uri(session, dataset.environmentUri)
+        environment = EnvironmentService.get_environment_by_uri(session, share.environmentUri)
         RedshiftTableValidator._validate_redshift_role(
             session=session,
             environment=environment,
@@ -60,7 +60,7 @@ class RedshiftTableValidator(SharesValidatorInterface):
 
     @staticmethod
     def validate_share_object_approve(session, dataset, share) -> bool:
-        environment = EnvironmentService.get_environment_by_uri(session, dataset.environmentUri)
+        environment = EnvironmentService.get_environment_by_uri(session, share.environmentUri)
         RedshiftTableValidator._validate_redshift_role(
             session=session,
             environment=environment,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
We were validating if the Redshift role for a Redshift share request existed in the dataset account, while we should be validating if it exists in the target account (share.environmentUri)

### Relates
- #955 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
