### PR TITLE
Add LIST_ENVIRONMENT_DATASETS permission for listing shared datasets and cleanup unused code

### DIFF
--- a/backend/dataall/modules/s3_datasets/db/dataset_profiling_repositories.py
+++ b/backend/dataall/modules/s3_datasets/db/dataset_profiling_repositories.py
@@ -51,17 +51,6 @@ class DatasetProfilingRepository:
         return run
 
     @staticmethod
-    def list_profiling_runs(session, dataset_uri):
-        # TODO filter is always default
-        filter = {}
-        q = (
-            session.query(DatasetProfilingRun)
-            .filter(DatasetProfilingRun.datasetUri == dataset_uri)
-            .order_by(DatasetProfilingRun.created.desc())
-        )
-        return paginate(q, page=filter.get('page', 1), page_size=filter.get('pageSize', 20)).to_dict()
-
-    @staticmethod
     def list_table_profiling_runs(session, table_uri):
         # TODO filter is always default
         filter = {}

--- a/backend/dataall/modules/s3_datasets/services/dataset_profiling_service.py
+++ b/backend/dataall/modules/s3_datasets/services/dataset_profiling_service.py
@@ -67,13 +67,6 @@ class DatasetProfilingService:
             session.add(task)
         Worker.queue(engine=context.db_engine, task_ids=[task.taskUri])
 
-    @staticmethod
-    @ResourcePolicyService.has_resource_permission(GET_DATASET)
-    @is_feature_enabled('modules.s3_datasets.features.metrics_data')
-    def list_profiling_runs(uri):
-        with get_context().db_engine.scoped_session() as session:
-            return DatasetProfilingRepository.list_profiling_runs(session, uri)
-
     @classmethod
     @is_feature_enabled('modules.s3_datasets.features.metrics_data')
     def get_dataset_table_profiling_run(cls, uri: str):

--- a/backend/dataall/modules/s3_datasets/services/dataset_table_service.py
+++ b/backend/dataall/modules/s3_datasets/services/dataset_table_service.py
@@ -40,11 +40,6 @@ class DatasetTableService:
         return table.datasetUri
 
     @staticmethod
-    def get_table(uri: str):
-        with get_context().db_engine.scoped_session() as session:
-            return DatasetTableRepository.get_dataset_table_by_uri(session, uri)
-
-    @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_DATASETS)
     @ResourcePolicyService.has_resource_permission(UPDATE_DATASET_TABLE, parent_resource=_get_dataset_uri)
     def update_table(uri: str, table_data: dict = None):

--- a/backend/dataall/modules/s3_datasets/services/dataset_table_service.py
+++ b/backend/dataall/modules/s3_datasets/services/dataset_table_service.py
@@ -40,6 +40,11 @@ class DatasetTableService:
         return table.datasetUri
 
     @staticmethod
+    def get_table(uri: str):
+        with get_context().db_engine.scoped_session() as session:
+            return DatasetTableRepository.get_dataset_table_by_uri(session, uri)
+
+    @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_DATASETS)
     @ResourcePolicyService.has_resource_permission(UPDATE_DATASET_TABLE, parent_resource=_get_dataset_uri)
     def update_table(uri: str, table_data: dict = None):

--- a/backend/dataall/modules/s3_datasets_shares/api/resolvers.py
+++ b/backend/dataall/modules/s3_datasets_shares/api/resolvers.py
@@ -65,13 +65,11 @@ def get_s3_consumption_data(context: Context, source, shareUri: str):
 
 
 def list_shared_databases_tables_with_env_group(context: Context, source, environmentUri: str, groupUri: str):
-    return S3ShareService.list_shared_databases_tables_with_env_group(environmentUri=environmentUri, groupUri=groupUri)
+    return S3ShareService.list_shared_databases_tables_with_env_group(uri=environmentUri, group_uri=groupUri)
 
 
 def resolve_shared_db_name(context: Context, source, **kwargs):
-    return S3ShareService.resolve_shared_db_name(
-        source.GlueDatabaseName, source.shareUri, source.targetEnvAwsAccountId, source.targetEnvRegion
-    )
+    return S3ShareService.resolve_shared_db_name(source.GlueDatabaseName, source.shareUri)
 
 
 def list_shared_table_columns(context: Context, source, tableUri: str, shareUri: str, filter: dict):

