### PR TITLE
restricting KMS permissions for cdkExecRole

### DIFF
--- a/deploy/cdk_exec_policy/cdkExecPolicy.yaml
+++ b/deploy/cdk_exec_policy/cdkExecPolicy.yaml
@@ -155,21 +155,39 @@ Resources:
           - Sid: KMS
             Effect: Allow
             Action:
-              - 'kms:CreateKey'
               - 'kms:CreateAlias'
               - 'kms:CreateGrant'
+              - 'kms:DescribeKey'
               - 'kms:Decrypt'
-              - 'kms:Describe*'
+              - 'kms:GenerateDataKey'
+              - 'kms:GenerateDataKeyPair'
+              - 'kms:GenerateDataKeyPairWithoutPlaintext'
+              - 'kms:GenerateDataKeyWithoutPlaintext'
+              - 'kms:GenerateMac'
+              - 'kms:ListGrants'
+              - 'kms:ListKeyPolicies'
+              - 'kms:ListKeyRotations'
+              - 'kms:ListResourceTags'
               - 'kms:EnableKeyRotation'
               - 'kms:Encrypt'
-              - 'kms:Get*'
-              - 'kms:List*'
-              - 'kms:Generate*'
               - 'kms:PutKeyPolicy'
               - 'kms:DeleteAlias'
               - 'kms:ScheduleKeyDeletion'
               - 'kms:*Tag*'
-            Resource: '*'
+            Resource: 
+               - 'arn:aws:kms:*:*:key/*'
+               - 'arn:aws:kms:*:*:alias/*'
+
+          - Sid: KMS2
+            Effect: Allow
+            Action:
+              - 'kms:CreateKey'
+              - 'kms:DescribeCustomKeyStores'
+              - 'kms:ListAliases'
+              - 'kms:ListKeys'
+              - 'kms:ListRetirableGrants'
+              - 'kms:GenerateRandom'
+            Resource: '*' 
 
           - Sid: Lambda
             Effect: Allow


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
This fix is to address the checkov failure issues for overly permissive cdkExecPolicy. This fix only addresses the KMS permissions. Glue/LF and SageMaker permissions are not yet restricted as they are pending on the resolution of the ticket - https://github.com/data-dot-all/dataall/issues/1189 

### Relates

https://github.com/data-dot-all/dataall/issues/1610

https://github.com/data-dot-all/dataall/issues/1189

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized? N/A
  - What precautions are you taking before deserializing the data you consume? N/A
  - Is injection prevented by parametrizing queries? N/A
  - Have you ensured no `eval` or similar functions are used? N/A
- Does this PR introduce any functionality or component that requires authorization? N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms? N/A
  - Are you logging failed auth attempts? N/A
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations? N/A
  - Are the used keys controlled by the customer? Where are they stored? N/A
- Are you introducing any new policies/roles/users? N/A
  - Have you used the least-privilege principle? How? Yes. We are restricting the KMS permissions to only the required resources.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
