### PR TITLE
Fix integration tests for list_environment_datasets unauthorized cases

### DIFF
--- a/tests_new/integration_tests/modules/s3_datasets/test_s3_dataset.py
+++ b/tests_new/integration_tests/modules/s3_datasets/test_s3_dataset.py
@@ -111,7 +111,6 @@ def test_list_s3_datasets_owned_by_env_group(
     client1,
     session_env1,
     group1,
-    group2,
     session_s3_dataset1,
     session_imported_sse_s3_dataset1,
     session_imported_kms_s3_dataset1,
@@ -122,16 +121,26 @@ def test_list_s3_datasets_owned_by_env_group(
             client1, environment_uri=session_env1.environmentUri, group_uri=group1, term=session_id
         ).nodes
     ).is_length(3)
-    assert_that(
-        list_s3_datasets_owned_by_env_group(
-            client1, environment_uri=session_env1.environmentUri, group_uri=group2, term=session_id
-        ).nodes
-    ).is_length(0)
 
 
-def test_list_s3_datasets_owned_by_env_group_unauthorized():
-    # TODO
-    pass
+def test_list_s3_datasets_owned_by_env_group_unauthorized(
+    client1,
+    client2,
+    session_env1,
+    group2,
+    session_s3_dataset1,
+    session_imported_sse_s3_dataset1,
+    session_imported_kms_s3_dataset1,
+    session_id,
+):
+    # Client that tries to call API without access to environment
+    assert_that(list_s3_datasets_owned_by_env_group).raises(GqlError).when_called_with(
+        client2, environment_uri=session_env1.environmentUri, group_uri=group2, term=session_id
+    ).contains('UnauthorizedOperation', 'LIST_ENVIRONMENT_DATASETS', session_env1.environmentUri)
+    # Client that tries to call API without being a member of the group
+    assert_that(list_s3_datasets_owned_by_env_group).raises(GqlError).when_called_with(
+        client1, environment_uri=session_env1.environmentUri, group_uri=group2, term=session_id
+    ).contains('UnauthorizedOperation', 'LIST_ENVIRONMENT_GROUP_DATASETS', 'not a member')
 
 
 @pytest.mark.parametrize(*DATASETS_FIXTURES_PARAMS)

--- a/tests_new/integration_tests/modules/s3_datasets/test_s3_dataset.py
+++ b/tests_new/integration_tests/modules/s3_datasets/test_s3_dataset.py
@@ -124,7 +124,6 @@ def test_list_s3_datasets_owned_by_env_group(
 
 
 def test_list_s3_datasets_owned_by_env_group_unauthorized(
-    client1,
     client2,
     session_env1,
     group2,
@@ -137,6 +136,17 @@ def test_list_s3_datasets_owned_by_env_group_unauthorized(
     assert_that(list_s3_datasets_owned_by_env_group).raises(GqlError).when_called_with(
         client2, environment_uri=session_env1.environmentUri, group_uri=group2, term=session_id
     ).contains('UnauthorizedOperation', 'LIST_ENVIRONMENT_DATASETS', session_env1.environmentUri)
+
+
+def test_list_s3_datasets_owned_by_env_group_unauthorized_not_member(
+    client1,
+    session_env1,
+    group2,
+    session_s3_dataset1,
+    session_imported_sse_s3_dataset1,
+    session_imported_kms_s3_dataset1,
+    session_id,
+):
     # Client that tries to call API without being a member of the group
     assert_that(list_s3_datasets_owned_by_env_group).raises(GqlError).when_called_with(
         client1, environment_uri=session_env1.environmentUri, group_uri=group2, term=session_id


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix - integration tests

### Detail
Update integration tests with additional checks included in https://github.com/data-dot-all/dataall/pull/1718

### Relates
- https://github.com/data-dot-all/dataall/pull/1718

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
