### PR TITLE
Fix share expiration date calculation for end-of-month days

### DIFF
--- a/backend/dataall/base/utils/expiration_util.py
+++ b/backend/dataall/base/utils/expiration_util.py
@@ -9,11 +9,21 @@ class ExpirationUtils:
     def calculate_expiry_date(expirationPeriod, expirySetting):
         currentDate = date.today()
         if expirySetting == Expiration.Quartely.value:
-            quarterlyCalculatedDate = currentDate + relativedelta(months=expirationPeriod * 3 - 1)
+            if currentDate < datetime(currentDate.year, currentDate.month, 15).date():
+                # First half of the month - extend 2.X months
+                quarterlyCalculatedDate = currentDate + relativedelta(months=expirationPeriod * 3 - 1)
+            else:
+                # Second half of the month - extend 3.X months
+                quarterlyCalculatedDate = currentDate + relativedelta(months=expirationPeriod * 3)
             day = calendar.monthrange(quarterlyCalculatedDate.year, quarterlyCalculatedDate.month)[1]
             shareExpiryDate = datetime(quarterlyCalculatedDate.year, quarterlyCalculatedDate.month, day)
         elif expirySetting == Expiration.Monthly.value:
-            monthlyCalculatedDate = currentDate + relativedelta(months=expirationPeriod - 1)
+            if currentDate < datetime(currentDate.year, currentDate.month, 15).date():
+                # First half of the month - extend until end of month
+                monthlyCalculatedDate = currentDate + relativedelta(months=expirationPeriod - 1)
+            else:
+                # Second half of the month - extend until end of next month
+                monthlyCalculatedDate = currentDate + relativedelta(months=expirationPeriod)
             monthEndDay = calendar.monthrange(monthlyCalculatedDate.year, monthlyCalculatedDate.month)[1]
             shareExpiryDate = datetime(monthlyCalculatedDate.year, monthlyCalculatedDate.month, monthEndDay)
         else:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Solves #1592 

With this PR for the 15 first days of the month, extending the share request for another month means extending it until the end of the month. For the second half of the month, extending the share request for another month means extending it until the end of the NEXT month.

### Relates
- #1592 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
