### PR TITLE
ES Search Query Collect All Response 

### DIFF
--- a/backend/dataall/modules/catalog/tasks/catalog_indexer_task.py
+++ b/backend/dataall/modules/catalog/tasks/catalog_indexer_task.py
@@ -43,12 +43,10 @@ class CatalogIndexerTask:
         # Search for documents in opensearch without an ID in the indexed_object_uris list
         query = {'query': {'bool': {'must_not': {'terms': {'_id': indexed_object_uris}}}}}
         # Delete All "Outdated" Objects from Index
-        docs = BaseIndexer.search(query)
-        for doc in docs.get('hits', {}).get('hits', []):
-            log.info(f'Deleting document {doc["_id"]}...')
+        docs = BaseIndexer.search_all(query, sort='_id')
+        for doc in docs:
             BaseIndexer.delete_doc(doc_id=doc['_id'])
-
-        log.info(f'Deleted {len(docs.get("hits", {}).get("hits", []))} records')
+        log.info(f'Deleted {len(docs)} records')
 
 
 if __name__ == '__main__':

--- a/frontend/src/modules/Maintenance/components/MaintenanceViewer.js
+++ b/frontend/src/modules/Maintenance/components/MaintenanceViewer.js
@@ -242,6 +242,7 @@ export const ReIndexConfirmationPopUp = (props) => {
               control={
                 <Switch
                   color="primary"
+                  checked={withDelete}
                   onChange={() => {
                     setWithDelete(!withDelete);
                   }}

--- a/tests/modules/s3_datasets/tasks/test_dataset_catalog_indexer.py
+++ b/tests/modules/s3_datasets/tasks/test_dataset_catalog_indexer.py
@@ -66,8 +66,8 @@ def test_catalog_indexer_with_deletes(db, org, env, sync_dataset, table, mocker)
         'dataall.modules.s3_datasets.indexers.dataset_indexer.DatasetIndexer.upsert', return_value=sync_dataset
     )
     mocker.patch(
-        'dataall.modules.catalog.indexers.base_indexer.BaseIndexer.search',
-        return_value={'hits': {'hits': [{'_id': table.tableUri}]}},
+        'dataall.modules.catalog.indexers.base_indexer.BaseIndexer.search_all',
+        return_value=[{'_id': table.tableUri}],
     )
     delete_doc_path = mocker.patch(
         'dataall.modules.catalog.indexers.base_indexer.BaseIndexer.delete_doc', return_value=True


### PR DESCRIPTION

### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- For `catalog_indexer_task` ensure we collect all hits from query response for `with_deletes` option
   -  Up the Query Size to 1000 results (default is 10)
   - Add logic to continue querying to collect all hits if there are more than the query size limit (i.e. > 1000)


### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
