### PR TITLE
make dashboards optional based on config

### DIFF
--- a/tests_new/integration_tests/core/environment/queries.py
+++ b/tests_new/integration_tests/core/environment/queries.py
@@ -63,13 +63,7 @@ def create_environment(client, name, group, organizationUri, awsAccountId, regio
                 'description': 'Created for integration testing',
                 'tags': tags,
                 'type': 'IntegrationTesting',
-                'parameters': [
-                    {'key': 'notebooksEnabled', 'value': 'true'},
-                    {'key': 'dashboardsEnabled', 'value': 'true'},
-                    {'key': 'mlStudiosEnabled', 'value': 'false'},
-                    {'key': 'pipelinesEnabled', 'value': 'true'},
-                    {'key': 'omicsEnabled', 'value': 'true'},
-                ],
+                'parameters': [],
             }
         },
         'query': f"""

--- a/tests_new/integration_tests/core/environment/utils.py
+++ b/tests_new/integration_tests/core/environment/utils.py
@@ -4,14 +4,12 @@ from integration_tests.core.stack.queries import update_stack
 
 
 def set_env_params(client, env, **new_params):
-    should_update = False
-    new_params_list = []
-    for param in env.parameters:
-        new_param_value = new_params.get(param.key, param.value)
-        if new_param_value != param.value:
-            should_update = True
-        new_params_list.append({'key': param.key, 'value': new_param_value})
-    if should_update:
+    old_params = {param.key: param.value for param in env.parameters}
+    updated_params = {**old_params, **new_params}
+
+    # update env only if there are param updates
+    if old_params != updated_params:
+        new_params_list = [{'key': param[0], 'value': param[1]} for param in updated_params.items()]
         env_uri = env.environmentUri
         stack_uri = env.stack.stackUri
         check_stack_ready(client, env_uri, stack_uri)

--- a/tests_new/integration_tests/modules/dashboards/conftest.py
+++ b/tests_new/integration_tests/modules/dashboards/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+
+from integration_tests.core.environment.utils import set_env_params
 from integration_tests.modules.dashboards.mutations import (
     import_dashboard,
     delete_dashboard,
@@ -6,16 +8,13 @@ from integration_tests.modules.dashboards.mutations import (
     reject_dashboard_share,
 )
 from integration_tests.modules.dashboards.queries import get_dashboard
-from integration_tests.core.environment.utils import set_env_params
-from integration_tests.modules.dashboards.aws_clients import QuickSightClient
 
 
 @pytest.fixture(scope='session')
-def quicksight_account_exists(session_env1, session_env1_aws_client):
-    if not QuickSightClient(
-        session_env1_aws_client, session_env1.AwsAccountId, session_env1.region
-    ).check_enterprise_account_exists():
-        pytest.skip('Skipping QuickSight tests because QuickSight account does not exist')
+def dashboards(testdata):
+    if testdata.dashboards:
+        return testdata.dashboards
+    pytest.skip('dashboards config is missing')
 
 
 def create_dataall_dashboard(client, session_id, dashboard_id, env):
@@ -33,9 +32,9 @@ def create_dataall_dashboard(client, session_id, dashboard_id, env):
 
 
 @pytest.fixture(scope='session')
-def dashboard1(session_id, client1, session_env1, testdata):
+def dashboard1(session_id, client1, session_env1, dashboards):
     set_env_params(client1, session_env1, dashboardsEnabled='true')
-    dashboardId = testdata.dashboards['session_env1'].dashboardId
+    dashboardId = dashboards['session_env1'].dashboardId
     ds = None
     try:
         ds = create_dataall_dashboard(client1, session_id, dashboardId, session_env1)

--- a/tests_new/integration_tests/modules/dashboards/test_dashboard.py
+++ b/tests_new/integration_tests/modules/dashboards/test_dashboard.py
@@ -1,3 +1,4 @@
+import pytest
 from assertpy import assert_that
 
 from integration_tests.modules.dashboards.queries import (
@@ -20,61 +21,63 @@ from integration_tests.errors import GqlError
 UPDATED_DESC = 'new description'
 
 
-def test_get_author_session(quicksight_account_exists, client1, session_env1):
+@pytest.mark.usefixtures('dashboards')
+def test_get_author_session(client1, session_env1):
     set_env_params(client1, session_env1, dashboardsEnabled='true')
     assert_that(get_author_session(client1, session_env1.environmentUri)).starts_with('https://')
 
 
-def test_get_author_session_unauthorized(quicksight_account_exists, client2, session_env1):
+@pytest.mark.usefixtures('dashboards')
+def test_get_author_session_unauthorized(client2, session_env1):
     assert_that(get_author_session).raises(GqlError).when_called_with(client2, session_env1.environmentUri).contains(
         'UnauthorizedOperation', 'CREATE_DASHBOARD', session_env1.environmentUri
     )
 
 
-def test_get_dashboard(quicksight_account_exists, session_id, dashboard1):
+def test_get_dashboard(session_id, dashboard1):
     assert_that(dashboard1.label).is_equal_to(session_id)
 
 
-def test_list_dashboards(quicksight_account_exists, client1, client2, session_id, dashboard1):
+def test_list_dashboards(client1, client2, session_id, dashboard1):
     filter = {'term': session_id}
     assert_that(search_dashboards(client1, filter).nodes).is_length(1)
     assert_that(search_dashboards(client2, filter).nodes).is_length(0)
 
 
-def test_get_dashboard_unauthorized(quicksight_account_exists, client2, dashboard1):
+def test_get_dashboard_unauthorized(client2, dashboard1):
     assert_that(get_dashboard).raises(GqlError).when_called_with(client2, dashboard1.dashboardUri).contains(
         'UnauthorizedOperation', 'GET_DASHBOARD', dashboard1.dashboardUri
     )
 
 
-def test_update_dashboard(quicksight_account_exists, client1, dashboard1):
+def test_update_dashboard(client1, dashboard1):
     update_dashboard(client1, {'dashboardUri': dashboard1.dashboardUri, 'description': UPDATED_DESC})
     ds = get_dashboard(client1, dashboard1.dashboardUri)
     assert_that(ds.description).is_equal_to(UPDATED_DESC)
 
 
-def test_update_dashboard_unauthorized(quicksight_account_exists, client2, dashboard1):
+def test_update_dashboard_unauthorized(client2, dashboard1):
     assert_that(update_dashboard).raises(GqlError).when_called_with(
         client2, {'dashboardUri': dashboard1.dashboardUri, 'description': UPDATED_DESC}
     ).contains('UnauthorizedOperation', 'UPDATE_DASHBOARD', dashboard1.dashboardUri)
 
 
-def test_request_dashboard_share(quicksight_account_exists, dashboard1_share):
+def test_request_dashboard_share(dashboard1_share):
     assert_that(dashboard1_share.shareUri).is_not_none()
     assert_that(dashboard1_share.status).is_equal_to('REQUESTED')
 
 
-def test_list_dashboard_shares(quicksight_account_exists, client1, session_id, dashboard1, dashboard1_share):
+def test_list_dashboard_shares(client1, session_id, dashboard1, dashboard1_share):
     assert_that(list_dashboard_shares(client1, dashboard1.dashboardUri, {'term': session_id}).nodes).is_length(1)
 
 
-def test_approve_dashboard_share_unauthorized(quicksight_account_exists, client2, dashboard1, dashboard1_share):
+def test_approve_dashboard_share_unauthorized(client2, dashboard1, dashboard1_share):
     assert_that(approve_dashboard_share).raises(GqlError).when_called_with(client2, dashboard1_share.shareUri).contains(
         'UnauthorizedOperation', 'SHARE_DASHBOARD', dashboard1.dashboardUri
     )
 
 
-def test_approve_dashboard_share(quicksight_account_exists, client1, client2, session_id, dashboard1, dashboard1_share):
+def test_approve_dashboard_share(client1, client2, session_id, dashboard1, dashboard1_share):
     filter = {'term': session_id}
     assert_that(search_dashboards(client2, filter).nodes).is_length(0)
     ds_share = approve_dashboard_share(client1, dashboard1_share.shareUri)
@@ -83,25 +86,25 @@ def test_approve_dashboard_share(quicksight_account_exists, client1, client2, se
     assert_that(search_dashboards(client2, filter).nodes).is_length(1)
 
 
-def test_reject_dashboard_share(quicksight_account_exists, client1, client2, session_id, dashboard1_share):
+def test_reject_dashboard_share(client1, client2, session_id, dashboard1_share):
     ds_share = reject_dashboard_share(client1, dashboard1_share.shareUri)
     assert_that(ds_share.status).is_equal_to('REJECTED')
     assert_that(search_dashboards(client2, {'term': session_id}).nodes).is_length(0)
 
 
-def test_get_reader_session(quicksight_account_exists, client1, dashboard1):
+def test_get_reader_session(client1, dashboard1):
     assert_that(get_reader_session(client1, dashboard1.dashboardUri)).starts_with('https://')
 
 
-def test_get_reader_session_unauthorized(quicksight_account_exists, client2, dashboard1):
+def test_get_reader_session_unauthorized(client2, dashboard1):
     assert_that(get_reader_session).raises(GqlError).when_called_with(client2, dashboard1.dashboardUri).contains(
         'UnauthorizedOperation', 'GET_DASHBOARD', dashboard1.dashboardUri
     )
 
 
-def test_delete_dashboard(quicksight_account_exists, client1, session_id, session_env1, testdata):
+def test_delete_dashboard(client1, session_id, session_env1, dashboards):
     filter = {'term': session_id}
-    dashboardId = testdata.dashboards['session_env1'].dashboardId
+    dashboardId = dashboards['session_env1'].dashboardId
     dashboard2 = create_dataall_dashboard(client1, session_id, dashboardId, session_env1)
     assert_that(search_dashboards(client1, filter).nodes).is_length(2)
 
@@ -109,7 +112,7 @@ def test_delete_dashboard(quicksight_account_exists, client1, session_id, sessio
     assert_that(search_dashboards(client1, filter).nodes).is_length(1)
 
 
-def test_delete_dashboard_unauthorized(quicksight_account_exists, client2, dashboard1):
+def test_delete_dashboard_unauthorized(client2, dashboard1):
     assert_that(delete_dashboard).raises(GqlError).when_called_with(client2, dashboard1.dashboardUri).contains(
         'UnauthorizedOperation', 'DELETE_DASHBOARD', dashboard1.dashboardUri
     )


### PR DESCRIPTION
### Feature or Bugfix
- Refactoring

### Detail
* make dashboards optional based on the presence of config (not by querying AWS)
* implcitly skip tests if dashboards fixture raises `pytest.skip`
* simplify set_env_params logic using sets
* remove params from create_env query and enable specific feature per module


### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
