### PR TITLE
Enable hyperlinks in dataset description

### DIFF
--- a/frontend/src/design/components/ObjectBrief.js
+++ b/frontend/src/design/components/ObjectBrief.js
@@ -6,9 +6,12 @@ import {
   CardHeader,
   Chip,
   Typography,
-  Divider
+  Divider,
+  useTheme
 } from '@mui/material';
 import { Label } from './Label';
+import { createLinkMarkup } from 'utils';
+import { SanitizedHTML } from 'design';
 
 export const ObjectBrief = (props) => {
   const {
@@ -23,6 +26,9 @@ export const ObjectBrief = (props) => {
     parameterTemplate,
     ...other
   } = props;
+
+  const theme = useTheme();
+  const linkColor = theme.palette.primary.main;
 
   return (
     <Card {...other}>
@@ -136,7 +142,9 @@ export const ObjectBrief = (props) => {
                 variant="subtitle2"
                 style={{ whiteSpace: 'pre-line' }}
               >
-                {description}
+                <SanitizedHTML
+                  dirtyHTML={createLinkMarkup(description, linkColor)}
+                />
               </Typography>
             </Box>
           )}

--- a/frontend/src/design/components/SanitizedHTML.js
+++ b/frontend/src/design/components/SanitizedHTML.js
@@ -3,7 +3,7 @@ import DOMPurify from 'dompurify';
 export const SanitizedHTML = ({ dirtyHTML }) => {
   const defaultOptions = {
     ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a'],
-    ALLOWED_ATTR: ['href']
+    ALLOWED_ATTR: ['href', 'target', 'rel', 'style']
   };
 
   const sanitizedHtml = DOMPurify.sanitize(dirtyHTML, defaultOptions);

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -48,7 +48,8 @@ import {
   ShareHealthStatus,
   TextAvatar,
   useSettings,
-  Label
+  Label,
+  SanitizedHTML
 } from 'design';
 import { SET_ERROR, useDispatch } from 'globalErrors';
 import { useClient } from 'services';
@@ -75,7 +76,10 @@ import {
   UpdateRequestReason,
   ShareItemFilterModal
 } from '../components';
-import { generateShareItemLabel } from 'utils';
+import {
+  generateShareItemLabel,
+  createLinkMarkup
+} from 'utils';
 import { ShareLogs } from '../components/ShareLogs';
 import { ShareSubmitModal } from '../components/ShareSubmitModal';
 import { UpdateExtensionReason } from '../components/ShareUpdateExtension';
@@ -747,6 +751,8 @@ const ShareView = () => {
   const dispatch = useDispatch();
   const params = useParams();
   const client = useClient();
+  const theme = useTheme();
+  const linkColor = theme.palette.primary.main;
   const [loading, setLoading] = useState(true);
   const [loadingShareItems, setLoadingShareItems] = useState(false);
   const [isAddItemModalOpen, setIsAddItemModalOpen] = useState(false);
@@ -962,9 +968,12 @@ const ShareView = () => {
                                 WebkitBoxOrient: 'vertical'
                               }}
                             >
-                              {share.dataset.description.trim().length !== 0
-                                ? share.dataset.description
-                                : 'No dataset description'}
+                              <SanitizedHTML
+                                dirtyHTML={createLinkMarkup(
+                                  share?.dataset?.description || '',
+                                  linkColor
+                                )}
+                              />
                             </Typography>
                           </Box>
                           <Box sx={{ mt: 3 }}>

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -76,12 +76,10 @@ import {
   UpdateRequestReason,
   ShareItemFilterModal
 } from '../components';
-import {
-  generateShareItemLabel,
-  createLinkMarkup
-} from 'utils';
+import { generateShareItemLabel, createLinkMarkup } from 'utils';
 import { ShareLogs } from '../components/ShareLogs';
 import { ShareSubmitModal } from '../components/ShareSubmitModal';
+import { useTheme } from '@mui/styles';
 import { UpdateExtensionReason } from '../components/ShareUpdateExtension';
 import CancelIcon from '@mui/icons-material/Close';
 

--- a/frontend/src/utils/helpers/index.js
+++ b/frontend/src/utils/helpers/index.js
@@ -2,3 +2,4 @@ export * from './bytesToSize';
 export * from './dayjs';
 export * from './listToTree';
 export * from './moduleUtils';
+export * from './linkMarkup';

--- a/frontend/src/utils/helpers/linkMarkup.js
+++ b/frontend/src/utils/helpers/linkMarkup.js
@@ -1,0 +1,33 @@
+export const createLinkMarkup = (text, color) => {
+  // Define the components of the regex pattern
+
+  // Matches optional protocol (http:// or https://)
+  const protocol = '(https?://)?';
+
+  // Matches any domain or subdomain
+  const domain = '([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}';
+
+  // Matches paths and query strings, excluding certain special characters
+  const pathAndQuery = '(\\/[^\\s()$@]*)?(\\?[\\w=&-]*)?(#[\\w\\-]*)?';
+
+  // Combine all parts into the final regex pattern
+  const urlRegex = new RegExp(
+    `(${protocol})?(${domain})(?=\\s|\\/|$)${pathAndQuery}(?=\\s|$)`,
+    'gi'
+  );
+
+  return text.replace(urlRegex, (fullMatch) => {
+    const decodedUrl = decodeURIComponent(fullMatch);
+
+    // Determine the correct href value for the anchor tag
+    let href = '';
+    if (decodedUrl.startsWith('https://') || decodedUrl.startsWith('http://')) {
+      href = decodedUrl;
+    } else {
+      href = `https://${decodedUrl}`;
+    }
+
+    // Return the HTML string for the anchor tag with the correct href and style
+    return `<a href="${href}" style="color: ${color};" target="_blank" rel="noopener noreferrer">${fullMatch}</a>`;
+  });
+};


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- Enables conversion of hyperlinks in dataset description text.

### Relates
- https://github.com/data-dot-all/dataall/issues/1590

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?  Dataset description field is parsed for hyperlinks
  - Is the input sanitized? Yes, and additional sanitization can take place in linkMarkup.js
  - What precautions are you taking before deserializing the data you consume?  N/A
  - Is injection prevented by parametrizing queries?  N/A
  - Have you ensured no `eval` or similar functions are used? Yes
- Does this PR introduce any functionality or component that requires authorization? No
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms? N/A
  - Are you logging failed auth attempts? N/A
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations? N/A
  - Are the used keys controlled by the customer? Where are they stored? N/A
- Are you introducing any new policies/roles/users? N/A
  - Have you used the least-privilege principle? How? N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
