### PR TITLE
add warning to untrust data.all account when removing an environment

### DIFF
--- a/documentation/userguide/docs/environments.md
+++ b/documentation/userguide/docs/environments.md
@@ -45,6 +45,9 @@ cdk bootstrap --trust DATA.ALL_AWS_ACCOUNT_NUMBER  -c @aws-cdk/core:newStyleStac
     ````bash
     cdk bootstrap --trust 222222222222  -c @aws-cdk/core:newStyleStackSynthesis=true --cloudformation-execution-policies arn:aws:iam::aws:policy/AdministratorAccess aws://333333333333/eu-west-1
     ````
+
+!!! danger "After deleting an environment it is strongly recommended to untrust data.all infrastructure account. Read more [here](#delete-an-environment)" 
+
 #### Restricted CDK Execution role
 In the above command we define the `--cloudformation-execution-policies` to use the AdministratorAccess policy `arn:aws:iam::aws:policy/AdministratorAccess`. 
 This is the default policy that CDK uses to deploy resources, nevertheless it is possible to restrict it to any IAM policy created in the account.
@@ -234,6 +237,16 @@ In the chosen environment, next to the Edit button, click on the **Delete** butt
     A message like this one: *"Remove all environment related objects before proceeding with the deletion!"* appears in
     the delete display. Don't ignore it! Before deleting an environment, clean it up: delete its datasets and other
     resources.
+
+!!! danger "Untrust <span style="color:grey">*data.all*</span> infrastructure account"
+    A message like this one: *"After removal users must untrust the data.all account manually from env account CDKToolkit stack!"* appears in
+    the delete display. Don't ignore it!
+    When you [boostrapped](#1-cdk-bootstrap) the environment account you explicitly "trusted" (using the `--trust <account id>` flag) the infrastructure
+    account to make deployments to your account.
+        
+    * If you don't want to make CDK deployments (not necesserily related to data.all) to that account/region you can completely remove the CDKToolkit stack from CFN
+        
+    * If you want to continue using the account/region for other CDK deployments you must untrust the data.all account by rerunning `cdk bootstrap --trust <TRUSTED_NON_DATAALL_ACC1> --trust <TRUSTED_NON_DATAALL_ACC2> ...`
 
 Note that we can keep the environment CloudFormation stack. What is this for? This is useful in case you want to keep
 using the environment resources (IAM roles, etc) created by <span style="color:grey">*data.all*</span> but outside of <span style="color:grey">*data.all*</span>

--- a/frontend/src/design/components/DeleteObjectWithFrictionModal.js
+++ b/frontend/src/design/components/DeleteObjectWithFrictionModal.js
@@ -22,6 +22,7 @@ export const DeleteObjectWithFrictionModal = (props) => {
     open,
     deleteFunction,
     isAWSResource = true,
+    confirmMessage = 'permanently delete',
     ...other
   } = props;
   const [confirmValue, setConfirmValue] = useState(null);
@@ -72,14 +73,15 @@ export const DeleteObjectWithFrictionModal = (props) => {
         )}
         <Box sx={{ mt: 2 }}>
           <Typography align="center" variant="subtitle2" color="textSecondary">
-            To confirm deletion, type <i>permanently delete</i> in the text
-            input field.
+            To confirm deletion, type <i>{confirmMessage}</i> in the text input
+            field.
           </Typography>
           <CardContent>
             <TextField
               fullWidth
-              label="permanently delete"
-              name="confirm"
+              id={confirmMessage}
+              label={confirmMessage}
+              name={confirmMessage}
               onChange={handleChange}
               value={confirmValue}
               variant="outlined"
@@ -88,7 +90,7 @@ export const DeleteObjectWithFrictionModal = (props) => {
           <CardContent>
             <Button
               fullWidth
-              disabled={confirmValue !== 'permanently delete'}
+              disabled={confirmValue !== confirmMessage}
               startIcon={<FaTrash size={15} />}
               color="error"
               type="submit"
@@ -114,5 +116,6 @@ DeleteObjectWithFrictionModal.propTypes = {
   onClose: PropTypes.func,
   deleteFunction: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,
-  isAWSResource: PropTypes.bool
+  isAWSResource: PropTypes.bool,
+  confirmMessage: PropTypes.string
 };

--- a/frontend/src/modules/Environments/views/EnvironmentView.js
+++ b/frontend/src/modules/Environments/views/EnvironmentView.js
@@ -17,8 +17,10 @@ import {
   Divider,
   Grid,
   Link,
+  Stack as MuiStack,
   Tab,
   Tabs,
+  Tooltip,
   Typography
 } from '@mui/material';
 import { useSnackbar } from 'notistack';
@@ -321,13 +323,31 @@ const EnvironmentView = () => {
           open={isArchiveObjectModalOpen}
           deleteFunction={archiveEnv}
           isAWSResource
+          confirmMessage="acknowledge and delete"
           deleteMessage={
             <Card variant="outlined" sx={{ mb: 2 }}>
               <CardContent>
-                <Typography variant="subtitle2" color="error">
-                  <Warning sx={{ mr: 1 }} /> Remove all environment related
-                  objects before proceeding with the deletion !
-                </Typography>
+                <MuiStack
+                  spacing={3}
+                  alignItems="center"
+                  direction="row"
+                  sx={{ mb: 1 }}
+                >
+                  <Warning sx={{ mr: 1 }} />
+                  <Typography variant="subtitle2" color="error">
+                    Remove all environment related objects before proceeding
+                    with the deletion!
+                  </Typography>
+                </MuiStack>
+                <Tooltip title="Untrusting can be achieved by running `cdk bootstrap` without the `--trust` flag or by deleting the CDKToolkit stack if it's not needed">
+                  <MuiStack spacing={3} alignItems="center" direction="row">
+                    <Warning sx={{ mr: 1 }} />
+                    <Typography variant="subtitle2" color="error">
+                      After removal users must untrust the data.all account
+                      manually from env account CDKToolkit stack!
+                    </Typography>
+                  </MuiStack>
+                </Tooltip>
               </CardContent>
             </Card>
           }


### PR DESCRIPTION
* add warning
* add tooltip
* make the confirmation message configurable
* add docs

![image](https://github.com/user-attachments/assets/98cf6cca-42a4-4772-93c7-b5b5e08b10d1)

![image](https://github.com/user-attachments/assets/43861df1-0873-444f-ada8-a891b60556bc)


### Feature or Bugfix
- Feature

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
