### PR TITLE
Share extension unitest fix

### DIFF
--- a/tests/modules/s3_datasets_shares/test_share.py
+++ b/tests/modules/s3_datasets_shares/test_share.py
@@ -2109,7 +2109,7 @@ def test_submit_share_extension_request_with_auto_approval(
         return_value='fake_role_arn',
     )
     # Submit a share extension request with a dataset which has auto approval on it
-    submit_share_extension(client, user2, group2, share3_with_expiration_processed_with_autoapproval.shareUri, 1)
+    submit_share_extension(client, user2, group2, share3_with_expiration_processed_with_autoapproval.shareUri, 2)
 
     get_share_object_response = get_share_object(
         client=client,
@@ -2125,7 +2125,7 @@ def test_submit_share_extension_request_with_auto_approval(
     share_expiration_date = datetime.strptime(get_share_object_response.data.getShareObject.expiryDate, date_format)
     assert (
         share_expiration_date.date()
-        == ExpirationUtils.calculate_expiry_date(1, dataset_with_expiration_with_autoapproval.expirySetting).date()
+        == ExpirationUtils.calculate_expiry_date(2, dataset_with_expiration_with_autoapproval.expirySetting).date()
     )
 
 
@@ -2272,7 +2272,7 @@ def test_approve_share_extension(
     )
 
     # Submit a share extension request
-    submit_share_extension(client, user2, group2, share3_with_expiration_processed.shareUri, 1)
+    submit_share_extension(client, user2, group2, share3_with_expiration_processed.shareUri, 2)
 
     get_share_object_response = get_share_object(
         client=client,
@@ -2289,7 +2289,7 @@ def test_approve_share_extension(
     )
     assert (
         share_expiration_date.date()
-        == ExpirationUtils.calculate_expiry_date(1, dataset_with_expiration_2.expirySetting).date()
+        == ExpirationUtils.calculate_expiry_date(2, dataset_with_expiration_2.expirySetting).date()
     )
     requested_expiration_date_raw = get_share_object_response.data.getShareObject.requestedExpiryDate
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- Initially share has expiration = 1
- In test the extension request with expiration value = 1 is submitted
- Expected that share is extended for 2 moths. But instead  is stays the same
- FIX: Submit extension with expiration value = 2 

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
