### PR TITLE
fix: missing CREATE_SHARE_OBJECT permission in integration tests

### DIFF
--- a/tests_new/integration_tests/core/environment/global_conftest.py
+++ b/tests_new/integration_tests/core/environment/global_conftest.py
@@ -51,7 +51,7 @@ def session_env1(client1, group1, group5, org1, session_id, testdata):
         env = create_env(
             client1, 'session_env1', group1, org1.organizationUri, envdata.accountId, envdata.region, tags=[session_id]
         )
-        invite_group_on_env(client1, env.environmentUri, group5, ['CREATE_DATASET'])
+        invite_group_on_env(client1, env.environmentUri, group5, ['CREATE_DATASET', 'CREATE_SHARE_OBJECT'])
         yield env
     finally:
         if env:


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Add CREATE_SHARE_OBJECT to group 5 invited to session_env1 in integration test. Needed to test the integration tests of Redshift

### Relates
- #1620 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
