### PR TITLE
Fix: check if Redshift table exists before publishing it to data.all

### DIFF
--- a/backend/dataall/modules/redshift_datasets/api/datasets/mutations.py
+++ b/backend/dataall/modules/redshift_datasets/api/datasets/mutations.py
@@ -44,7 +44,7 @@ addRedshiftDatasetTables = gql.MutationField(
         gql.Argument('datasetUri', gql.NonNullableType(gql.String)),
         gql.Argument('tables', gql.NonNullableType(gql.ArrayType(gql.String))),
     ],
-    type=gql.Boolean,
+    type=gql.Ref('RedshiftAddTableResult'),
     resolver=add_redshift_dataset_tables,
 )
 

--- a/backend/dataall/modules/redshift_datasets/api/datasets/types.py
+++ b/backend/dataall/modules/redshift_datasets/api/datasets/types.py
@@ -70,6 +70,8 @@ RedshiftDataset = gql.ObjectType(
             type=gql.Ref('RedshiftConnection'),
             resolver=resolve_dataset_connection,
         ),
+        gql.Field('successTables', gql.ArrayType(gql.String)),
+        gql.Field('errorTables', gql.ArrayType(gql.String)),
     ],
 )
 
@@ -150,4 +152,9 @@ RedshiftDatasetTableColumnSearchResult = gql.ObjectType(
         gql.Field('hasNext', gql.Boolean),
         gql.Field('hasPrevious', gql.Boolean),
     ],
+)
+
+RedshiftAddTableResult = gql.ObjectType(
+    name='RedshiftAddTableResult',
+    fields=[gql.Field('successTables', gql.ArrayType(gql.String)), gql.Field('errorTables', gql.ArrayType(gql.String))],
 )

--- a/backend/dataall/modules/redshift_datasets/api/datasets/types.py
+++ b/backend/dataall/modules/redshift_datasets/api/datasets/types.py
@@ -1,5 +1,3 @@
-from email.policy import default
-
 from dataall.base.api import gql
 from dataall.modules.datasets_base.services.datasets_enums import DatasetRole
 

--- a/backend/dataall/modules/redshift_datasets/api/datasets/types.py
+++ b/backend/dataall/modules/redshift_datasets/api/datasets/types.py
@@ -1,3 +1,5 @@
+from email.policy import default
+
 from dataall.base.api import gql
 from dataall.modules.datasets_base.services.datasets_enums import DatasetRole
 
@@ -70,8 +72,7 @@ RedshiftDataset = gql.ObjectType(
             type=gql.Ref('RedshiftConnection'),
             resolver=resolve_dataset_connection,
         ),
-        gql.Field('successTables', gql.ArrayType(gql.String)),
-        gql.Field('errorTables', gql.ArrayType(gql.String)),
+        gql.Field('addedTables', gql.Ref('RedshiftAddTableResult')),
     ],
 )
 

--- a/backend/dataall/modules/redshift_datasets/services/redshift_dataset_service.py
+++ b/backend/dataall/modules/redshift_datasets/services/redshift_dataset_service.py
@@ -119,8 +119,7 @@ class RedshiftDatasetService:
                 connection=connection,
                 tables=data.get('tables', []),
             )
-            dataset.successTables = success_tables
-            dataset.errorTables = error_tables
+            dataset.addedTables = {'successTables': success_tables, 'errorTables': error_tables}
         return dataset
 
     @staticmethod
@@ -158,6 +157,7 @@ class RedshiftDatasetService:
                 DatasetBaseRepository.update_dataset_activity(session, dataset, username)
 
             DatasetIndexer.upsert(session, dataset_uri=uri)
+            dataset.addedTables = {}
             return dataset
 
     @staticmethod
@@ -251,6 +251,7 @@ class RedshiftDatasetService:
             dataset = RedshiftDatasetRepository.get_redshift_dataset_by_uri(session, uri)
             if dataset.SamlAdminGroupName in context.groups:
                 dataset.userRoleForDataset = DatasetRole.Admin.value
+            dataset.addedTables = {}
             return dataset
 
     @staticmethod

