### PR TITLE
Fix: Add conditional to not lock empty list of resources

### DIFF
--- a/backend/dataall/modules/s3_datasets_shares/services/share_processors/glue_table_share_processor.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_processors/glue_table_share_processor.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import nullcontext
 from typing import List
 from warnings import warn
 from datetime import datetime
@@ -244,11 +245,15 @@ class ProcessLakeFormationShare(SharesProcessorInterface):
         log.info(f'Additional Resources to be locked while revoking glue tables: {additional_resources_to_lock}')
 
         try:
-            with ResourceLockRepository.acquire_lock_with_retry(
-                resources=additional_resources_to_lock,
-                session=self.session,
-                acquired_by_uri=self.share_data.share.shareUri,
-                acquired_by_type=self.share_data.share.__tablename__,
+            with (
+                ResourceLockRepository.acquire_lock_with_retry(
+                    resources=additional_resources_to_lock,
+                    session=self.session,
+                    acquired_by_uri=self.share_data.share.shareUri,
+                    acquired_by_type=self.share_data.share.__tablename__,
+                )
+                if additional_resources_to_lock
+                else nullcontext()
             ):
                 log.info('##### Starting Revoking tables #######')
                 success = True


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
In https://github.com/data-dot-all/dataall/pull/1706 all the scenarios tested had multiple Datasets sharing a shared-Glue database. The issue is that when there is no common shared Glue database the lock will try to lock an empty list of resources, resulting in timeouts in `backend/dataall/modules/s3_datasets_shares/services/share_processors/glue_table_share_processor.py:248` 

### Relates
- https://github.com/data-dot-all/dataall/pull/1706

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
