### PR TITLE
Extend id token duration if tests included as part of pipeline

### DIFF
--- a/deploy/stacks/cognito.py
+++ b/deploy/stacks/cognito.py
@@ -100,6 +100,7 @@ class IdpStack(pyNestedClass):
                 domain_prefix=f"{resource_prefix.replace('-', '')}{envname}{self.region.replace('-', '')}{self.account}"
             ),
         )
+        id_token_duration = 120 if with_approval_tests else 60
         self.client = cognito.UserPoolClient(
             self,
             f'AppClient-{envname}',
@@ -107,6 +108,7 @@ class IdpStack(pyNestedClass):
             auth_flows=AuthFlow(user_password=with_approval_tests, user_srp=True, custom=True),
             prevent_user_existence_errors=True,
             refresh_token_validity=Duration.minutes(cognito_user_session_timeout_inmins),
+            id_toekn_validity=Duration.minutes(id_token_duration),
         )
 
         if enable_cw_rum:

--- a/deploy/stacks/cognito.py
+++ b/deploy/stacks/cognito.py
@@ -108,7 +108,7 @@ class IdpStack(pyNestedClass):
             auth_flows=AuthFlow(user_password=with_approval_tests, user_srp=True, custom=True),
             prevent_user_existence_errors=True,
             refresh_token_validity=Duration.minutes(cognito_user_session_timeout_inmins),
-            id_toekn_validity=Duration.minutes(id_token_duration),
+            id_token_validity=Duration.minutes(id_token_duration),
         )
 
         if enable_cw_rum:


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature

### Detail
- Extend ID Token Validity to 120 if enabling integration tests to allow integration test suite to run  fully (note: runs take ~70-80 minutes currently) 


### Relates
- NA

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
