### PR TITLE
Fix error message of Redshift share verifier

### DIFF
--- a/backend/dataall/modules/redshift_datasets_shares/aws/redshift.py
+++ b/backend/dataall/modules/redshift_datasets_shares/aws/redshift.py
@@ -42,7 +42,7 @@ class RedshiftShareClient:
             log.info(f'Checking status of datashare {datashare_arn=} for {consumer_id=}')
             response = self.client.describe_data_shares(DataShareArn=datashare_arn)
             all_datashares = response.get('DataShares', [])
-            if len(all_datashares) == 0:
+            if not all_datashares:
                 return RedshiftDatashareStatus.NotFound.value
             consumer_datashares = [
                 d.get('Status')


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
The share verify task for Redshift shares was returning a `list index out of range` error when verifying the health of a share given that the datashare was desauthorized in the source.

Tested in AWS:

![Screenshot 2024-10-17 at 14 44 31](https://github.com/user-attachments/assets/fa008a2a-4b99-46eb-bb6d-635d518159a3)

### Relates
- #955 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
