### PR TITLE
Add GET_WORKSHEET permission in RUN_SQL_QUERY

### DIFF
--- a/backend/dataall/modules/worksheets/services/worksheet_service.py
+++ b/backend/dataall/modules/worksheets/services/worksheet_service.py
@@ -135,7 +135,7 @@ class WorksheetService:
     def run_sql_query(uri, worksheetUri, sqlQuery):
         with get_context().db_engine.scoped_session() as session:
             environment = EnvironmentService.get_environment_by_uri(session, uri)
-            worksheet = WorksheetService._get_worksheet_by_uri(session, worksheetUri)
+            worksheet = WorksheetService.get_worksheet(uri=worksheetUri)
 
             env_group = EnvironmentService.get_environment_group(
                 session, worksheet.SamlAdminGroupName, environment.environmentUri


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
In the run_sql query in Worksheets we are checking the permissions of the user to execute the query if the user has environment-level permissions to execute queries. This does not prevent a user to use another team's worksheets to execute athena queries. This means that the user would use other team permissions to query data.

This PR retrieves the worksheet using the service decorated get_worksheet function

### Relates

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
