### PR TITLE
Fix count votes integ test

### DIFF
--- a/tests_new/integration_tests/modules/vote/test_vote.py
+++ b/tests_new/integration_tests/modules/vote/test_vote.py
@@ -39,13 +39,5 @@ def test_count_upvote_invalid(client1, vote1, session_s3_dataset1):
     )
 
 
-def test_count_votes(client2, vote1, session_s3_dataset1):
-    count = count_upvotes(client2, session_s3_dataset1.datasetUri, S3_DATASET_TARGET_TYPE)
-
-    # Assert incremeent by 1
-    upvote(client2, session_s3_dataset1.datasetUri, S3_DATASET_TARGET_TYPE, True)
-    assert_that(count_upvotes(client2, session_s3_dataset1.datasetUri, S3_DATASET_TARGET_TYPE)).is_equal_to(count + 1)
-
-    # Assert decrement by 1
-    upvote(client2, session_s3_dataset1.datasetUri, S3_DATASET_TARGET_TYPE, False)
-    assert_that(count_upvotes(client2, session_s3_dataset1.datasetUri, S3_DATASET_TARGET_TYPE)).is_equal_to(count)
+def test_count_votes(client1, vote1, session_s3_dataset1):
+    assert_that(count_upvotes(client1, session_s3_dataset1.datasetUri, S3_DATASET_TARGET_TYPE)).is_equal_to(1)


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Tests to count votes from #1724 fail because the client2 has no permissions to GET a dataset and cannot upvote it

### Relates
- #1724 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
