### PR TITLE
Introduce is_owner permissions to Glossary mutations + add new integration tests

### DIFF
--- a/backend/dataall/modules/catalog/services/glossaries_service.py
+++ b/backend/dataall/modules/catalog/services/glossaries_service.py
@@ -1,6 +1,8 @@
+from functools import wraps
 import logging
 
 from dataall.base.context import get_context
+from dataall.base.db import exceptions
 from dataall.core.permissions.services.tenant_policy_service import TenantPolicyService
 
 from dataall.modules.catalog.db.glossary_repositories import GlossaryRepository
@@ -15,6 +17,30 @@ def _session():
     return get_context().db_engine.scoped_session()
 
 
+class GlossariesResourceAccess:
+    @staticmethod
+    def is_owner(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            uri = kwargs.get('uri')
+            if not uri:
+                raise KeyError(f"{f.__name__} doesn't have parameter uri.")
+            context = get_context()
+            with context.db_engine.scoped_session() as session:
+                node = GlossaryRepository.get_node(session=session, uri=uri)
+                while node.nodeType != 'G':
+                    node = GlossaryRepository.get_node(session=session, uri=node.parentUri)
+                if node and (node.admin in context.groups):
+                    return f(*args, **kwargs)
+                else:
+                    raise exceptions.UnauthorizedOperation(
+                        action='GLOSSARY MUTATION',
+                        message=f'User {context.username} is not the admin of the glossary {node.label}.',
+                    )
+
+        return wrapper
+
+
 class GlossariesService:
     @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_GLOSSARIES)
@@ -24,12 +50,14 @@ class GlossariesService:
 
     @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_GLOSSARIES)
+    @GlossariesResourceAccess.is_owner
     def create_category(uri: str, data: dict = None):
         with _session() as session:
             return GlossaryRepository.create_category(session=session, uri=uri, data=data)
 
     @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_GLOSSARIES)
+    @GlossariesResourceAccess.is_owner
     def create_term(uri: str, data: dict = None):
         with _session() as session:
             return GlossaryRepository.create_term(session=session, uri=uri, data=data)
@@ -95,12 +123,14 @@ class GlossariesService:
 
     @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_GLOSSARIES)
+    @GlossariesResourceAccess.is_owner
     def update_node(uri: str = None, data: dict = None):
         with _session() as session:
             return GlossaryRepository.update_node(session=session, uri=uri, data=data)
 
     @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_GLOSSARIES)
+    @GlossariesResourceAccess.is_owner
     def delete_node(uri: str = None):
         with _session() as session:
             return GlossaryRepository.delete_node(session=session, uri=uri)
@@ -108,6 +138,7 @@ class GlossariesService:
     @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_GLOSSARIES)
     def approve_term_association(linkUri: str):
+        # is_owner permissions checked in GlossaryRepository.approve_term_association
         with _session() as session:
             return GlossaryRepository.approve_term_association(
                 session=session, username=get_context().username, groups=get_context().groups, linkUri=linkUri
@@ -116,6 +147,7 @@ class GlossariesService:
     @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_GLOSSARIES)
     def dismiss_term_association(linkUri: str):
