### PR TITLE
Avoid infinite loop in glossaries checks

### DIFF
--- a/backend/dataall/modules/catalog/services/glossaries_service.py
+++ b/backend/dataall/modules/catalog/services/glossaries_service.py
@@ -29,8 +29,11 @@ class GlossariesResourceAccess:
                 context = get_context()
                 with context.db_engine.scoped_session() as session:
                     node = GlossaryRepository.get_node(session=session, uri=uri)
-                    while node.nodeType != 'G':
+                    MAX_GLOSSARY_DEPTH = 10
+                    depth = 0
+                    while node.nodeType != 'G' and depth <= MAX_GLOSSARY_DEPTH:
                         node = GlossaryRepository.get_node(session=session, uri=node.parentUri)
+                        depth += 1
                     if node and (node.admin in context.groups):
                         return f(*args, **kwargs)
                     else:


### PR DESCRIPTION
### Feature or Bugfix
- Feature
- Bugfix

### Detail
In some edge cases where a category and term is orphan and does not have a Glossary as parent we would run into an infinite loop in the glossaries permission check. This PR adds a maximum depth level (which in reality is lower, categories can only host terms, the REAL_MAX_DEPTH=3) 


### Relates
- #1721 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
