### PR TITLE
log API handler response only for LOG_LEVEL DEBUG. Set log level INFO for prod deployments

### DIFF
--- a/backend/api_handler.py
+++ b/backend/api_handler.py
@@ -141,8 +141,8 @@ def handler(event, context):
     dispose_context()
     response = json.dumps(response)
 
-    log.info('Lambda Response %s', response)
-
+    log.info('Lambda Response Success: %s', success)
+    log.debug('Lambda Response %s', response)
     return {
         'statusCode': 200 if success else 400,
         'headers': {

--- a/backend/aws_handler.py
+++ b/backend/aws_handler.py
@@ -7,7 +7,7 @@ from dataall.base.db import get_engine
 from dataall.base.loader import load_modules, ImportMode
 
 logger = logging.getLogger()
-logger.setLevel(os.environ.get('LOG_LEVEL'))
+logger.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 log = logging.getLogger(__name__)
 
 ENVNAME = os.getenv('envname', 'local')

--- a/backend/dataall/base/aws/quicksight.py
+++ b/backend/dataall/base/aws/quicksight.py
@@ -3,8 +3,7 @@ import re
 
 from .sts import SessionHelper
 
-logger = logging.getLogger('QuicksightHandler')
-logger.setLevel(logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 
 class QuicksightClient:

--- a/backend/dataall/core/environment/tasks/env_stacks_updater.py
+++ b/backend/dataall/core/environment/tasks/env_stacks_updater.py
@@ -13,10 +13,10 @@ from dataall.base.db import get_engine
 from dataall.base.utils import Parameter
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 RETRIES = 30
 SLEEP_TIME = 30

--- a/backend/dataall/core/stacks/tasks/cdkproxy.py
+++ b/backend/dataall/core/stacks/tasks/cdkproxy.py
@@ -6,10 +6,10 @@ from dataall.base.cdkproxy.cdk_cli_wrapper import deploy_cdk_stack
 from dataall.base.db import get_engine
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 logger = logging.getLogger(__name__)
+logger.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 if __name__ == '__main__':

--- a/backend/dataall/modules/catalog/tasks/catalog_indexer_task.py
+++ b/backend/dataall/modules/catalog/tasks/catalog_indexer_task.py
@@ -10,10 +10,10 @@ from dataall.base.loader import load_modules, ImportMode
 from dataall.base.utils.alarm_service import AlarmService
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 class CatalogIndexerTask:

--- a/backend/dataall/modules/dashboards/aws/dashboard_quicksight_client.py
+++ b/backend/dataall/modules/dashboards/aws/dashboard_quicksight_client.py
@@ -9,7 +9,6 @@ from dataall.base.aws.quicksight import QuicksightClient
 from dataall.base.aws.secrets_manager import SecretsManager
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 class DashboardQuicksightClient:

--- a/backend/dataall/modules/notifications/handlers/notifications_handler.py
+++ b/backend/dataall/modules/notifications/handlers/notifications_handler.py
@@ -5,7 +5,6 @@ from dataall.core.tasks.db.task_models import Task
 from dataall.modules.notifications.services.ses_email_notification_service import SESEmailNotificationService
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.INFO)
 
 
 class NotificationHandler:

--- a/backend/dataall/modules/omics/tasks/omics_workflows_fetcher.py
+++ b/backend/dataall/modules/omics/tasks/omics_workflows_fetcher.py
@@ -12,10 +12,10 @@ from dataall.modules.omics.db.omics_repository import OmicsRepository
 
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 def fetch_omics_workflows(engine):

--- a/backend/dataall/modules/s3_datasets/tasks/tables_syncer.py
+++ b/backend/dataall/modules/s3_datasets/tasks/tables_syncer.py
@@ -17,10 +17,10 @@ from dataall.modules.s3_datasets.indexers.dataset_indexer import DatasetIndexer
 from dataall.modules.s3_datasets.services.dataset_alarm_service import DatasetAlarmService
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 def sync_tables(engine):

--- a/backend/dataall/modules/s3_datasets_shares/tasks/dataset_subscription_task.py
+++ b/backend/dataall/modules/s3_datasets_shares/tasks/dataset_subscription_task.py
@@ -23,10 +23,10 @@ from dataall.modules.shares_base.db.share_object_models import ShareObject
 from dataall.modules.shares_base.services.share_notification_service import DataSharingNotificationType
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 # TODO: review this task usage and remove if not needed
 

--- a/backend/dataall/modules/s3_datasets_shares/tasks/subscriptions/sqs_poller.py
+++ b/backend/dataall/modules/s3_datasets_shares/tasks/subscriptions/sqs_poller.py
@@ -7,10 +7,10 @@ import boto3
 from botocore.exceptions import ClientError
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 ENVNAME = os.getenv('envname', 'local')
 region = os.getenv('AWS_REGION', 'eu-west-1')

--- a/backend/dataall/modules/shares_base/tasks/persistent_email_reminders_task.py
+++ b/backend/dataall/modules/shares_base/tasks/persistent_email_reminders_task.py
@@ -10,10 +10,10 @@ from dataall.modules.datasets_base.db.dataset_repositories import DatasetBaseRep
 
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 def persistent_email_reminders(engine):

--- a/backend/dataall/modules/shares_base/tasks/share_expiration_task.py
+++ b/backend/dataall/modules/shares_base/tasks/share_expiration_task.py
@@ -13,10 +13,10 @@ from dataall.modules.shares_base.services.shares_enums import ShareObjectActions
 from dataall.modules.shares_base.services.sharing_service import SharingService
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 def share_expiration_checker(engine):

--- a/backend/dataall/modules/shares_base/tasks/share_manager_task.py
+++ b/backend/dataall/modules/shares_base/tasks/share_manager_task.py
@@ -7,10 +7,10 @@ from dataall.base.db import get_engine
 from dataall.base.loader import load_modules, ImportMode
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 if __name__ == '__main__':

--- a/backend/dataall/modules/shares_base/tasks/share_reapplier_task.py
+++ b/backend/dataall/modules/shares_base/tasks/share_reapplier_task.py
@@ -12,10 +12,10 @@ from dataall.base.db import get_engine
 from dataall.base.loader import load_modules, ImportMode
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 class EcsBulkShareRepplyService:

--- a/backend/dataall/modules/shares_base/tasks/share_verifier_task.py
+++ b/backend/dataall/modules/shares_base/tasks/share_verifier_task.py
@@ -12,10 +12,10 @@ from dataall.base.db import get_engine
 from dataall.base.loader import load_modules, ImportMode
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
 if not root.hasHandlers():
     root.addHandler(logging.StreamHandler(sys.stdout))
 log = logging.getLogger(__name__)
+log.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 def verify_shares(engine):

--- a/deploy/stacks/container.py
+++ b/deploy/stacks/container.py
@@ -52,12 +52,13 @@ class ContainerStack(pyNestedClass):
         self._ecr_repository = ecr_repository
         self._vpc = vpc
         self._prod_sizing = prod_sizing
+        self._log_level = 'INFO' if prod_sizing else 'DEBUG'
 
         (self.scheduled_tasks_sg, self.share_manager_sg) = self.create_ecs_security_groups(
             envname, resource_prefix, vpc, vpce_connection, s3_prefix_list, lambdas
         )
         self.ecs_security_groups: [aws_ec2.SecurityGroup] = [self.scheduled_tasks_sg, self.share_manager_sg]
-        self.env_vars = self._create_env('INFO')
+        self.env_vars = self._create_env()
 
         # Check if custom domain exists and if it exists email notifications could be enabled.
         # Create an env variable which stores the domain URL.
@@ -160,7 +161,7 @@ class ContainerStack(pyNestedClass):
             command=['python3.9', '-m', 'dataall.core.environment.tasks.env_stacks_updater'],
             container_id='container',
             ecr_repository=ecr_repository,
-            environment=self._create_env('INFO'),
+            environment=self._create_env(),
             image_tag=self._cdkproxy_image_tag,
             log_group=self.create_log_group(envname, resource_prefix, log_group_name='stacks-updater'),
             schedule_expression=Schedule.expression('cron(0 1 * * ? *)'),
@@ -216,7 +217,7 @@ class ContainerStack(pyNestedClass):
             command=['python3.9', '-m', 'dataall.modules.catalog.tasks.catalog_indexer_task'],
             container_id=container_id,
             ecr_repository=self._ecr_repository,
-            environment=self._create_env('INFO'),
+            environment=self._create_env(),
             image_tag=self._cdkproxy_image_tag,
             log_group=self.create_log_group(self._envname, self._resource_prefix, log_group_name='catalog-indexer'),
             schedule_expression=Schedule.expression('rate(6 hours)'),
@@ -260,7 +261,7 @@ class ContainerStack(pyNestedClass):
             f'ShareManagementTaskContainer{self._envname}',
             container_name='container',
             image=ecs.ContainerImage.from_ecr_repository(repository=self._ecr_repository, tag=self._cdkproxy_image_tag),
-            environment=self._create_env('DEBUG'),
+            environment=self._create_env(),
             command=['python3.9', '-m', 'dataall.modules.shares_base.tasks.share_manager_task'],
             logging=ecs.LogDriver.aws_logs(
                 stream_prefix='task',
@@ -291,7 +292,7 @@ class ContainerStack(pyNestedClass):
             command=['python3.9', '-m', 'dataall.modules.shares_base.tasks.share_verifier_task'],
             container_id='container',
             ecr_repository=self._ecr_repository,
-            environment=self._create_env('INFO'),
+            environment=self._create_env(),
             image_tag=self._cdkproxy_image_tag,
             log_group=self.create_log_group(self._envname, self._resource_prefix, log_group_name='share-verifier'),
             schedule_expression=Schedule.expression('rate(7 days)'),
@@ -320,7 +321,7 @@ class ContainerStack(pyNestedClass):
             f'ShareReapplierTaskContainer{self._envname}',
             container_name='container',
             image=ecs.ContainerImage.from_ecr_repository(repository=self._ecr_repository, tag=self._cdkproxy_image_tag),
-            environment=self._create_env('INFO'),
+            environment=self._create_env(),
             command=['python3.9', '-m', 'dataall.modules.shares_base.tasks.share_reapplier_task'],
             logging=ecs.LogDriver.aws_logs(
                 stream_prefix='task',
@@ -382,7 +383,7 @@ class ContainerStack(pyNestedClass):
             ],
             container_id='container',
             ecr_repository=self._ecr_repository,
-            environment=self._create_env('INFO'),
+            environment=self._create_env(),
             image_tag=self._cdkproxy_image_tag,
             log_group=self.create_log_group(self._envname, self._resource_prefix, log_group_name='subscriptions'),
             schedule_expression=Schedule.expression('rate(15 minutes)'),
@@ -402,7 +403,7 @@ class ContainerStack(pyNestedClass):
             command=['python3.9', '-m', 'dataall.modules.s3_datasets.tasks.tables_syncer'],
             container_id='container',
             ecr_repository=self._ecr_repository,
-            environment=self._create_env('INFO'),
+            environment=self._create_env(),
             image_tag=self._cdkproxy_image_tag,
             log_group=self.create_log_group(self._envname, self._resource_prefix, log_group_name='tables-syncer'),
             schedule_expression=Schedule.expression('rate(15 minutes)'),
@@ -422,7 +423,7 @@ class ContainerStack(pyNestedClass):
             command=['python3.9', '-m', 'dataall.modules.omics.tasks.omics_workflows_fetcher'],
             container_id='container',
             ecr_repository=self._ecr_repository,
-            environment=self._create_env('DEBUG'),
+            environment=self._create_env(),
             image_tag=self._cdkproxy_image_tag,
             log_group=self.create_log_group(
                 self._envname, self._resource_prefix, log_group_name='omics-workflows-fetcher'
@@ -822,10 +823,10 @@ class ContainerStack(pyNestedClass):
     def ecs_task_role(self) -> iam.Role:
         return self.task_role
 
-    def _create_env(self, log_lvl) -> Dict:
+    def _create_env(self) -> Dict:
         return {
             'AWS_REGION': self.region,
             'envname': self._envname,
-            'LOGLEVEL': log_lvl,
+            'LOG_LEVEL': self._log_level,
             'config_location': '/config.json',
         }

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -64,6 +64,7 @@ class LambdaApiStack(pyNestedClass):
         super().__init__(scope, id, **kwargs)
 
         self.log_retention_duration = log_retention_duration
+        log_level = 'INFO' if prod_sizing else 'DEBUG'
 
         if self.node.try_get_context('image_tag'):
             image_tag = self.node.try_get_context('image_tag')
@@ -100,7 +101,7 @@ class LambdaApiStack(pyNestedClass):
 
         self.esproxy_dlq = self.set_dlq(f'{resource_prefix}-{envname}-esproxy-dlq')
         esproxy_sg = self.create_lambda_sgs(envname, 'esproxy', resource_prefix, vpc)
-        esproxy_env = {'envname': envname, 'LOG_LEVEL': 'INFO', 'ALLOWED_ORIGINS': allowed_origins}
+        esproxy_env = {'envname': envname, 'LOG_LEVEL': log_level, 'ALLOWED_ORIGINS': allowed_origins}
         if custom_auth:
             esproxy_env['custom_auth'] = custom_auth.get('provider', None)
         self.elasticsearch_proxy_handler = _lambda.DockerImageFunction(
@@ -134,7 +135,7 @@ class LambdaApiStack(pyNestedClass):
         api_handler_sg = self.create_lambda_sgs(envname, 'apihandler', resource_prefix, vpc)
         api_handler_env = {
             'envname': envname,
-            'LOG_LEVEL': 'INFO',
+            'LOG_LEVEL': log_level,
             'REAUTH_TTL': str(reauth_ttl),
             'ALLOWED_ORIGINS': allowed_origins,
         }
@@ -174,7 +175,7 @@ class LambdaApiStack(pyNestedClass):
         awsworker_sg = self.create_lambda_sgs(envname, 'awsworker', resource_prefix, vpc)
         awshandler_env = {
             'envname': envname,
-            'LOG_LEVEL': 'INFO',
+            'LOG_LEVEL': log_level,
             'email_sender_id': email_notification_sender_email_id,
         }
         self.aws_handler = _lambda.DockerImageFunction(


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Define LOG_LEVEL based on prod_sizing parameter: for prod deployments LOG_LEVEL=INFO, for non-prod deployments LOG_LEVEL=DEBUG. Set it as environment variable for backend Lambdas and ECS tasks
- Remove any hardcoded setLevel and re-use the environment variable
- For the API handler Lambda, log the response of the API call with level=DEBUG and log the success with level=INFO.

### Testing
Deployed in AWS, CICD pipeline succeeds (with prod_sizing=False)
- API calls work as usual - logs collect INFO (logs success) and DEBUG (logs lambda response)
- ECS tasks work as usual - tested with CDK proxy call



### Relates


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
