### PR TITLE
Aurora upgrade

### DIFF
--- a/deploy/stacks/aurora.py
+++ b/deploy/stacks/aurora.py
@@ -10,7 +10,6 @@ from aws_cdk import (
 )
 
 from .pyNestedStack import pyNestedClass
-from .dms_task import DMSTaskStack
 
 
 class AuroraServerlessStack(pyNestedClass):
@@ -61,10 +60,7 @@ class AuroraServerlessStack(pyNestedClass):
         )
 
         db_credentials = rds.DatabaseSecret(
-            self,
-            f'{resource_prefix}-{envname}-aurora-v2-db',
-            username='dtaadmin',
-            encryption_key=key,
+            self, f'{resource_prefix}-{envname}-aurora-v2-db', username='dtaadmin', encryption_key=key
         )
 
         database_name = f'{envname}db'
@@ -191,14 +187,6 @@ class AuroraServerlessStack(pyNestedClass):
 
         self.cluster = database
         self.aurora_sg = db_security_group
-
-        if codebuild_dbmigration_sg:
-            DMSTaskStack(
-                self,
-                'DMSTaskStack',
-                secret_id_aurora_v1='arn:aws:secretsmanager:eu-west-2:637423210447:secret:devdb-cluster-old-sH1KVw',
-                secret_id_aurora_v2=db_credentials.secret_arn,
-                database_name=database_name,
-                vpc_security_group=codebuild_dbmigration_sg.security_group_id,
-                replication_subnet_group_identifier=f'default-{vpc.vpc_id}',
-            )
+        self.db_credentials = db_credentials
+        self.kms_key = key
+        self.db_name = database_name

--- a/deploy/stacks/aurora.py
+++ b/deploy/stacks/aurora.py
@@ -94,6 +94,7 @@ class AuroraServerlessStack(pyNestedClass):
             serverless_v2_min_capacity=4 if prod_sizing else 2,
             serverless_v2_max_capacity=16 if prod_sizing else 8,
             storage_encryption_key=key,
+            monitoring_interval=Duration.seconds(1),
         )
         database.add_rotation_single_user(automatically_after=Duration.days(90))
 

--- a/deploy/stacks/aurora.py
+++ b/deploy/stacks/aurora.py
@@ -60,7 +60,7 @@ class AuroraServerlessStack(pyNestedClass):
         )
 
         db_credentials = rds.DatabaseSecret(
-            self, f'{resource_prefix}-{envname}-aurora-db', username='dtaadmin', encryption_key=key
+            self, f'{resource_prefix}-{envname}-aurora-v2-db', username='dtaadmin', encryption_key=key
         )
 
         database_name = f'{envname}db'

--- a/deploy/stacks/backend_stage.py
+++ b/deploy/stacks/backend_stage.py
@@ -39,6 +39,8 @@ class BackendStage(Stage):
         with_approval_tests=False,
         allowed_origins='*',
         log_retention_duration=None,
+        deploy_dms_stack=False,
+        old_aurora_connection_secret_arn=None,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -75,6 +77,8 @@ class BackendStage(Stage):
             with_approval_tests=with_approval_tests,
             allowed_origins=allowed_origins,
             log_retention_duration=log_retention_duration,
+            deploy_dms_stack=deploy_dms_stack,
+            old_aurora_connection_secret_arn=old_aurora_connection_secret_arn,
             **kwargs,
         )
 

