### PR TITLE
Upgrade `http-proxy-middleware` 2.0.7

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20885,9 +20885,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -100,7 +100,8 @@
     "path-to-regexp": "0.1.10",
     "body-parser": "^1.20.3",
     "send": "0.19.0",
-    "rollup": "3.29.5"
+    "rollup": "3.29.5",
+    "http-proxy-middleware": "2.0.7"
   },
   "resolutions": {
     "react-redux": "^7.2.6",
@@ -120,7 +121,8 @@
     "path-to-regexp": "0.1.10",
     "body-parser": "^1.20.3",
     "send": "0.19.0",
-    "rollup": "3.29.5"
+    "rollup": "3.29.5",
+    "http-proxy-middleware": "2.0.7"
   },
   "devDependencies": {
     "env-cmd": "^10.1.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9201,10 +9201,10 @@ http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@^2.0.3:
-  version "2.0.6"
-  resolved "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz"
-  integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==
+http-proxy-middleware@2.0.7:
+  version "2.0.7"
+  resolved "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz"
+  integrity sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==
   dependencies:
     "@types/http-proxy" "^1.17.8"
     http-proxy "^1.18.1"


### PR DESCRIPTION
### Feature or Bugfix
- Upgrade dependencies


### Detail
Upgrade `http-proxy-middleware` from 2.0.6 -> 2.0.7
Solves: https://github.com/advisories/GHSA-c7qv-q95q-8v27
### Relates
- https://github.com/advisories/GHSA-c7qv-q95q-8v27

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