--- a/frontend/src/modules/Redshift_Datasets/components/AddTablesModal.js
+++ b/frontend/src/modules/Redshift_Datasets/components/AddTablesModal.js
@@ -57,13 +57,24 @@ export const AddTablesModal = (props) => {
       })
     );
     if (!response.errors) {
-      enqueueSnackbar('Tables added', {
-        anchorOrigin: {
-          horizontal: 'right',
-          vertical: 'top'
-        },
-        variant: 'success'
-      });
+      if (response.data.addRedshiftDatasetTables.successTables.length > 0) {
+        enqueueSnackbar(
+          `Tables added: ${response.data.addRedshiftDatasetTables.successTables}`,
+          {
+            anchorOrigin: {
+              horizontal: 'right',
+              vertical: 'top'
+            },
+            variant: 'success'
+          }
+        );
+      }
+      if (response.data.addRedshiftDatasetTables.errorTables.length > 0) {
+        dispatch({
+          type: SET_ERROR,
+          error: `The following tables could not be imported, either they do not exist or the connection used has no access to them: ${response.data.addRedshiftDatasetTables.errorTables}`
+        });
+      }
       fetchItems();
       setSelectedTables(null);
     } else {

--- a/frontend/src/modules/Redshift_Datasets/services/addRedshiftDatasetTables.js
+++ b/frontend/src/modules/Redshift_Datasets/services/addRedshiftDatasetTables.js
@@ -10,7 +10,10 @@ export const addRedshiftDatasetTables = ({ datasetUri, tables }) => ({
       $datasetUri: String!
       $tables: [String]!
     ) {
-      addRedshiftDatasetTables(datasetUri: $datasetUri, tables: $tables)
+      addRedshiftDatasetTables(datasetUri: $datasetUri, tables: $tables) {
+        successTables
+        errorTables
+      }
     }
   `
 });

--- a/frontend/src/modules/Redshift_Datasets/services/importRedshiftDataset.js
+++ b/frontend/src/modules/Redshift_Datasets/services/importRedshiftDataset.js
@@ -10,6 +10,8 @@ export const importRedshiftDataset = (input) => ({
         datasetUri
         label
         userRoleForDataset
+        errorTables
+        successTables
       }
     }
   `

--- a/frontend/src/modules/Redshift_Datasets/services/importRedshiftDataset.js
+++ b/frontend/src/modules/Redshift_Datasets/services/importRedshiftDataset.js
@@ -10,8 +10,10 @@ export const importRedshiftDataset = (input) => ({
         datasetUri
         label
         userRoleForDataset
-        errorTables
-        successTables
+        addedTables {
+          errorTables
+          successTables
+        }
       }
     }
   `

--- a/frontend/src/modules/Redshift_Datasets/views/RSDatasetImportForm.js
+++ b/frontend/src/modules/Redshift_Datasets/views/RSDatasetImportForm.js
@@ -222,6 +222,24 @@ const RSDatasetImportForm = (props) => {
           },
           variant: 'success'
         });
+        if (response.data.importRedshiftDataset.successTables.length > 0) {
+          enqueueSnackbar(
+            `Tables added: ${response.data.importRedshiftDataset.successTables}`,
+            {
+              anchorOrigin: {
+                horizontal: 'right',
+                vertical: 'top'
+              },
+              variant: 'success'
+            }
+          );
+        }
+        if (response.data.importRedshiftDataset.errorTables.length > 0) {
+          dispatch({
+            type: SET_ERROR,
+            error: `The following tables could not be imported, either they do not exist or the connection used has no access to them: ${response.data.importRedshiftDataset.errorTables}`
+          });
+        }
         navigate(
           `/console/redshift-datasets/${response.data.importRedshiftDataset.datasetUri}`
         );

--- a/frontend/src/modules/Redshift_Datasets/views/RSDatasetImportForm.js
+++ b/frontend/src/modules/Redshift_Datasets/views/RSDatasetImportForm.js
@@ -222,9 +222,12 @@ const RSDatasetImportForm = (props) => {
           },
           variant: 'success'
         });
-        if (response.data.importRedshiftDataset.successTables.length > 0) {
+        if (
+          response.data.importRedshiftDataset.addedTables.successTables.length >
+          0
+        ) {
           enqueueSnackbar(
-            `Tables added: ${response.data.importRedshiftDataset.successTables}`,
+            `Tables added: ${response.data.importRedshiftDataset.addedTables.successTables}`,
             {
               anchorOrigin: {
                 horizontal: 'right',
@@ -234,10 +237,12 @@ const RSDatasetImportForm = (props) => {
             }
           );
         }
-        if (response.data.importRedshiftDataset.errorTables.length > 0) {
+        if (
+          response.data.importRedshiftDataset.addedTables.errorTables.length > 0
+        ) {
           dispatch({
             type: SET_ERROR,
-            error: `The following tables could not be imported, either they do not exist or the connection used has no access to them: ${response.data.importRedshiftDataset.errorTables}`
+            error: `The following tables could not be imported, either they do not exist or the connection used has no access to them: ${response.data.importRedshiftDataset.addedTables.errorTables}`
           });
         }
         navigate(

--- a/tests/modules/redshift_datasets/conftest.py
+++ b/tests/modules/redshift_datasets/conftest.py
@@ -222,7 +222,9 @@ def imported_redshift_dataset_1_no_tables(db, user, group, env_fixture, connecti
 
 
 @pytest.fixture(scope='function')
-def imported_redshift_dataset_2_with_tables(db, user, group, env_fixture, connection1_serverless, api_context_1):
+def imported_redshift_dataset_2_with_tables(
+    db, user, group, env_fixture, connection1_serverless, api_context_1, mock_redshift_data
+):
     dataset = RedshiftDatasetService.import_redshift_dataset(
         uri=env_fixture.environmentUri,
         admin_group=group.name,

--- a/tests/modules/redshift_datasets/test_unit_redshift_dataset_service.py
+++ b/tests/modules/redshift_datasets/test_unit_redshift_dataset_service.py
@@ -61,7 +61,7 @@ def test_delete_redshift_dataset_unauthorized(imported_redshift_dataset_1_no_tab
     ).contains('UnauthorizedOperation', 'DELETE_REDSHIFT_DATASET', imported_redshift_dataset_1_no_tables.datasetUri)
 
 
-def test_delete_redshift_dataset(env_fixture, group, connection1_serverless, api_context_1):
+def test_delete_redshift_dataset(env_fixture, group, connection1_serverless, api_context_1, mock_redshift_data):
     dataset = RedshiftDatasetService.import_redshift_dataset(
         uri=env_fixture.environmentUri,
         admin_group=group.name,
@@ -109,10 +109,10 @@ def test_delete_redshift_dataset_table_unauthorized(imported_dataset_2_table_1, 
 def test_delete_redshift_dataset_table(imported_redshift_dataset_1_no_tables, api_context_1):
     # Given`
     response = RedshiftDatasetService.add_redshift_dataset_tables(
-        uri=imported_redshift_dataset_1_no_tables.datasetUri, tables=['table-to-delete']
+        uri=imported_redshift_dataset_1_no_tables.datasetUri, tables=['table4']
     )
     tables = RedshiftDatasetService.list_redshift_dataset_tables(
-        uri=imported_redshift_dataset_1_no_tables.datasetUri, filter={'term': 'table-to-delete'}
+        uri=imported_redshift_dataset_1_no_tables.datasetUri, filter={'term': 'table4'}
     )
     # When
     response = RedshiftDatasetService.delete_redshift_dataset_table(uri=tables['nodes'][0].rsTableUri)

--- a/tests/modules/redshift_datasets/test_unit_redshift_dataset_service.py
+++ b/tests/modules/redshift_datasets/test_unit_redshift_dataset_service.py
@@ -99,6 +99,17 @@ def test_add_redshift_dataset_tables(imported_redshift_dataset_1_no_tables, api_
     assert_that(tables).contains_entry(count=1)
 
 
+def test_add_redshift_dataset_tables_invalid_table(
+    imported_redshift_dataset_1_no_tables, api_context_1, mock_redshift_data
+):
+    # When
+    response = RedshiftDatasetService.add_redshift_dataset_tables(
+        uri=imported_redshift_dataset_1_no_tables.datasetUri, tables=['table-does-not-exist']
+    )
+    assert_that(response.get('errorTables')).contains('table-does-not-exist')
+    assert_that(response.get('successTables')).is_empty()
+
+
 def test_delete_redshift_dataset_table_unauthorized(imported_dataset_2_table_1, api_context_2):
     # When
     assert_that(RedshiftDatasetService.delete_redshift_dataset_table).raises(Exception).when_called_with(

--- a/tests_new/integration_tests/modules/redshift_datasets/dataset_queries.py
+++ b/tests_new/integration_tests/modules/redshift_datasets/dataset_queries.py
@@ -242,8 +242,12 @@ def import_redshift_dataset(
                 label
                 userRoleForDataset
                 connection {
-                 connectionUri
-                 } 
+                    connectionUri
+                }
+                addedTables {
+                    errorTables
+                    successTables
+                }
               }
             }
         """,

--- a/tests_new/integration_tests/modules/redshift_datasets/dataset_queries.py
+++ b/tests_new/integration_tests/modules/redshift_datasets/dataset_queries.py
@@ -303,7 +303,10 @@ def add_redshift_dataset_tables(client, dataset_uri, tables):
               $datasetUri: String!
               $tables: [String]!
             ) {
-              addRedshiftDatasetTables(datasetUri: $datasetUri, tables: $tables)
+              addRedshiftDatasetTables(datasetUri: $datasetUri, tables: $tables) {
+                successTables
+                errorTables
+              }
             }
         """,
     }

--- a/tests_new/integration_tests/modules/redshift_datasets/test_redshift_dataset.py
+++ b/tests_new/integration_tests/modules/redshift_datasets/test_redshift_dataset.py
@@ -125,9 +125,23 @@ def test_add_redshift_dataset_tables(client1, session_redshift_dataset_serverles
     response = add_redshift_dataset_tables(
         client=client1, dataset_uri=session_redshift_dataset_serverless.datasetUri, tables=[REDSHIFT_TABLE2]
     )
-    assert_that(response).is_true()
+    assert_that(response.successTables).contains(REDSHIFT_TABLE2)
+    assert_that(response.errorTables).is_empty()
     tables = list_redshift_dataset_tables(client=client1, dataset_uri=session_redshift_dataset_serverless.datasetUri)
     assert_that(tables.count).is_equal_to(initial_number_of_tables + 1)
+
+
+def test_add_redshift_dataset_tables_invalid_table(client1, session_redshift_dataset_serverless):
+    initial_number_of_tables = list_redshift_dataset_tables(
+        client=client1, dataset_uri=session_redshift_dataset_serverless.datasetUri
+    ).count
+    response = add_redshift_dataset_tables(
+        client=client1, dataset_uri=session_redshift_dataset_serverless.datasetUri, tables=['does-not-exist']
+    )
+    assert_that(response.successTables).is_empty()
+    assert_that(response.errorTables).contains('does-not-exist')
+    tables = list_redshift_dataset_tables(client=client1, dataset_uri=session_redshift_dataset_serverless.datasetUri)
+    assert_that(tables.count).is_equal_to(initial_number_of_tables)
 
 
 def test_add_redshift_dataset_tables_unauthorized(client2, session_redshift_dataset_serverless):
@@ -162,7 +176,7 @@ def test_delete_redshift_dataset_table(client1, session_redshift_dataset_serverl
         response = add_redshift_dataset_tables(
             client=client1, dataset_uri=session_redshift_dataset_serverless.datasetUri, tables=[REDSHIFT_TABLE2]
         )
-        assert_that(response).is_true()
+        assert_that(response.successTables).contains(REDSHIFT_TABLE2)
     table_2 = list_redshift_dataset_tables(
         client=client1, dataset_uri=session_redshift_dataset_serverless.datasetUri, term=REDSHIFT_TABLE2
     ).nodes[0]


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Currently when we hit the addRedshiftTable api, we do not check if the provided table exists in Redshift. In the UI the users must select from a list that retrieves the Redshift tables, but programmatically they could introduce any table, which can result in non-existent tables being added to the data.all Catalog.

This PR 
1) checks if a table exists in Redshift and is accessible by the Redshift connection before adding it to data.all
2) in the UI, it shows a success banner with the list of tables added and an error banner with the list of error tables if any.
 
### Testing
- Tested in AWS 
      - UI views show banner with added tables for importDataset and addDataset
      - UI import Dataset does not show anything if no tables are added
- Added unit tests - checked as part of PR checks 🟢 
- Added integration tests -  attached screenshot of redshift dataset tests

![image](https://github.com/user-attachments/assets/e7e40b97-74ac-4d4c-9590-11c22055f524)

### Relates
- #1424 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
