### PR TITLE
fix test_get_dashboard_unauthorized

### DIFF
--- a/tests_new/integration_tests/modules/dashboards/test_dashboard.py
+++ b/tests_new/integration_tests/modules/dashboards/test_dashboard.py
@@ -1,6 +1,15 @@
 import pytest
 from assertpy import assert_that
 
+from integration_tests.core.environment.utils import set_env_params
+from integration_tests.errors import GqlError
+from integration_tests.modules.dashboards.conftest import create_dataall_dashboard
+from integration_tests.modules.dashboards.mutations import (
+    update_dashboard,
+    delete_dashboard,
+    approve_dashboard_share,
+    reject_dashboard_share,
+)
 from integration_tests.modules.dashboards.queries import (
     search_dashboards,
     get_dashboard,
@@ -8,15 +17,6 @@ from integration_tests.modules.dashboards.queries import (
     get_author_session,
     get_reader_session,
 )
-from integration_tests.modules.dashboards.mutations import (
-    update_dashboard,
-    delete_dashboard,
-    approve_dashboard_share,
-    reject_dashboard_share,
-)
-from integration_tests.modules.dashboards.conftest import create_dataall_dashboard
-from integration_tests.core.environment.utils import set_env_params
-from integration_tests.errors import GqlError
 
 UPDATED_DESC = 'new description'
 
@@ -45,9 +45,7 @@ def test_list_dashboards(client1, client2, session_id, dashboard1):
 
 
 def test_get_dashboard_unauthorized(client2, dashboard1):
-    assert_that(get_dashboard).raises(GqlError).when_called_with(client2, dashboard1.dashboardUri).contains(
-        'UnauthorizedOperation', 'GET_DASHBOARD', dashboard1.dashboardUri
-    )
+    assert_that(get_dashboard(client2, dashboard1.dashboardUri)).contains_entry(restricted=None, environment=None)
 
 
 def test_update_dashboard(client1, dashboard1):


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Before #1729 an unauthorized getDashboard query meant a global failure, after #1729 it returns partial data and only raises an error for `environment` and `restricted` fields.

```json
{'data': {'getDashboard': {'SamlGroupName': 'testGroup1',
                           'created': '2024-12-06 15:27:15.811303',
                           'dashboardUri': 'obfuscated_uri',
                           'description': 'No description provided',
                           'environment': None,
                           'label': '2024-12-06T14:57:28.249142',
                           'name': '2024-12-06t14-57-28-249142',
                           'owner': 'testUser1@amazonaws.com',
                           'restricted': None,
                           'tags': ['2024-12-06T14:57:28.249142'],
                           'terms': {'count': 0, 'nodes': []},
                           'userRoleForDashboard': 'Shared'}},
 'errors': [{'locations': [{'column': 17, 'line': 13}],
             'message': '\n'
                        '            An error occurred (UnauthorizedOperation) '
                        'when calling GET_DASHBOARD operation:\n'
                        '            User: aUser@amazonaws.com is not '
                        'authorized to perform: GET_DASHBOARD on resource: '
                        'obfuscated_uri\n'
                        '        ',
             'path': ['getDashboard', 'restricted']},
            {'locations': [{'column': 17, 'line': 17}],
             'message': '\n'
                        '            An error occurred (UnauthorizedOperation) '
                        'when calling GET_ENVIRONMENT operation:\n'
                        '            User: aUser@amazonaws.com is not '
                        'authorized to perform: GET_ENVIRONMENT on resource: '
                        'obfuscated_uri\n'
                        '        ',
             'path': ['getDashboard', 'environment']}]}
```

### Relates
Issue introduced at #1729

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
