### PR TITLE
set typeguard version 4.2.1

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -2,3 +2,4 @@ aws-cdk-lib==2.160.0
 boto3==1.35.26
 boto3-stubs==1.35.26
 cdk-nag==2.7.2
+typeguard==4.2.1


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- With latest bumps in dependency versions - `requirements.txt` had no set `typeguard` version installed so installing latst `4.3.0` which raised errors on `cdk synth` with the following:
    - `typeguard.TypeCheckError: aws_cdk.aws_ec2.Vpc is not compatible with the IVpc protocol because its 'add_client_vpn_endpoint' method has mandatory keyword-only arguments in its declaration: cidr, server_certificate_arn`
    - This looks like a bug coming from `jsii` similar to some other open issues like https://github.com/aws/jsii/issues/4531 and the subsequent issues linked to it

- Fixing `typeguard` to version `4.2.1` resolves the issue for the time being


### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
