### PR TITLE
 Fix: Remove optional AllowWrites 2 - not supported in all regions 

### DIFF
--- a/backend/dataall/modules/redshift_datasets_shares/aws/redshift.py
+++ b/backend/dataall/modules/redshift_datasets_shares/aws/redshift.py
@@ -33,8 +33,8 @@ class RedshiftShareClient:
         try:
             log.info(f'Associating datashare {datashare_arn=} to {consumer_arn=}...')
             self.client.associate_data_share_consumer(
-                DataShareArn=datashare_arn, ConsumerArn=consumer_arn, AllowWrites=False, AssociateEntireAccount=False
-            )
+                DataShareArn=datashare_arn, ConsumerArn=consumer_arn, AssociateEntireAccount=False
+            )  # AllowWrites in preview
         except ClientError as e:
             log.error(e)
             raise e

--- a/tests_new/integration_tests/modules/shares/redshift_datasets_shares/test_redshift_shares.py
+++ b/tests_new/integration_tests/modules/shares/redshift_datasets_shares/test_redshift_shares.py
@@ -234,6 +234,7 @@ def test_create_redshift_share_invalid_target_connection(
     client5, group5, session_cross_acc_env_1, session_connection_cluster_data_user, session_redshift_dataset_serverless
 ):
     # DATA_USER connections cannot be used as target connection for a share. Even if used by the connection owners.
+    # it checks that there are no CREATE_SHARE_REQUEST_WITH_CONNECTION on the connection
     assert_that(create_share_object).raises(GqlError).when_called_with(
         client=client5,
         dataset_or_item_params={'datasetUri': session_redshift_dataset_serverless.datasetUri},
@@ -249,27 +250,6 @@ def test_create_redshift_share_invalid_target_connection(
         'UnauthorizedOperation',
         'CREATE_SHARE_REQUEST_WITH_CONNECTION',
         session_connection_cluster_data_user.connectionUri,
-    )
-
-
-def test_create_redshift_share_unauthorized_target_connection(
-    client5, group5, session_env1, session_connection_serverless_admin, session_redshift_dataset_cluster
-):
-    assert_that(create_share_object).raises(GqlError).when_called_with(
-        client=client5,
-        dataset_or_item_params={'datasetUri': session_redshift_dataset_cluster.datasetUri},
-        environmentUri=session_env1.environmentUri,
-        groupUri=group5,
-        principalRoleName=REDSHIFT_TEST_ROLE_NAME,
-        principalId=session_connection_serverless_admin.connectionUri,
-        principalType=REDSHIFT_PRINCIPAL_TYPE,
-        requestPurpose='Integration tests - Redshift shares',
-        attachMissingPolicies=False,
-        permissions=['Read'],
-    ).contains(
-        'UnauthorizedOperation',
-        'CREATE_SHARE_REQUEST_WITH_CONNECTION',
-        session_connection_serverless_admin.connectionUri,
     )
 
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Follow up of #1664 but for the associate_data_share API call. In addition this PR removes a test that is already covered by the previous test.

### Relates
- #1664 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
