### PR TITLE
try to create AP every time, catch if already exists

### DIFF
--- a/backend/dataall/core/environment/cdk/pivot_role_core_policies/s3.py
+++ b/backend/dataall/core/environment/cdk/pivot_role_core_policies/s3.py
@@ -17,6 +17,7 @@ class S3PivotRole(PivotRoleStatementSet):
                 effect=iam.Effect.ALLOW,
                 actions=[
                     's3:ListAllMyBuckets',
+                    's3:ListAccessPoints',
                     's3:GetBucketLocation',
                     's3:PutBucketTagging',
                     's3:GetEncryptionConfiguration',

--- a/backend/dataall/modules/s3_datasets_shares/aws/s3_client.py
+++ b/backend/dataall/modules/s3_datasets_shares/aws/s3_client.py
@@ -49,10 +49,9 @@ class S3ControlClient:
                 Bucket=bucket_name,
             )
         except Exception as e:
-            if 'AccessPointAlreadyOwnedByYou' in str(e):
-                log.info(f'S3 bucket access point {access_point_name} already exists on {self._account_id}')
-                return self.get_bucket_access_point_arn(access_point_name)
             log.error(f'S3 bucket access point creation failed for location {bucket_name} : {e}')
+            if 'AccessPointAlreadyOwnedByYou' in str(e):
+                return self.get_bucket_access_point_arn(access_point_name)
             raise e
         else:
             return access_point['AccessPointArn']

--- a/backend/dataall/modules/s3_datasets_shares/aws/s3_client.py
+++ b/backend/dataall/modules/s3_datasets_shares/aws/s3_client.py
@@ -49,6 +49,9 @@ class S3ControlClient:
                 Bucket=bucket_name,
             )
         except Exception as e:
+            if 'AccessPointAlreadyOwnedByYou' in str(e):
+                log.info(f'S3 bucket access point {access_point_name} already exists on {self._account_id}')
+                return self.get_bucket_access_point_arn(access_point_name)
             log.error(f'S3 bucket access point creation failed for location {bucket_name} : {e}')
             raise e
         else:

--- a/backend/dataall/modules/s3_datasets_shares/aws/s3_client.py
+++ b/backend/dataall/modules/s3_datasets_shares/aws/s3_client.py
@@ -58,6 +58,7 @@ class S3ControlClient:
 
     @retry(retry_on_result=lambda arn: arn is None, stop_max_attempt_number=10, wait_fixed=30000)
     def try_get_bucket_access_point_arn(self, bucket_name: str, access_point_name: str):
+        log.info(f'Attempt to get access point arn for bucket {bucket_name} and accesspoint {access_point_name}')
         all_access_points = self._client.list_access_points(
             AccountId=self._account_id, Bucket=bucket_name, MaxResults=1000
         )

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
@@ -492,9 +492,9 @@ class S3AccessPointShareManager:
         }
         Retrying(
             retry_on_exception=lambda ex: 'NoSuchAccessPoint' in str(ex),
-            stop_max_attempt_number=5,
-            wait_random_min=1000,
-            wait_random_max=3000,
+            stop_max_attempt_number=10,
+            wait_random_min=5000,
+            wait_random_max=10000,
         ).call(s3_client.attach_access_point_policy, **policy_dict)
 
     def check_dataset_bucket_key_policy(self) -> None:

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
@@ -486,16 +486,9 @@ class S3AccessPointShareManager:
                 perms_to_actions(self.share.permissions, SidType.BucketPolicy),
             )
 
