### PR TITLE
CICD: assume consumption role from environment client

### DIFF
--- a/tests_new/integration_tests/aws_clients/sts.py
+++ b/tests_new/integration_tests/aws_clients/sts.py
@@ -45,8 +45,8 @@ class STSClient:
         session.set_config_variable('region', self.region)
         return Session(botocore_session=session)
 
-    def get_role_session(self) -> Session:
-        sts_client = boto3.client('sts', region_name=self.region)
+    def get_role_session(self, session) -> Session:
+        sts_client = session.client('sts', region_name=self.region)
         assumed_role_object = sts_client.assume_role(RoleArn=self.role_arn, RoleSessionName=self.session_name)
         credentials = assumed_role_object['Credentials']
 

--- a/tests_new/integration_tests/modules/share_base/conftest.py
+++ b/tests_new/integration_tests/modules/share_base/conftest.py
@@ -74,7 +74,7 @@ def session_consumption_role_1(client5, group5, session_cross_acc_env_1, session
     yield consumption_role
     remove_consumption_role(client5, session_cross_acc_env_1.environmentUri, consumption_role.consumptionRoleUri)
     iam_client = IAMClient(session=session_cross_acc_env_1_aws_client, region=session_cross_acc_env_1['region'])
-    iam_client.delete_consumption_role(consumption_role['Role']['RoleName'])
+    iam_client.delete_consumption_role(test_session_cons_role_name)
 
 
 @pytest.fixture(scope='session')

--- a/tests_new/integration_tests/modules/share_base/shared_test_functions.py
+++ b/tests_new/integration_tests/modules/share_base/shared_test_functions.py
@@ -148,7 +148,7 @@ def check_share_items_access(
     elif principal_type == 'ConsumptionRole':
         session = STSClient(
             role_arn=consumption_role.IAMRoleArn, region=dataset.region, session_name='ConsumptionRole'
-        ).get_role_session()
+        ).get_role_session(env_client)
     else:
         raise Exception('wrong principal type')
 


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->

- Bugfix

### Detail
- <feature1 or bug1>
- <feature2 or bug2>

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