--- a/deploy/stacks/dms_task.py
+++ b/deploy/stacks/dms_task.py
@@ -1,0 +1,73 @@
+from aws_cdk import Stack, aws_dms as dms, aws_iam as iam
+from constructs import Construct
+
+
+class DMSTaskStack(Stack):
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        secret_id_aurora_v1: str,
+        secret_id_aurora_v2: str,
+        database_name: str,
+        vpc_security_group: str,
+        replication_subnet_group_identifier: str,
+        **kwargs,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        replication_role = iam.Role(
+            self,
+            'DMSReplicationRole',
+            role_name='dataall-dms-replication-role',
+            assumed_by=iam.ServicePrincipal('dms.amazonaws.com'),
+        )
+        replication_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=['secretsmanager:DescribeSecret', 'secretsmanager:GetSecretValue'],
+                effect=iam.Effect.ALLOW,
+                resources=[secret_id_aurora_v1, secret_id_aurora_v2],
+            )
+        )
+
+        cfn_replication_instance = dms.CfnReplicationInstance(
+            self,
+            'MyCfnReplicationInstance',
+            replication_instance_class='dms.c4.large',
+            vpc_security_group_ids=[vpc_security_group],
+            replication_subnet_group_identifier=replication_subnet_group_identifier,
+            replication_instance_identifier='test1',
+        )
+        cfn_endpoint_source = dms.CfnEndpoint(
+            self,
+            'MyCfnEndpoint',
+            endpoint_type='source',
+            engine_name='aurora-postgresql',
+            database_name=database_name,
+            postgre_sql_settings=dms.CfnEndpoint.PostgreSqlSettingsProperty(
+                secrets_manager_access_role_arn=replication_role.role_arn,
+                secrets_manager_secret_id=secret_id_aurora_v1,
+            ),
+        )
+
+        cfn_endpoint_target = dms.CfnEndpoint(
+            self,
+            'MyCfnEndpointTarget',
+            endpoint_type='target',
+            engine_name='aurora-postgresql',
+            database_name=database_name,
+            postgre_sql_settings=dms.CfnEndpoint.PostgreSqlSettingsProperty(
+                secrets_manager_access_role_arn=replication_role.role_arn,
+                secrets_manager_secret_id=secret_id_aurora_v2,
+            ),
+        )
+
+        cfn_replication_task = dms.CfnReplicationTask(
+            self,
+            'MyCfnReplicationTask',
+            migration_type='full-load',
+            replication_instance_arn=cfn_replication_instance.ref,
+            source_endpoint_arn=cfn_endpoint_source.ref,
+            table_mappings='{ "rules": [ { "rule-type": "selection", "rule-id": "1", "rule-name": "1", "object-locator": { "schema-name": "%", "table-name": "%" }, "rule-action": "include" } ] }',
+            target_endpoint_arn=cfn_endpoint_target.ref,
+        )

--- a/deploy/stacks/dms_task.py
+++ b/deploy/stacks/dms_task.py
@@ -1,8 +1,9 @@
 from aws_cdk import Stack, aws_dms as dms, aws_iam as iam
 from constructs import Construct
+from .pyNestedStack import pyNestedClass
 
 
-class DMSTaskStack(Stack):
+class DMSTaskStack(pyNestedClass):
     def __init__(
         self,
         scope: Construct,

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -681,6 +681,8 @@ class PipelineStack(Stack):
                 with_approval_tests=target_env.get('with_approval_tests', False),
                 allowed_origins=target_env.get('allowed_origins', '*'),
                 log_retention_duration=self.log_retention_duration,
+                deploy_dms_stack=target_env.get('aurora_migration_enabled', False),
+                old_aurora_connection_secret_arn=target_env.get('old_aurora_connection_secret_arn', ''),
             )
         )
         return backend_stage

--- a/deploy/stacks/trigger_function_stack.py
+++ b/deploy/stacks/trigger_function_stack.py
@@ -81,6 +81,7 @@ class TriggerFunctionStack(pyNestedClass):
         self.trigger_function.connections.allow_to(
             ec2.Peer.any_ipv4(), ec2.Port.tcp(443), 'Allow NAT Internet Access SG Egress'
         )
+        self.security_group = function_sgs
 
     def get_policy_statements(self, resource_prefix) -> List[iam.PolicyStatement]:
         return [


### PR DESCRIPTION
### Feature or Bugfix
<!-- please choose -->
- Feature


### Detail
- `cdk.json` configure pipelline to deploy DMS task for data migration
- inside environment section of cdk.json: 
```
  "aurora_migration_enabled": true,
   "old_aurora_connection_secret_arn": "arn:aws:secretsmanager:..."
```
- After DMS task is deployed, it has to be started manually
- Before start the pipeline, the secret of previous Aurora cluster (v1) should be copied and this new secret arn should be provided 
- !!! Right now DMS has bug, so `dataset` table won't be migrated properly. After task is failed, we can make `alter table dataset alter column enableExpiration drop not null`. After that the task will be executed without errors, but  `enableExpiration` will be `NULL` for every row.
- This feature also can be used to migrate data from any other data.all cluster
### Relates
- #1513 

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
