### PR TITLE
Add Removal Policy Retain to Bucket Policy IaC

### DIFF
--- a/backend/dataall/core/environment/cdk/environment_stack.py
+++ b/backend/dataall/core/environment/cdk/environment_stack.py
@@ -176,6 +176,7 @@ class EnvironmentSetup(Stack):
             versioned=True,
             enforce_ssl=True,
         )
+        default_environment_bucket.policy.apply_removal_policy(RemovalPolicy.RETAIN)
         self.default_environment_bucket = default_environment_bucket
 
         default_environment_bucket.add_to_resource_policy(

--- a/backend/dataall/modules/s3_datasets/cdk/dataset_stack.py
+++ b/backend/dataall/modules/s3_datasets/cdk/dataset_stack.py
@@ -132,6 +132,7 @@ class DatasetStack(Stack):
                 'DatasetKmsKey',
                 alias=dataset.KmsAlias,
                 enable_key_rotation=True,
+                removal_policy=RemovalPolicy.RETAIN,
                 policy=iam.PolicyDocument(
                     statements=[
                         iam.PolicyStatement(
@@ -184,6 +185,7 @@ class DatasetStack(Stack):
                 bucket_name=dataset.S3BucketName,
                 encryption=s3.BucketEncryption.KMS,
                 encryption_key=dataset_key,
+                removal_policy=RemovalPolicy.RETAIN,
                 cors=[
                     s3.CorsRule(
                         allowed_methods=[
@@ -209,6 +211,7 @@ class DatasetStack(Stack):
                 versioned=True,
                 bucket_key_enabled=True,
             )
+            dataset_bucket.policy.apply_removal_policy(RemovalPolicy.RETAIN)
 
             dataset_bucket.add_lifecycle_rule(
                 abort_incomplete_multipart_upload_after=Duration.days(7),


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- 

### Detail
- Add Removal Policy Retain to Bucket Policy IaC where applicable
    - Retain Bucket, KMS Key, and Policy for Created Datasets on Delete
    - Retain Bucket and Bucket Policy (SSE-S3 encrypted so no key) for Environments

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
