### PR TITLE
CICD: S3 dataset bug, position arguments vs arguments by name

### DIFF
--- a/tests_new/integration_tests/modules/s3_datasets/global_conftest.py
+++ b/tests_new/integration_tests/modules/s3_datasets/global_conftest.py
@@ -490,7 +490,12 @@ def persistent_imported_sse_s3_dataset1(client1, group1, persistent_env1, persis
     except Exception as e:
         raise Exception(f'Error creating {bucket_name=} due to: {e}')
     return get_or_create_persistent_s3_dataset(
-        'persistent_imported_sse_s3_dataset1', client1, group1, persistent_env1, bucket_name
+        'persistent_imported_sse_s3_dataset1',
+        client1,
+        group1,
+        persistent_env1,
+        autoApprovalEnabled=False,
+        bucket=bucket_name,
     )
 
 
@@ -538,7 +543,8 @@ def persistent_imported_kms_s3_dataset1(
         client1,
         group1,
         persistent_env1,
-        resource_name,
-        resource_name,
-        resource_name,
+        autoApprovalEnabled=False,
+        bucket=resource_name,
+        kms_alias=resource_name,
+        glue_database=resource_name,
     )


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->

- Bugfix


### Detail
- pass arguments by name to avoid confusion

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
