### PR TITLE
Fix: integration tests missing default value for principalRoleName and msg in exception forceDelete task

### DIFF
--- a/backend/dataall/modules/shares_base/api/input_types.py
+++ b/backend/dataall/modules/shares_base/api/input_types.py
@@ -11,7 +11,9 @@ NewShareObjectInput = gql.InputType(
         gql.Argument(name='principalType', type=gql.NonNullableType(gql.String)),
         gql.Argument(name='requestPurpose', type=gql.String),
         gql.Argument(name='attachMissingPolicies', type=gql.Boolean),
-        gql.Argument(name='permissions', type=gql.ArrayType(ShareObjectDataPermission.toGraphQLEnum())),
+        gql.Argument(
+            name='permissions', type=gql.NonNullableType(gql.ArrayType(ShareObjectDataPermission.toGraphQLEnum()))
+        ),
         gql.Argument(name='shareExpirationPeriod', type=gql.Integer),
         gql.Argument(name='nonExpirable', type=gql.Boolean),
     ],

--- a/backend/dataall/modules/shares_base/services/share_manager_utils.py
+++ b/backend/dataall/modules/shares_base/services/share_manager_utils.py
@@ -36,4 +36,4 @@ def execute_and_suppress_exception(func: Callable, exc: Type[Exception] = Except
     try:
         func(*args, **kwargs)
     except exc:
-        logger.exception()
+        logger.exception('')

--- a/backend/dataall/modules/shares_base/services/sharing_service.py
+++ b/backend/dataall/modules/shares_base/services/sharing_service.py
@@ -383,9 +383,9 @@ class SharingService:
                     if shareable_items:
                         processor.Processor(session, share_data, shareable_items).cleanup_shares()
                     else:
-                        log.info(f'There are no items to verify of type {type.value}')
+                        log.info(f'There are no items to clean-up of type {type.value}')
                 except Exception as e:
-                    log.error(f'Error occurred during share verifying of {type.value}: {e}')
+                    log.error(f'Error occurred during clean-up of {type.value}: {e}')
 
         return True
 

--- a/tests_new/integration_tests/modules/shares/queries.py
+++ b/tests_new/integration_tests/modules/shares/queries.py
@@ -9,9 +9,9 @@ def create_share_object(
     groupUri,
     principalId,
     principalType,
-    requestPurpose,
-    attachMissingPolicies,
     permissions,
+    requestPurpose=None,
+    attachMissingPolicies=None,
     principalRoleName=None,
 ):
     query = {

--- a/tests_new/integration_tests/modules/shares/queries.py
+++ b/tests_new/integration_tests/modules/shares/queries.py
@@ -8,11 +8,11 @@ def create_share_object(
     environmentUri,
     groupUri,
     principalId,
-    principalRoleName,
     principalType,
     requestPurpose,
     attachMissingPolicies,
     permissions,
+    principalRoleName=None,
 ):
     query = {
         'operationName': 'createShareObject',


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- principalRoleName default to None in the integration tests query functions (it is already nullable in backend)
- added msg argument to the forceDelete exception handling.

### Relates


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
