### PR TITLE
add salt to FrontendCognitoConfig to make it always run

### DIFF
--- a/deploy/stacks/frontend_cognito_config.py
+++ b/deploy/stacks/frontend_cognito_config.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from aws_cdk import (
     aws_lambda as _lambda,
     aws_iam as iam,
@@ -105,6 +107,7 @@ class FrontendCognitoConfig(pyNestedClass):
                 'envname': envname,
                 'deployment_region': backend_region,
                 'custom_domain': str(bool(custom_domain)),
+                'timestamp': datetime.utcnow().isoformat(),
             },
             environment_encryption=lambda_env_key,
             tracing=_lambda.Tracing.ACTIVE,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Problem:
We modify the Cognito UserPoolClient manually with CustomResources (not through CDK deployment) and as such everytime we make a change to the UserPoolClient CDK code (i.e enabling/disabling integtests, changing the timeout etc) the new deployment is overrriding the manual changes.
We could specify the callback URLs in CDK but we don't know the URLs until later in the pipeline when the CDN is being deployed. Additionally AuthAtEdge requires Cognito to be already setup and as such we have a chicken and egg situation.

Solution:
Adding a random salt (timestamp) as an environment variable to force triggering the CustomResource on every deployment.
The downside of this solution is that the particular stack will always create a diff but due to the structure of the stacks it is very complicated to work around the issue.

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
