### PR TITLE
Added error view and unified utility to check tenant user

### DIFF
--- a/frontend/src/authentication/components/MaintenanceGuard.js
+++ b/frontend/src/authentication/components/MaintenanceGuard.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
-import { isModuleEnabled, ModuleNames } from 'utils';
+import { isModuleEnabled, isTenantUser, ModuleNames } from 'utils';
 import { useClient, useGroups } from 'services';
 import { LoadingScreen, NoAccessMaintenanceWindow } from 'design';
 import { getMaintenanceStatus } from '../../modules/Maintenance/services';
@@ -25,7 +25,7 @@ export const MaintenanceGuard = (props) => {
           response.data.getMaintenanceWindowStatus.status
         ) &&
         response.data.getMaintenanceWindowStatus.mode === 'NO-ACCESS' &&
-        !groups.includes('DAAdministrators')
+        !isTenantUser(groups)
       ) {
         setNoAccessMaintenanceFlag(true);
       } else {

--- a/frontend/src/design/components/popovers/AccountPopover.js
+++ b/frontend/src/design/components/popovers/AccountPopover.js
@@ -16,6 +16,7 @@ import { useGroups } from 'services';
 import { CogIcon } from '../../icons';
 import { TextAvatar } from '../TextAvatar';
 import { useAuth } from 'authentication';
+import { isTenantUser } from 'utils';
 
 export const AccountPopover = () => {
   const anchorRef = useRef(null);
@@ -84,7 +85,7 @@ export const AccountPopover = () => {
         </Box>
         <Divider />
         <Box sx={{ mt: 2 }}>
-          {groups && groups.indexOf('DAAdministrators') !== -1 && (
+          {isTenantUser(groups) && (
             <MenuItem component={RouterLink} to="/console/administration">
               <ListItemIcon>
                 <CogIcon fontSize="small" />

--- a/frontend/src/modules/Administration/views/AdministrationView.js
+++ b/frontend/src/modules/Administration/views/AdministrationView.js
@@ -1,6 +1,10 @@
 import {
+  Alert,
   Box,
   Breadcrumbs,
+  Card,
+  CardHeader,
+  CardContent,
   Container,
   Divider,
   Grid,
@@ -15,8 +19,9 @@ import { Link as RouterLink } from 'react-router-dom';
 import { ChevronRightIcon, useSettings } from 'design';
 import { AdministrationTeams, DashboardViewer } from '../components';
 import { MaintenanceViewer } from '../../Maintenance/components/MaintenanceViewer';
-import { isModuleEnabled, ModuleNames } from 'utils';
+import { isModuleEnabled, ModuleNames, isTenantUser } from 'utils';
 import config from '../../../generated/config.json';
+import { useGroups } from 'services';
 
 const tabs = [{ label: 'Teams', value: 'teams' }];
 
@@ -30,13 +35,37 @@ if (isModuleEnabled(ModuleNames.MAINTENANCE)) {
 
 const AdministrationView = () => {
   const { settings } = useSettings();
+  const groups = useGroups();
   const [currentTab, setCurrentTab] = useState('teams');
 
   const handleTabsChange = (event, value) => {
     setCurrentTab(value);
   };
 
-  return (
+  return !isTenantUser(groups) ? (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: '100vh',
+        backgroundColor: 'background.default'
+      }}
+    >
+      <Card sx={{ maxWidth: 400 }}>
+        <CardHeader
+          title="Unauthorized Access"
+          sx={{ bgcolor: 'error.main', color: 'error.contrastText' }}
+        />
+        <CardContent>
+          <Alert severity="error">
+            You do not have permission to view this page. Please contact an
+            administrator if you believe this is an error.
+          </Alert>
+        </CardContent>
+      </Card>
+    </Box>
+  ) : (
     <>
       <Helmet>
         <title>Administration: Settings | data.all</title>

--- a/frontend/src/utils/helpers/index.js
+++ b/frontend/src/utils/helpers/index.js
@@ -3,3 +3,4 @@ export * from './dayjs';
 export * from './listToTree';
 export * from './moduleUtils';
 export * from './linkMarkup';
+export * from './tenantUtils';

--- a/frontend/src/utils/helpers/tenantUtils.js
+++ b/frontend/src/utils/helpers/tenantUtils.js
@@ -1,0 +1,5 @@
+function isTenantUser(groups) {
+  return groups && groups.includes('DAAdministrators');
+}
+
+export { isTenantUser };


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
Users that do not belong to the DAAdministrators team can still navigate to the admin console. They cannot do anything as all the API calls will return errors. This PR takes it a step further and shows an error message and does not render any of the components if the admin view. Here is an snapshot of what users view:

I considered restricting the route in routes, but because we need to use the useGroups hook, it was giving a lot of errors.


![image](https://github.com/user-attachments/assets/561dcb84-941b-4f01-8a62-18213364f5e8)


In addition, we have created a utility that unifies the checks to this Cognito group in other places of the frontend.


### Relates


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