+        # is_owner permissions checked in GlossaryRepository.dismiss_term_association
         with _session() as session:
             return GlossaryRepository.dismiss_term_association(
                 session=session, username=get_context().username, groups=get_context().groups, linkUri=linkUri

--- a/tests_new/integration_tests/modules/catalog/test_glossaries.py
+++ b/tests_new/integration_tests/modules/catalog/test_glossaries.py
@@ -84,6 +84,16 @@ def test_search_glossary(client1, glossary1, category1, glossary_term1, category
     assert_that(response.count).is_equal_to(1)
 
 
+def test_update_glossary_unauthorized(client2, group2, glossary1):
+    assert_that(update_glossary).raises(GqlError).when_called_with(
+        client2,
+        node_uri=glossary1.nodeUri,
+        name='glossaryUpdated',
+        group=group2,
+        read_me='dummy',
+    ).contains('UnauthorizedOperation', 'GLOSSARY MUTATION')
+
+
 def test_update_glossary(client1, group1, glossary1, session_id):
     response = update_glossary(
         client1,
@@ -94,6 +104,12 @@ def test_update_glossary(client1, group1, glossary1, session_id):
     )
     assert_that(response.label).is_equal_to('glossaryUpdated')
     assert_that(response.readme).is_equal_to(f'UPDATED: {session_id} Glossary created for integration testing')
+
+
+def test_delete_glossary_unauthorized(client2, group2, glossary1):
+    assert_that(delete_glossary).raises(GqlError).when_called_with(client2, glossary1.nodeUri).contains(
+        'UnauthorizedOperation', 'GLOSSARY MUTATION'
+    )
 
 
 def test_delete_glossary(client1, group1):
@@ -122,6 +138,15 @@ def test_create_category(client1, category1):
     assert_that(category1.label).is_equal_to('category1')
 
 
+def test_update_category_unauthorized(client2, group2, category1):
+    assert_that(update_category).raises(GqlError).when_called_with(
+        client2,
+        node_uri=category1.nodeUri,
+        name=category1.label,
+        read_me='dummy',
+    ).contains('UnauthorizedOperation', 'GLOSSARY MUTATION')
+
+
 def test_update_category(client1, category1, session_id):
     response = update_category(
         client1,
@@ -130,6 +155,13 @@ def test_update_category(client1, category1, session_id):
         read_me=f'UPDATED: {session_id} Category created for integration testing',
     )
     assert_that(response.readme).is_equal_to(f'UPDATED: {session_id} Category created for integration testing')
+
+
+def test_delete_category_unauthorized(client2, group2, category1):
+    assert_that(delete_category).raises(GqlError).when_called_with(
+        client2,
+        category1.nodeUri,
+    ).contains('UnauthorizedOperation', 'GLOSSARY MUTATION')
 
 
 def test_delete_category(client1, glossary1):
@@ -154,14 +186,35 @@ def test_delete_category_with_terms(client1, glossary1):
     assert_that(response).is_true()
 
 
+def test_create_term_in_glossary_unauthorized(client2, glossary1):
+    assert_that(create_term).raises(GqlError).when_called_with(
+        client2, name='glos_term1', parent_uri=glossary1.nodeUri, read_me='Term created for integration testing'
+    ).contains('UnauthorizedOperation', 'GLOSSARY MUTATION')
+
+
 def test_create_term_in_glossary(client1, glossary_term1):
     assert_that(glossary_term1.nodeUri).is_not_none()
     assert_that(glossary_term1.label).is_equal_to('glos_term1')
 
 
+def test_create_term_in_category_unauthorized(client2, category1):
+    assert_that(create_term).raises(GqlError).when_called_with(
+        client2, name='glos_term1', parent_uri=category1.nodeUri, read_me='Term created for integration testing'
+    ).contains('UnauthorizedOperation', 'GLOSSARY MUTATION')
+
+
 def test_create_term_in_category(client1, category_term1):
     assert_that(category_term1.nodeUri).is_not_none()
     assert_that(category_term1.label).is_equal_to('cat_term1')
+
+
+def test_update_term_unauthorized(client2, glossary_term1):
+    assert_that(update_term).raises(GqlError).when_called_with(
+        client2,
+        node_uri=glossary_term1.nodeUri,
+        name=glossary_term1.label,
+        read_me='Dummy',
+    ).contains('UnauthorizedOperation', 'GLOSSARY MUTATION')
 
 
 def test_update_term(client1, glossary_term1, session_id):
@@ -172,6 +225,13 @@ def test_update_term(client1, glossary_term1, session_id):
         read_me=f'UPDATED: {session_id} Glossary term created for integration testing',
     )
     assert_that(response.readme).is_equal_to(f'UPDATED: {session_id} Glossary term created for integration testing')
+
+
+def test_delete_term_unauthorized(client2, glossary_term1):
+    assert_that(delete_term).raises(GqlError).when_called_with(
+        client2,
+        glossary_term1.nodeUri,
+    ).contains('UnauthorizedOperation', 'GLOSSARY MUTATION')
 
 
 def test_delete_term(client1, group1, category1, glossary1):
@@ -185,7 +245,7 @@ def test_delete_term(client1, group1, category1, glossary1):
     assert_that(response.stats.terms).is_equal_to(number_terms_before_delete - 1)
 
 
-def test_approve_term_association_unathorized(client2, dataset_association1):
+def test_approve_term_association_unauthorized(client2, dataset_association1):
     assert_that(approve_term_association).raises(GqlError).when_called_with(
         client2, link_uri=dataset_association1.linkUri
     ).contains('UnauthorizedOperation', 'ASSOCIATE_GLOSSARY_TERM')
@@ -196,7 +256,7 @@ def test_approve_term_association(approved_dataset_association1, dataset_associa
     assert_that(approved_dataset_association1.approvedBySteward).is_equal_to(True)
 
 
-def test_dismiss_term_association_unathorized(client2, approved_dataset_association1):
+def test_dismiss_term_association_unauthorized(client2, approved_dataset_association1):
     assert_that(dismiss_term_association).raises(GqlError).when_called_with(
         client2, link_uri=approved_dataset_association1.linkUri
     ).contains('UnauthorizedOperation', 'ASSOCIATE_GLOSSARY_TERM')


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature
- Bugfix
- Refactoring

### Detail
In the frontend Glossary operations that involve creating, modifying or deleting (WRITE) glossary resources are limited to the Glossary admins. To mimic this behavior in the backend this PR introduces permission checks that ensure that only the glossary admins can execute mutations on the glossary.

In addition, the PR includes integration tests for the unauthorized testing scenarios.


#### Testing 

deployed Lambda in real AWS account
- tested glossary owners can create, update and delete nodes
- tested unauthorized users cannot execute API mutations programatically. They obtain errors of the type: `An error occurred (UnauthorizedOperation) when calling GLOSSARY MUTATION operation:\n            User johndoe@amazon.com is not the admin of the glossary Sesssion glossary1.\n        ", "locations": [{"line": 2, "column": 3}], "path": ["updateCategory"]}]}%  `

### Relates

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