--- a/backend/dataall/modules/s3_datasets_shares/services/s3_share_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/s3_share_service.py
@@ -1,6 +1,6 @@
 import logging
 
-from dataall.base.db import utils
+from dataall.base.db import utils, exceptions
 from dataall.base.context import get_context
 from dataall.base.aws.sts import SessionHelper
 from dataall.base.aws.iam import IAM
@@ -10,6 +10,7 @@ from dataall.core.environment.services.environment_service import EnvironmentSer
 from dataall.core.tasks.db.task_models import Task
 from dataall.core.tasks.service_handlers import Worker
 from dataall.modules.datasets_base.db.dataset_repositories import DatasetBaseRepository
+from dataall.modules.datasets_base.services.dataset_list_permissions import LIST_ENVIRONMENT_DATASETS
 from dataall.modules.shares_base.db.share_object_models import ShareObject
 from dataall.modules.shares_base.db.share_object_repositories import ShareObjectRepository
 from dataall.modules.shares_base.db.share_object_item_repositories import ShareObjectItemRepository
@@ -173,12 +174,13 @@ class S3ShareService:
         return True
 
     @staticmethod
-    def list_shared_tables_by_env_dataset(dataset_uri: str, env_uri: str):
+    @ResourcePolicyService.has_resource_permission(LIST_ENVIRONMENT_DATASETS)
+    def list_shared_tables_by_env_dataset(uri: str, dataset_uri: str):
         context = get_context()
         with context.db_engine.scoped_session() as session:
             log.info(
                 S3ShareObjectRepository.query_dataset_tables_shared_with_env(
-                    session, env_uri, dataset_uri, context.username, context.groups
+                    session, uri, dataset_uri, context.username, context.groups
                 )
             )
             return [
@@ -188,7 +190,7 @@ class S3ShareService:
                     + (f'_{res.resourceLinkSuffix}' if res.resourceLinkSuffix else ''),
                 }
                 for res in S3ShareObjectRepository.query_dataset_tables_shared_with_env(
-                    session, env_uri, dataset_uri, context.username, context.groups
+                    session, uri, dataset_uri, context.username, context.groups
                 )
             ]
 
@@ -259,11 +261,17 @@ class S3ShareService:
             }
 
     @staticmethod
-    def list_shared_databases_tables_with_env_group(environmentUri: str, groupUri: str):
+    @ResourcePolicyService.has_resource_permission(LIST_ENVIRONMENT_DATASETS)
+    def list_shared_databases_tables_with_env_group(uri: str, group_uri: str):
         context = get_context()
+        if group_uri not in context.groups:
+            raise exceptions.UnauthorizedOperation(
+                action='LIST_ENVIRONMENT_GROUP_DATASETS',
+                message=f'User: {context.username} is not a member of the team {group_uri}',
+            )
         with context.db_engine.scoped_session() as session:
             return S3ShareObjectRepository.query_shared_glue_databases(
-                session=session, groups=context.groups, env_uri=environmentUri, group_uri=groupUri
+                session=session, groups=context.groups, env_uri=uri, group_uri=group_uri
             )
 
     @staticmethod
@@ -303,7 +311,7 @@ class S3ShareService:
             )
 
     @staticmethod
-    def resolve_shared_db_name(GlueDatabaseName: str, shareUri: str, targetEnvAwsAccountId: str, targetEnvRegion: str):
+    def resolve_shared_db_name(GlueDatabaseName: str, shareUri: str):
         with get_context().db_engine.scoped_session() as session:
             share = ShareObjectRepository.get_share_by_uri(session, shareUri)
             dataset = DatasetBaseRepository.get_dataset_by_uri(session, share.datasetUri)

--- a/backend/dataall/modules/s3_datasets_shares/services/s3_share_service.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/s3_share_service.py
@@ -267,7 +267,7 @@ class S3ShareService:
         if group_uri not in context.groups:
             raise exceptions.UnauthorizedOperation(
                 action='LIST_ENVIRONMENT_GROUP_DATASETS',
-                message=f'User: {context.username} is not a member of the team {group_uri}',
+                message=f'User: {context.username} is not a member of the owner team',
             )
         with context.db_engine.scoped_session() as session:
             return S3ShareObjectRepository.query_shared_glue_databases(


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Added permission check on the list datasets API calls from the S3 shares module. Ensuring that only environment members can see environment shared datasets.

++ remove some unused code

### Relates

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
