### PR TITLE
Fix: Remove optional AllowWrites - not supported in all regions

### DIFF
--- a/backend/dataall/modules/redshift_datasets_shares/aws/redshift.py
+++ b/backend/dataall/modules/redshift_datasets_shares/aws/redshift.py
@@ -19,7 +19,9 @@ class RedshiftShareClient:
         """
         try:
             log.info(f'Authorizing datashare {datashare_arn=} to consumer {account}...')
-            self.client.authorize_data_share(DataShareArn=datashare_arn, ConsumerIdentifier=account, AllowWrites=False)
+            self.client.authorize_data_share(
+                DataShareArn=datashare_arn, ConsumerIdentifier=account
+            )  # AllowWrites in preview
         except ClientError as e:
             log.error(e)
             raise e


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Redshift sharing is implemented for the READ-only datashares. Write datashares is in preview in multiple regions, but in those regions where it is still not in preview, using the AllowWrites parameter in the API call of authorize_data_share results in an error of the type `An error occurred (InvalidParameterValue) when calling the AuthorizeDataShare operation: DATA_SHARING_WRITES support is not yet available.`

This PR removes the usage of that parameter, which was in either case already using the default value (allowWrites=False)

### Relates
- #955 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
