### PR TITLE
MF7  bugfix

### DIFF
--- a/backend/dataall/modules/metadata_forms/services/attached_metadata_form_service.py
+++ b/backend/dataall/modules/metadata_forms/services/attached_metadata_form_service.py
@@ -31,8 +31,9 @@ class AttachedMetadataFormValidationService:
 
 
 class AttachedMetadataFormService:
+    # session is rudimentary here, but it is required for the ResourcePolicyService to work
     @staticmethod
-    def _get_entity_uri(data):
+    def _get_entity_uri(session, data):
         return data.get('entityUri')
 
     @staticmethod

--- a/backend/dataall/modules/metadata_forms/services/attached_metadata_form_service.py
+++ b/backend/dataall/modules/metadata_forms/services/attached_metadata_form_service.py
@@ -80,9 +80,15 @@ class AttachedMetadataFormService:
                 page_size=filter.get('pageSize', 10),
             ).to_dict()
 
+    # session is rudimentary here, but it is required for the ResourcePolicyService to work
+    @staticmethod
+    def _get_entity_uri_by_mf_uri(session, uri):
+        mf = AttachedMetadataFormService.get_attached_metadata_form(uri)
+        return mf.entityUri
+
     @staticmethod
     @ResourcePolicyService.has_resource_permission(
-        ATTACH_METADATA_FORM, parent_resource=_get_entity_uri, param_name='data'
+        ATTACH_METADATA_FORM, parent_resource=_get_entity_uri_by_mf_uri, param_name='uri'
     )
     def delete_attached_metadata_form(uri):
         mf = AttachedMetadataFormService.get_attached_metadata_form(uri)


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->

- Bugfix


### Detail
- _get_entity_uri requires the dummy parameter session 
- _get_entity_uri_by_mf_uri for delete_attached_metadata_form
- it is required for the ResourcePolicyService to work

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