-        policy_dict = {
-            'access_point_name': self.access_point_name,
-            'policy': json.dumps(access_point_policy),
-        }
-        Retrying(
-            retry_on_exception=lambda ex: 'NoSuchAccessPoint' in str(ex),
-            stop_max_attempt_number=10,
-            wait_random_min=10000,
-            wait_random_max=30000,
-        ).call(s3_client.attach_access_point_policy, **policy_dict)
+        s3_client.attach_access_point_policy(
+            access_point_name=self.access_point_name, policy=json.dumps(access_point_policy)
+        )
 
     def check_dataset_bucket_key_policy(self) -> None:
         """

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
@@ -1,6 +1,5 @@
 import logging
 import json
-import time
 from itertools import count
 
 from retrying import Retrying
@@ -41,9 +40,6 @@ from dataall.modules.s3_datasets.db.dataset_models import DatasetStorageLocation
 from dataall.modules.shares_base.services.sharing_service import ShareData
 
 logger = logging.getLogger(__name__)
-ACCESS_POINT_CREATION_TIME = 30
-ACCESS_POINT_CREATION_RETRIES = 10
-ACCESS_POINT_BACKOFF_COEFFICIENT = 1.1  # every time increase retry delay by 10%
 
 
 class S3AccessPointShareManager:

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
@@ -2,7 +2,6 @@ import logging
 import json
 from itertools import count
 
-from retrying import Retrying
 
 from dataall.core.environment.services.environment_service import EnvironmentService
 from dataall.base.db import utils
@@ -441,6 +440,8 @@ class S3AccessPointShareManager:
 
         s3_client = S3ControlClient(self.source_account_id, self.source_environment.region)
         access_point_arn = s3_client.create_bucket_access_point(self.bucket_name, self.access_point_name)
+        if not access_point_arn:
+            raise Exception('Failed to create access point')
         existing_policy = s3_client.get_access_point_policy(self.access_point_name)
         # requester will use this role to access resources
         target_requester_id = SessionHelper.get_role_id(

--- a/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_managers/s3_access_point_share_manager.py
@@ -493,8 +493,8 @@ class S3AccessPointShareManager:
         Retrying(
             retry_on_exception=lambda ex: 'NoSuchAccessPoint' in str(ex),
             stop_max_attempt_number=10,
-            wait_random_min=5000,
-            wait_random_max=10000,
+            wait_random_min=10000,
+            wait_random_max=30000,
         ).call(s3_client.attach_access_point_policy, **policy_dict)
 
     def check_dataset_bucket_key_policy(self) -> None:

--- a/tests/modules/s3_datasets_shares/tasks/test_s3_access_point_share_manager.py
+++ b/tests/modules/s3_datasets_shares/tasks/test_s3_access_point_share_manager.py
@@ -670,6 +670,7 @@ def test_manage_access_point_and_policy_2(
     access_point_arn = 'existing-access-point-arn'
     s3_client = mock_s3_control_client(mocker)
     s3_client().get_bucket_access_point_arn.return_value = access_point_arn
+    s3_client().create_bucket_access_point.return_value = access_point_arn
 
     # target_env_admin is already in policy but current folder is NOT yet in prefix_list
     existing_ap_policy = _generate_ap_policy_object(
@@ -690,6 +691,7 @@ def test_manage_access_point_and_policy_2(
     # Then
     s3_client().attach_access_point_policy.assert_called()
     policy = s3_client().attach_access_point_policy.call_args.kwargs.get('policy')
+    print(f'{policy=}')
 
     # Assert S3 Prefix of share folder in prefix_list
     new_ap_policy = json.loads(policy)
@@ -700,6 +702,7 @@ def test_manage_access_point_and_policy_2(
 
     # Assert s3 prefix is in resource_list
     resource_list = statements[f'{target_environment.SamlGroupName}1']['Resource']
+    print(f'{resource_list=}')
 
     assert f'{access_point_arn}/object/{location1.S3Prefix}/*' in resource_list
 
@@ -716,6 +719,7 @@ def test_manage_access_point_and_policy_3(
     access_point_arn = 'existing-access-point-arn'
     s3_control_client = mock_s3_control_client(mocker)
     s3_control_client().get_bucket_access_point_arn.return_value = access_point_arn
+    s3_control_client().create_bucket_access_point.return_value = access_point_arn
 
     # New target env admin and prefix are not in existing ap policy
     existing_ap_policy = _generate_ap_policy_object(access_point_arn, [['another-env-admin', ['existing-prefix']]])


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix


### Detail
- Try to create AP every time we process the share
- Catch error if it already exists
- Retry on put_access_point_policy

### Relates
- #1608 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
