### PR TITLE
Fix global conftest shares after notifications PR

### DIFF
--- a/tests_new/integration_tests/modules/shares/s3_datasets_shares/test_new_crossacc_s3_share.py
+++ b/tests_new/integration_tests/modules/shares/s3_datasets_shares/test_new_crossacc_s3_share.py
@@ -3,7 +3,7 @@ from assertpy import assert_that
 
 from integration_tests.errors import GqlError
 from integration_tests.modules.s3_datasets.aws_clients import LakeFormationClient
-from integration_tests.modules.shares.s3_datasets_shares.conftest import clean_up_share
+from integration_tests.modules.shares.s3_datasets_shares.global_conftest import clean_up_share
 from tests_new.integration_tests.modules.shares.queries import (
     create_share_object,
     submit_share_object,


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Bugfix

### Detail
- Change path to `global_conftest` for shares integ tests


### Relates
- #1597 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
