### PR TITLE
Disable introspection on prod sizing

### DIFF
--- a/backend/api_handler.py
+++ b/backend/api_handler.py
@@ -33,9 +33,9 @@ start = perf_counter()
 for name in ['boto3', 's3transfer', 'botocore', 'boto']:
     logging.getLogger(name).setLevel(logging.ERROR)
 
-SCHEMA_EXPLORATION = True if os.getenv('SCHEMA_EXPLORATION') == 'True' else False
+ALLOW_INTROSPECTION = True if os.getenv('ALLOW_INTROSPECTION') == 'True' else False
 
-if SCHEMA_EXPLORATION:
+if not ALLOW_INTROSPECTION:
     did_you_mean.__globals__['MAX_LENGTH'] = 0
 
 load_modules(modes={ImportMode.API})
@@ -145,7 +145,7 @@ def handler(event, context):
         raise Exception(f'Could not initialize user context from event {event}')
 
     success, response = graphql_sync(
-        schema=executable_schema, data=query, context_value=app_context, introspection=SCHEMA_EXPLORATION
+        schema=executable_schema, data=query, context_value=app_context, introspection=ALLOW_INTROSPECTION
     )
 
     dispose_context()

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -145,7 +145,7 @@ class LambdaApiStack(pyNestedClass):
             'LOG_LEVEL': log_level,
             'REAUTH_TTL': str(reauth_ttl),
             'ALLOWED_ORIGINS': allowed_origins,
-            'SCHEMA_EXPLORATION': str(prod_sizing),
+            'ALLOW_INTROSPECTION': str(not prod_sizing),
         }
         # Check if custom domain exists and if it exists email notifications could be enabled. Create a env variable which stores the domain url. This is used for sending data.all share weblinks in the email notifications.
         if custom_domain and custom_domain.get('hosted_zone_name', None):

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -145,6 +145,7 @@ class LambdaApiStack(pyNestedClass):
             'LOG_LEVEL': log_level,
             'REAUTH_TTL': str(reauth_ttl),
             'ALLOWED_ORIGINS': allowed_origins,
+            'SCHEMA_EXPLORATION': str(prod_sizing),
         }
         # Check if custom domain exists and if it exists email notifications could be enabled. Create a env variable which stores the domain url. This is used for sending data.all share weblinks in the email notifications.
         if custom_domain and custom_domain.get('hosted_zone_name', None):


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
-

### Detail
- Disable introspection on `prod_sizing`

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
