### PR TITLE
Limit Response info dataset queries

### DIFF
--- a/backend/dataall/modules/dashboards/api/types.py
+++ b/backend/dataall/modules/dashboards/api/types.py
@@ -19,17 +19,13 @@ Dashboard = gql.ObjectType(
         gql.Field('DashboardId', type=gql.String),
         gql.Field('tags', type=gql.ArrayType(gql.String)),
         gql.Field('created', type=gql.String),
+        gql.Field('AwsAccountId', type=gql.String),
         gql.Field('updated', type=gql.String),
         gql.Field('owner', type=gql.String),
         gql.Field('SamlGroupName', type=gql.String),
         gql.Field(
-            'organization',
-            type=gql.Ref('Organization'),
-            resolver=get_dashboard_organization,
-        ),
-        gql.Field(
             'environment',
-            type=gql.Ref('Environment'),
+            type=gql.Ref('EnvironmentSimplified'),
             resolver=resolve_environment,
         ),
         gql.Field(

--- a/backend/dataall/modules/datasets_base/api/types.py
+++ b/backend/dataall/modules/datasets_base/api/types.py
@@ -31,13 +31,8 @@ DatasetBase = gql.ObjectType(
         gql.Field(name='imported', type=gql.Boolean),
         gql.Field(
             name='environment',
-            type=gql.Ref('Environment'),
+            type=gql.Ref('EnvironmentSimplified'),
             resolver=get_dataset_environment,
-        ),
-        gql.Field(
-            name='organization',
-            type=gql.Ref('Organization'),
-            resolver=get_dataset_organization,
         ),
         gql.Field(
             name='owners',

--- a/backend/dataall/modules/redshift_datasets/api/datasets/types.py
+++ b/backend/dataall/modules/redshift_datasets/api/datasets/types.py
@@ -32,13 +32,8 @@ RedshiftDataset = gql.ObjectType(
         gql.Field('imported', gql.Boolean),
         gql.Field(
             name='environment',
-            type=gql.Ref('Environment'),
+            type=gql.Ref('EnvironmentSimplified'),
             resolver=resolve_dataset_environment,
-        ),
-        gql.Field(
-            name='organization',
-            type=gql.Ref('Organization'),
-            resolver=resolve_dataset_organization,
         ),
         gql.Field(
             name='owners',

--- a/backend/dataall/modules/s3_datasets/api/dataset/types.py
+++ b/backend/dataall/modules/s3_datasets/api/dataset/types.py
@@ -60,13 +60,8 @@ Dataset = gql.ObjectType(
         gql.Field(name='imported', type=gql.Boolean),
         gql.Field(
             name='environment',
-            type=gql.Ref('Environment'),
+            type=gql.Ref('EnvironmentSimplified'),
             resolver=get_dataset_environment,
-        ),
-        gql.Field(
-            name='organization',
-            type=gql.Ref('Organization'),
-            resolver=get_dataset_organization,
         ),
         gql.Field(
             name='owners',

--- a/frontend/src/modules/Dashboards/components/DashboardListItem.js
+++ b/frontend/src/modules/Dashboards/components/DashboardListItem.js
@@ -159,7 +159,7 @@ export const DashboardListItem = (props) => {
             </Grid>
             <Grid item md={8} xs={6}>
               <Typography color="textPrimary" variant="body2">
-                {dashboard.environment.AwsAccountId}
+                {dashboard.AwsAccountId}
               </Typography>
             </Grid>
           </Grid>

--- a/frontend/src/modules/Dashboards/components/DashboardOverview.js
+++ b/frontend/src/modules/Dashboards/components/DashboardOverview.js
@@ -31,7 +31,7 @@ export const DashboardOverview = (props) => {
         <ObjectMetadata
           environment={dashboard.environment}
           region={dashboard.environment.region}
-          organization={dashboard.organization}
+          organization={dashboard.environment.organization}
           owner={dashboard.owner}
           admins={dashboard.SamlGroupName || '-'}
           created={dashboard.created}

--- a/frontend/src/modules/Dashboards/services/getDashboard.js
+++ b/frontend/src/modules/Dashboards/services/getDashboard.js
@@ -19,13 +19,13 @@ export const getDashboard = (dashboardUri) => ({
         DashboardId
         upvotes
         environment {
+          environmentUri
           label
           region
-        }
-        organization {
-          organizationUri
-          label
-          name
+          organization {
+            organizationUri
+            label
+          }
         }
         terms {
           count

--- a/frontend/src/modules/Dashboards/services/searchDashboards.js
+++ b/frontend/src/modules/Dashboards/services/searchDashboards.js
@@ -17,22 +17,16 @@ export const searchDashboards = (filter) => ({
           name
           owner
           SamlGroupName
+          AwsAccountId
           description
           label
           created
           tags
           userRoleForDashboard
           upvotes
-          organization {
-            organizationUri
-            label
-            name
-          }
           environment {
             environmentUri
-            name
             label
-            AwsAccountId
             region
           }
         }

--- a/frontend/src/modules/DatasetsBase/components/DatasetGovernance.js
+++ b/frontend/src/modules/DatasetsBase/components/DatasetGovernance.js
@@ -9,9 +9,8 @@ import {
   Typography
 } from '@mui/material';
 import PropTypes from 'prop-types';
-import { Label } from 'design';
+import { Label, UserModal } from 'design';
 import { isFeatureEnabled } from 'utils';
-import { UserModal } from 'design';
 import { useState } from 'react';
 
 export const DatasetGovernance = (props) => {

--- a/frontend/src/modules/DatasetsBase/services/listDatasets.js
+++ b/frontend/src/modules/DatasetsBase/services/listDatasets.js
@@ -24,10 +24,6 @@ export const listDatasets = ({ filter }) => ({
           userRoleInEnvironment
           tags
           topics
-          organization {
-            organizationUri
-            label
-          }
           AwsAccountId
           environment {
             label

--- a/frontend/src/modules/DatasetsBase/services/listDatasets.js
+++ b/frontend/src/modules/DatasetsBase/services/listDatasets.js
@@ -31,8 +31,11 @@ export const listDatasets = ({ filter }) => ({
           AwsAccountId
           environment {
             label
-            AwsAccountId
             region
+            organization {
+              organizationUri
+              label
+            }
           }
           stack {
             status

--- a/frontend/src/modules/Environments/components/EnvironmentOverview.js
+++ b/frontend/src/modules/Environments/components/EnvironmentOverview.js
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import { Box, Grid } from '@mui/material';
 import PropTypes from 'prop-types';
-import { ObjectBrief, ObjectMetadata } from 'design';
-import { UserModal } from 'design';
+import { ObjectBrief, ObjectMetadata, UserModal } from 'design';
 import { EnvironmentConsoleAccess } from './EnvironmentConsoleAccess';
 import { EnvironmentFeatures } from './EnvironmentFeatures';
 

--- a/frontend/src/modules/Folders/components/FolderOverview.js
+++ b/frontend/src/modules/Folders/components/FolderOverview.js
@@ -27,9 +27,9 @@ export const FolderOverview = (props) => {
       </Grid>
       <Grid item lg={4} xl={3} xs={12}>
         <ObjectMetadata
-          environment={folder.dataset.environment.label}
+          environment={folder.dataset.environment}
           region={folder.dataset.region}
-          organization={folder.dataset.organization.label}
+          organization={folder.dataset.environment.organization}
           owner={folder.owner}
           admins={folder.dataset.SamlAdminGroupName || '-'}
           created={folder.created}

--- a/frontend/src/modules/Folders/services/getDatasetStorageLocation.js
+++ b/frontend/src/modules/Folders/services/getDatasetStorageLocation.js
@@ -16,17 +16,14 @@ export const getDatasetStorageLocation = (locationUri) => ({
           S3BucketName
           AwsAccountId
           owner
-          organization {
-            label
-          }
           environment {
+            environmentUri
             label
             region
-            subscriptionsEnabled
-            subscriptionsProducersTopicImported
-            subscriptionsConsumersTopicImported
-            subscriptionsConsumersTopicName
-            subscriptionsProducersTopicName
+            organization {
+              organizationUri
+              label
+            }
           }
         }
         owner

--- a/frontend/src/modules/Organizations/components/OrganizationOverview.js
+++ b/frontend/src/modules/Organizations/components/OrganizationOverview.js
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import { Box, Grid } from '@mui/material';
 import PropTypes from 'prop-types';
-import { ObjectBrief, ObjectMetadata } from 'design';
-import { UserModal } from 'design';
+import { ObjectBrief, ObjectMetadata, UserModal } from 'design';
 
 export const OrganizationOverview = (props) => {
   const { organization, ...other } = props;

--- a/frontend/src/modules/Redshift_Datasets/components/RedshiftDatasetOverview.js
+++ b/frontend/src/modules/Redshift_Datasets/components/RedshiftDatasetOverview.js
@@ -23,7 +23,7 @@ export const RedshiftDatasetOverview = (props) => {
         <ObjectMetadata
           environment={dataset.environment}
           region={dataset.region}
-          organization={dataset.organization}
+          organization={dataset.environment.organization}
           owner={dataset.owner}
           created={dataset.created}
           status={dataset.stack?.status}

--- a/frontend/src/modules/Redshift_Datasets/components/TableOverview.js
+++ b/frontend/src/modules/Redshift_Datasets/components/TableOverview.js
@@ -27,7 +27,7 @@ export const TableOverview = (props) => {
         <ObjectMetadata
           environment={table.dataset.environment}
           region={table.dataset.region}
-          organization={table.dataset.organization}
+          organization={table.dataset.environment.organization}
           owner={table.dataset.owner}
           admins={table.dataset.SamlAdminGroupName || '-'}
           created={table.created}

--- a/frontend/src/modules/Redshift_Datasets/services/getRedshiftDataset.js
+++ b/frontend/src/modules/Redshift_Datasets/services/getRedshiftDataset.js
@@ -23,10 +23,6 @@ export const getRedshiftDataset = (datasetUri) => ({
         topics
         confidentiality
         autoApprovalEnabled
-        organization {
-          organizationUri
-          label
-        }
         terms {
           count
           nodes {

--- a/frontend/src/modules/Redshift_Datasets/services/getRedshiftDatasetTable.js
+++ b/frontend/src/modules/Redshift_Datasets/services/getRedshiftDatasetTable.js
@@ -31,11 +31,14 @@ export const getRedshiftDatasetTable = ({ rsTableUri }) => ({
           name
           label
           userRoleForDataset
-          organization {
-            label
-          }
           environment {
+            environmentUri
             label
+            region
+            organization {
+              organizationUri
+              label
+            }
           }
           region
         }

--- a/frontend/src/modules/S3_Datasets/components/DatasetOverview.js
+++ b/frontend/src/modules/S3_Datasets/components/DatasetOverview.js
@@ -26,7 +26,7 @@ export const DatasetOverview = (props) => {
         <ObjectMetadata
           environment={dataset.environment}
           region={dataset.region}
-          organization={dataset.organization}
+          organization={dataset.environment.organization}
           owner={dataset.owner}
           created={dataset.created}
           status={dataset.stack?.status}

--- a/frontend/src/modules/Tables/components/TableOverview.js
+++ b/frontend/src/modules/Tables/components/TableOverview.js
@@ -27,7 +27,7 @@ export const TableOverview = (props) => {
         <ObjectMetadata
           environment={table.dataset.environment}
           region={table.dataset.region}
-          organization={table.dataset.organization}
+          organization={table.dataset.environment.organization}
           owner={table.owner}
           admins={table.dataset.SamlAdminGroupName || '-'}
           created={table.created}

--- a/frontend/src/modules/Tables/services/getDatasetTable.js
+++ b/frontend/src/modules/Tables/services/getDatasetTable.js
@@ -15,17 +15,14 @@ export const getDatasetTable = (tableUri) => ({
           SamlAdminGroupName
           owner
           confidentiality
-          organization {
-            label
-          }
           environment {
+            environmentUri
             label
             region
-            subscriptionsEnabled
-            subscriptionsProducersTopicImported
-            subscriptionsConsumersTopicImported
-            subscriptionsConsumersTopicName
-            subscriptionsProducersTopicName
+            organization {
+              organizationUri
+              label
+            }
           }
         }
         datasetUri

--- a/frontend/src/services/graphql/Datasets/getDataset.js
+++ b/frontend/src/services/graphql/Datasets/getDataset.js
@@ -46,10 +46,6 @@ export const getDataset = (datasetUri) => ({
         expirySetting
         expiryMinDuration
         expiryMaxDuration
-        organization {
-          organizationUri
-          label
-        }
         terms {
           count
           nodes {
@@ -65,11 +61,6 @@ export const getDataset = (datasetUri) => ({
           environmentUri
           label
           region
-          subscriptionsEnabled
-          subscriptionsProducersTopicImported
-          subscriptionsConsumersTopicImported
-          subscriptionsConsumersTopicName
-          subscriptionsProducersTopicName
           organization {
             organizationUri
             label

--- a/tests/modules/dashboards/test_dashboards.py
+++ b/tests/modules/dashboards/test_dashboards.py
@@ -79,14 +79,14 @@ def test_get_dashboard(client, env_fixture, db, dashboard, group):
                     label
                     created
                     tags
-                    environment{
-                        label
-                        region
-                    }
-                    organization{
+                    environment {
+                      environmentUri
+                      label
+                      region
+                      organization {
                         organizationUri
                         label
-                        name
+                      }
                     }
                 }
             }
@@ -211,14 +211,14 @@ def test_request_dashboard_share(
                     label
                     created
                     tags
-                    environment{
-                        label
-                        region
-                    }
-                    organization{
+                    environment {
+                      environmentUri
+                      label
+                      region
+                      organization {
                         organizationUri
                         label
-                        name
+                      }
                     }
                 }
             }

--- a/tests/modules/s3_datasets/conftest.py
+++ b/tests/modules/s3_datasets/conftest.py
@@ -116,10 +116,6 @@ def dataset(client, patch_es, patch_dataset_methods):
                     language
                     confidentiality
                     autoApprovalEnabled
-                    organization{
-                        organizationUri
-                        label
-                    }
                     terms{
                         count
                         nodes{

--- a/tests/modules/s3_datasets/conftest.py
+++ b/tests/modules/s3_datasets/conftest.py
@@ -131,19 +131,14 @@ def dataset(client, patch_es, patch_dataset_methods):
                             }
                         }
                     }
-                    environment{
-                        environmentUri
+                    environment {
+                      environmentUri
+                      label
+                      region
+                      organization {
+                        organizationUri
                         label
-                        region
-                        subscriptionsEnabled
-                        subscriptionsProducersTopicImported
-                        subscriptionsConsumersTopicImported
-                        subscriptionsConsumersTopicName
-                        subscriptionsProducersTopicName
-                        organization{
-                            organizationUri
-                            label
-                        }
+                      }
                     }
                     statistics{
                         tables

--- a/tests/modules/s3_datasets_shares/conftest.py
+++ b/tests/modules/s3_datasets_shares/conftest.py
@@ -119,10 +119,6 @@ def dataset(client, patch_es, patch_dataset_methods):
                     language
                     confidentiality
                     autoApprovalEnabled
-                    organization{
-                        organizationUri
-                        label
-                    }
                     terms{
                         count
                         nodes{

--- a/tests/modules/s3_datasets_shares/conftest.py
+++ b/tests/modules/s3_datasets_shares/conftest.py
@@ -134,19 +134,14 @@ def dataset(client, patch_es, patch_dataset_methods):
                             }
                         }
                     }
-                    environment{
-                        environmentUri
+                    environment {
+                      environmentUri
+                      label
+                      region
+                      organization {
+                        organizationUri
                         label
-                        region
-                        subscriptionsEnabled
-                        subscriptionsProducersTopicImported
-                        subscriptionsConsumersTopicImported
-                        subscriptionsConsumersTopicName
-                        subscriptionsProducersTopicName
-                        organization{
-                            organizationUri
-                            label
-                        }
+                      }
                     }
                     statistics{
                         tables

--- a/tests_new/integration_tests/modules/dashboards/queries.py
+++ b/tests_new/integration_tests/modules/dashboards/queries.py
@@ -26,22 +26,20 @@ def search_dashboards(client, filter):
                   owner
                   SamlGroupName
                   description
+                  AwsAccountId
                   label
                   created
                   tags
                   userRoleForDashboard
                   upvotes
-                  organization {
-                    organizationUri
-                    label
-                    name
-                  }
                   environment {
                     environmentUri
-                    name
                     label
-                    AwsAccountId
                     region
+                    organization {
+                      organizationUri
+                      label
+                    }
                   }
                 }
               }
@@ -69,13 +67,13 @@ def get_dashboard(client, dashboardUri):
                 tags
                 userRoleForDashboard
                 environment {
+                  environmentUri
                   label
                   region
-                }
-                organization {
-                  organizationUri
-                  label
-                  name
+                  organization {
+                    organizationUri
+                    label
+                  }
                 }
                 terms {
                   count

--- a/tests_new/integration_tests/modules/datasets_base/queries.py
+++ b/tests_new/integration_tests/modules/datasets_base/queries.py
@@ -15,12 +15,7 @@ region
 environment { 
   environmentUri
   label
-  AwsAccountId
   region
-}
-organization { 
-  organizationUri
-  label
 }
 owners
 stewards

--- a/tests_new/integration_tests/modules/redshift_datasets/dataset_queries.py
+++ b/tests_new/integration_tests/modules/redshift_datasets/dataset_queries.py
@@ -130,11 +130,13 @@ def get_redshift_dataset_table(client, rs_table_uri):
                   name
                   label
                   userRoleForDataset
-                  organization {
-                    label
-                  }
                   environment {
+                    environmentUri
                     label
+                    organization {
+                      organizationUri
+                      label
+                    }
                   }
                   region
                 }

--- a/tests_new/integration_tests/modules/redshift_datasets/dataset_queries.py
+++ b/tests_new/integration_tests/modules/redshift_datasets/dataset_queries.py
@@ -24,10 +24,6 @@ def get_redshift_dataset(client, dataset_uri):
                 topics
                 confidentiality
                 autoApprovalEnabled
-                organization {
-                  organizationUri
-                  label
-                }
                 terms {
                   count
                   nodes {

--- a/tests_new/integration_tests/modules/s3_datasets/queries.py
+++ b/tests_new/integration_tests/modules/s3_datasets/queries.py
@@ -31,12 +31,7 @@ imported
 environment { 
   environmentUri
   label
-  AwsAccountId
   region
-}
-organization { 
-  organizationUri
-  label
 }
 owners
 stewards

--- a/tests_new/integration_tests/modules/shares/s3_datasets_shares/shared_test_functions.py
+++ b/tests_new/integration_tests/modules/shares/s3_datasets_shares/shared_test_functions.py
@@ -166,7 +166,7 @@ def check_share_items_access(
         f'arn:aws:s3:{dataset.region}:{dataset.AwsAccountId}:accesspoint/{consumption_data.s3AccessPointName}'
     )
     if principal_type == 'Group':
-        workgroup = athena_client.get_env_work_group(share.environment.name)
+        workgroup = athena_client.get_env_work_group(share.environment.label)
         athena_workgroup_output_location = None
     else:
         workgroup = 'primary'

--- a/tests_new/integration_tests/modules/shares/types.py
+++ b/tests_new/integration_tests/modules/shares/types.py
@@ -70,11 +70,9 @@ items(filter: $filter){{
     {SharedItemSearchResult}
 }},
 environment{{
-        environmentUri,
-        AwsAccountId,
+        environmentUri
+        label
         region
-        resourcePrefix    
-        name
 }}
 canViewLogs,
 userRoleForShareObject,


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Refactor

### Detail
- Change Response Types for Dataset, Dashboard, and Shares Modules:
  - S3Datasets: `getDataset`, `getDatasetTables`, and `getDatasetStorageLocation` to only return Simplified Env / Org 
return types
  - ++ Redshift Datasets
  - ++ Dataset Shares

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
