### PR TITLE
[BUGFIX] gh-1734 

### DIFF
--- a/backend/dataall/modules/s3_datasets/services/dataset_table_service.py
+++ b/backend/dataall/modules/s3_datasets/services/dataset_table_service.py
@@ -140,8 +140,7 @@ class DatasetTableService:
             existing_tables = DatasetTableRepository.find_dataset_tables(session, uri)
             existing_table_names = [e.GlueTableName for e in existing_tables]
             existing_dataset_tables_map = {t.GlueTableName: t for t in existing_tables}
-
-            DatasetTableRepository.update_existing_tables_status(existing_tables, glue_tables)
+            DatasetTableRepository.update_existing_tables_status(existing_tables, glue_tables, session)
             log.info(f'existing_tables={glue_tables}')
             for table in glue_tables:
                 if table['Name'] not in existing_table_names:

--- a/backend/dataall/modules/shares_base/db/share_object_repositories.py
+++ b/backend/dataall/modules/shares_base/db/share_object_repositories.py
@@ -107,14 +107,6 @@ class ShareObjectRepository:
         return session.query(share_type_model).get(item_uri)
 
     @staticmethod
-    def get_shares_for_principal_and_database(session, principal, database):
-        return (
-            session.query(ShareObject)
-            .join(S3Dataset, S3Dataset.datasetUri == ShareObject.datasetUri)
-            .filter(and_(S3Dataset.GlueDatabaseName == database, ShareObject.principalIAMRoleName == principal))
-        )
-
-    @staticmethod
     def remove_share_object_item(session, share_item):
         session.delete(share_item)
         return True

--- a/backend/dataall/modules/shares_base/db/share_object_repositories.py
+++ b/backend/dataall/modules/shares_base/db/share_object_repositories.py
@@ -10,7 +10,6 @@ from dataall.core.environment.db.environment_models import Environment, Environm
 from dataall.modules.datasets_base.db.dataset_models import DatasetBase
 from dataall.modules.datasets_base.db.dataset_repositories import DatasetBaseRepository
 from dataall.modules.notifications.db.notification_models import Notification
-from dataall.modules.s3_datasets.db.dataset_models import S3Dataset
 from dataall.modules.shares_base.db.share_object_models import ShareObjectItem, ShareObject
 from dataall.modules.shares_base.services.shares_enums import ShareItemHealthStatus, PrincipalType, ShareableType
 


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix


### Detail

- After tables are synced and if the tables are deleted from the glue db then delete the tables where they are used in the shares and add an activity records for it

### Relates
- https://github.com/data-dot-all/dataall/issues/1734

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
