### PR TITLE
Added permission check - is tenant to update SSM parameters API

### DIFF
--- a/backend/dataall/core/permissions/api/resolvers.py
+++ b/backend/dataall/core/permissions/api/resolvers.py
@@ -1,11 +1,5 @@
 import logging
-import os
-
-from dataall.base.aws.sts import SessionHelper
-from dataall.base.aws.parameter_store import ParameterStoreManager
-from dataall.base.db.exceptions import RequiredParameter
-from dataall.core.permissions.services.permission_service import PermissionService
-from dataall.core.permissions.services.tenant_policy_service import TenantPolicyService
+from dataall.core.permissions.services.tenant_policy_service import TenantPolicyService, TenantActionsService
 
 log = logging.getLogger(__name__)
 
@@ -26,12 +20,4 @@ def list_tenant_groups(context, source, filter=None):
 
 
 def update_ssm_parameter(context, source, name: str = None, value: str = None):
-    current_account = SessionHelper.get_account()
-    region = os.getenv('AWS_REGION', 'eu-west-1')
-    response = ParameterStoreManager.update_parameter(
-        AwsAccountId=current_account,
-        region=region,
-        parameter_name=f'/dataall/{os.getenv("envname", "local")}/quicksightmonitoring/{name}',
-        parameter_value=value,
-    )
-    return response
+    return TenantActionsService.update_monitoring_ssm_parameter(name, value)

--- a/backend/dataall/core/permissions/services/tenant_policy_service.py
+++ b/backend/dataall/core/permissions/services/tenant_policy_service.py
@@ -9,6 +9,8 @@ from dataall.core.permissions.db.tenant.tenant_repositories import TenantReposit
 from dataall.core.permissions.services.permission_service import PermissionService
 from dataall.core.permissions.db.tenant.tenant_models import Tenant
 from dataall.base.services.service_provider_factory import ServiceProviderFactory
+from dataall.base.aws.sts import SessionHelper
+from dataall.base.aws.parameter_store import ParameterStoreManager
 import logging
 import os
 from functools import wraps
@@ -119,6 +121,26 @@ class TenantPolicyValidationService:
                 )
             )
         return tenant_group_permissions
+
+
+class TenantActionsService:
+    @staticmethod
+    def update_monitoring_ssm_parameter(name, value):
+        # raises UnauthorizedOperation exception, if there is no admin access
+        context = get_context()
+        TenantPolicyValidationService.validate_admin_access(
+            context.username, context.groups, 'UPDATE_SSM_PARAMETER_MONITORING'
+        )
+
+        current_account = SessionHelper.get_account()
+        region = os.getenv('AWS_REGION', 'eu-west-1')
+        response = ParameterStoreManager.update_parameter(
+            AwsAccountId=current_account,
+            region=region,
+            parameter_name=f'/dataall/{os.getenv("envname", "local")}/quicksightmonitoring/{name}',
+            parameter_value=value,
+        )
+        return response
 
 
 class TenantPolicyService:


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
- Added service function and check if the user is a tenant for the updateSSM API call

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
