### PR TITLE
Add GET_SHARE_OBJECT permissions to get data filters API

### DIFF
--- a/backend/dataall/modules/shares_base/api/resolvers.py
+++ b/backend/dataall/modules/shares_base/api/resolvers.py
@@ -313,12 +313,10 @@ def list_shares_in_my_outbox(context: Context, source, filter: dict = None):
 def list_shared_with_environment_data_items(context: Context, source, environmentUri: str = None, filter: dict = None):
     if not filter:
         filter = {}
-    with context.engine.scoped_session() as session:
-        return ShareItemService.paginated_shared_with_environment_datasets(
-            session=session,
-            uri=environmentUri,
-            data=filter,
-        )
+    return ShareItemService.paginated_shared_with_environment_datasets(
+        uri=environmentUri,
+        data=filter,
+    )
 
 
 def update_share_request_purpose(context: Context, source, shareUri: str = None, requestPurpose: str = None):

--- a/backend/dataall/modules/shares_base/services/share_item_service.py
+++ b/backend/dataall/modules/shares_base/services/share_item_service.py
@@ -220,9 +220,11 @@ class ShareItemService:
 
     @staticmethod
     @ResourcePolicyService.has_resource_permission(LIST_ENVIRONMENT_SHARED_WITH_OBJECTS)
-    def paginated_shared_with_environment_datasets(session, uri, data) -> dict:
-        share_item_shared_states = ShareStatusRepository.get_share_item_shared_states()
-        return ShareObjectRepository.paginate_shared_datasets(session, uri, data, share_item_shared_states)
+    def paginated_shared_with_environment_datasets(uri, data) -> dict:
+        context = get_context()
+        with context.db_engine.scoped_session() as session:
+            share_item_shared_states = ShareStatusRepository.get_share_item_shared_states()
+            return ShareObjectRepository.paginate_shared_datasets(session, uri, data, share_item_shared_states)
 
     @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_SHARES)

--- a/backend/dataall/modules/shares_base/services/share_item_service.py
+++ b/backend/dataall/modules/shares_base/services/share_item_service.py
@@ -258,6 +258,9 @@ class ShareItemService:
             raise ObjectNotFound('ShareObjectItem', uri)
 
     @staticmethod
+    @ResourcePolicyService.has_resource_permission(
+        GET_SHARE_OBJECT, parent_resource=_get_share_uri_from_item_filter_uri
+    )
     def get_share_item_data_filters(uri: str):
         with get_context().db_engine.scoped_session() as session:
             return ShareObjectItemRepository.get_share_item_filter_by_uri(session, uri)

--- a/backend/dataall/modules/shares_base/services/share_logs_service.py
+++ b/backend/dataall/modules/shares_base/services/share_logs_service.py
@@ -45,7 +45,7 @@ class ShareLogsService:
             return True
 
     @staticmethod
-    def get_share_logs_name_query(shareUri):
+    def _get_share_logs_name_query(shareUri):
         log.info(f'Get share Logs stream name for share {shareUri}')
 
         query = f"""fields @logStream
@@ -56,7 +56,7 @@ class ShareLogsService:
         return query
 
     @staticmethod
-    def get_share_logs_query(log_stream_name):
+    def _get_share_logs_query(log_stream_name):
         query = f"""fields @timestamp, @message, @logStream, @log as @logGroup
                     | sort @timestamp asc
                     | filter @logStream like "{log_stream_name}"
@@ -65,14 +65,13 @@ class ShareLogsService:
 
     @staticmethod
     def get_share_logs(shareUri):
-        context = get_context()
         ShareLogsService.check_view_logs_permissions(shareUri)
         envname = os.getenv('envname', 'local')
         log_query_period_days = config.get_property('core.log_query_period_days', 1)
         log.info(f'log_query_period_days: {log_query_period_days}')
         log_group_name = f"/{Parameter().get_parameter(env=envname, path='resourcePrefix')}/{envname}/ecs/share-manager"
 
-        query_for_name = ShareLogsService.get_share_logs_name_query(shareUri=shareUri)
+        query_for_name = ShareLogsService._get_share_logs_name_query(shareUri=shareUri)
         name_query_result = CloudWatch.run_query(
             query=query_for_name,
             log_group_name=log_group_name,
@@ -83,7 +82,7 @@ class ShareLogsService:
 
         name = name_query_result[0]['logStream']
 
-        query = ShareLogsService.get_share_logs_query(log_stream_name=name)
+        query = ShareLogsService._get_share_logs_query(log_stream_name=name)
         results = CloudWatch.run_query(
             query=query,
             log_group_name=log_group_name,


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
- Add GET_SHARE_OBJECT permissions to get data filters API
- Cosmetic changes on shares_base module

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
