### PR TITLE
feature(GH-1613)- New policy management types

### DIFF
--- a/backend/dataall/core/environment/__init__.py
+++ b/backend/dataall/core/environment/__init__.py
@@ -1,3 +1,3 @@
 """The central package of the application to work with the environment"""
 
-from dataall.core.environment import api, cdk, tasks
+from dataall.core.environment import api, db, cdk, tasks

--- a/backend/dataall/core/environment/api/input_types.py
+++ b/backend/dataall/core/environment/api/input_types.py
@@ -120,6 +120,6 @@ UpdateConsumptionRoleInput = gql.InputType(
     arguments=[
         gql.Argument('consumptionRoleName', gql.String),
         gql.Argument('groupUri', gql.String),
-        gql.Argument('dataallManaged', gql.NonNullableType(PolicyManagementOptions.toGraphQLEnum()))
+        gql.Argument('dataallManaged', gql.NonNullableType(PolicyManagementOptions.toGraphQLEnum())),
     ],
 )

--- a/backend/dataall/core/environment/api/input_types.py
+++ b/backend/dataall/core/environment/api/input_types.py
@@ -101,7 +101,7 @@ AddConsumptionRoleToEnvironmentInput = gql.InputType(
         gql.Argument('groupUri', gql.NonNullableType(gql.String)),
         gql.Argument('IAMRoleArn', gql.NonNullableType(gql.String)),
         gql.Argument('environmentUri', gql.NonNullableType(gql.String)),
-        gql.Argument('dataallManaged', gql.NonNullableType(gql.Boolean)),
+        gql.Argument('dataallManaged', gql.NonNullableType(gql.String)),
     ],
 )
 

--- a/backend/dataall/core/environment/api/input_types.py
+++ b/backend/dataall/core/environment/api/input_types.py
@@ -1,6 +1,6 @@
 from dataall.base.api import gql
 from dataall.base.api.constants import GraphQLEnumMapper, SortDirection
-
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
 
 AwsEnvironmentInput = gql.InputType(
     name='AwsEnvironmentInput',
@@ -101,7 +101,7 @@ AddConsumptionRoleToEnvironmentInput = gql.InputType(
         gql.Argument('groupUri', gql.NonNullableType(gql.String)),
         gql.Argument('IAMRoleArn', gql.NonNullableType(gql.String)),
         gql.Argument('environmentUri', gql.NonNullableType(gql.String)),
-        gql.Argument('dataallManaged', gql.NonNullableType(gql.String)),
+        gql.Argument('dataallManaged', gql.NonNullableType(PolicyManagementOptions.toGraphQLEnum())),
     ],
 )
 

--- a/backend/dataall/core/environment/api/input_types.py
+++ b/backend/dataall/core/environment/api/input_types.py
@@ -120,5 +120,6 @@ UpdateConsumptionRoleInput = gql.InputType(
     arguments=[
         gql.Argument('consumptionRoleName', gql.String),
         gql.Argument('groupUri', gql.String),
+        gql.Argument('dataallManaged', gql.NonNullableType(PolicyManagementOptions.toGraphQLEnum()))
     ],
 )

--- a/backend/dataall/core/environment/api/types.py
+++ b/backend/dataall/core/environment/api/types.py
@@ -8,7 +8,7 @@ from dataall.core.environment.api.resolvers import (
     resolve_user_role,
 )
 from dataall.core.environment.api.enums import EnvironmentPermission
-
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
 
 EnvironmentUserPermission = gql.ObjectType(
     name='EnvironmentUserPermission',
@@ -176,7 +176,7 @@ ConsumptionRole = gql.ObjectType(
         gql.Field(name='environmentUri', type=gql.String),
         gql.Field(name='IAMRoleArn', type=gql.String),
         gql.Field(name='IAMRoleName', type=gql.String),
-        gql.Field(name='dataallManaged', type=gql.String),
+        gql.Field(name='dataallManaged', type=gql.NonNullableType(PolicyManagementOptions.toGraphQLEnum())),
         gql.Field(name='created', type=gql.String),
         gql.Field(name='updated', type=gql.String),
         gql.Field(name='deleted', type=gql.String),

--- a/backend/dataall/core/environment/api/types.py
+++ b/backend/dataall/core/environment/api/types.py
@@ -176,7 +176,7 @@ ConsumptionRole = gql.ObjectType(
         gql.Field(name='environmentUri', type=gql.String),
         gql.Field(name='IAMRoleArn', type=gql.String),
         gql.Field(name='IAMRoleName', type=gql.String),
-        gql.Field(name='dataallManaged', type=gql.Boolean),
+        gql.Field(name='dataallManaged', type=gql.String),
         gql.Field(name='created', type=gql.String),
         gql.Field(name='updated', type=gql.String),
         gql.Field(name='deleted', type=gql.String),

--- a/backend/dataall/core/environment/api/types.py
+++ b/backend/dataall/core/environment/api/types.py
@@ -163,7 +163,7 @@ RoleManagedPolicy = gql.ObjectType(
         gql.Field(name='policy_name', type=gql.String),
         gql.Field(name='policy_type', type=gql.String),
         gql.Field(name='exists', type=gql.Boolean),
-        gql.Field(name='attached', type=gql.Boolean),
+        gql.Field(name='attached', type=gql.String),
     ],
 )
 

--- a/backend/dataall/core/environment/cdk/environment_stack.py
+++ b/backend/dataall/core/environment/cdk/environment_stack.py
@@ -453,10 +453,14 @@ class EnvironmentSetup(Stack):
 
         with self.engine.scoped_session() as session:
             external_managed_policies = []
-            policy_manager = PolicyManager(session=session, account=self._environment.AwsAccountId, region=self._environment.region,
-                                           environmentUri=self._environment.environmentUri,
-                                           resource_prefix=self._environment.resourcePrefix,
-                                           role_name=group.environmentIAMRoleName)
+            policy_manager = PolicyManager(
+                session=session,
+                account=self._environment.AwsAccountId,
+                region=self._environment.region,
+                environmentUri=self._environment.environmentUri,
+                resource_prefix=self._environment.resourcePrefix,
+                role_name=group.environmentIAMRoleName,
+            )
             try:
                 managed_policies = policy_manager.get_all_policies()
             except Exception as e:

--- a/backend/dataall/core/environment/cdk/environment_stack.py
+++ b/backend/dataall/core/environment/cdk/environment_stack.py
@@ -451,32 +451,29 @@ class EnvironmentSetup(Stack):
             permissions=group_permissions,
         ).generate_policies()
 
-        external_managed_policies = []
-        policy_manager = PolicyManager(
-            environmentUri=self._environment.environmentUri,
-            resource_prefix=self._environment.resourcePrefix,
-            role_name=group.environmentIAMRoleName,
-            account=self._environment.AwsAccountId,
-            region=self._environment.region,
-        )
-        try:
-            managed_policies = policy_manager.get_all_policies()
-        except Exception as e:
-            logger.info(f'Not adding any managed policy because of exception: {e}')
-            # Known exception raised in first deployment because pivot role does not exist and cannot be assumed
-            managed_policies = []
-        for policy in managed_policies:
-            # If there is a managed policy that exist it should be attached to the IAM role
-            if policy.get('exists', False):
-                external_managed_policies.append(
-                    iam.ManagedPolicy.from_managed_policy_name(
-                        self,
-                        id=f'{self._environment.resourcePrefix}-managed-policy-{policy.get("policy_name")}',
-                        managed_policy_name=policy.get('policy_name'),
-                    )
-                )
-
         with self.engine.scoped_session() as session:
+            external_managed_policies = []
+            policy_manager = PolicyManager(session=session, account=self._environment.AwsAccountId, region=self._environment.region,
+                                           environmentUri=self._environment.environmentUri,
+                                           resource_prefix=self._environment.resourcePrefix,
+                                           role_name=group.environmentIAMRoleName)
+            try:
+                managed_policies = policy_manager.get_all_policies()
+            except Exception as e:
+                logger.info(f'Not adding any managed policy because of exception: {e}')
+                # Known exception raised in first deployment because pivot role does not exist and cannot be assumed
+                managed_policies = []
+            for policy in managed_policies:
+                # If there is a managed policy that exist it should be attached to the IAM role
+                if policy.get('exists', False):
+                    external_managed_policies.append(
+                        iam.ManagedPolicy.from_managed_policy_name(
+                            self,
+                            id=f'{self._environment.resourcePrefix}-managed-policy-{policy.get("policy_name")}',
+                            managed_policy_name=policy.get('policy_name'),
+                        )
+                    )
+
             data_policy = S3Policy(
                 stack=self,
                 tag_key='Team',

--- a/backend/dataall/core/environment/db/__init__.py
+++ b/backend/dataall/core/environment/db/__init__.py
@@ -1,0 +1,5 @@
+from . import (
+    environment_enums,
+    environment_models,
+    environment_repositories
+)

--- a/backend/dataall/core/environment/db/__init__.py
+++ b/backend/dataall/core/environment/db/__init__.py
@@ -1,5 +1,1 @@
-from . import (
-    environment_enums,
-    environment_models,
-    environment_repositories
-)
+from . import environment_enums, environment_models, environment_repositories

--- a/backend/dataall/core/environment/db/environment_enums.py
+++ b/backend/dataall/core/environment/db/environment_enums.py
@@ -1,0 +1,7 @@
+from dataall.base.api import GraphQLEnumMapper
+
+
+class ConsumptionRolePolicyManagementOptions(GraphQLEnumMapper):
+    FULLY_MANAGED = 'FullyManaged'
+    PARTIALLY_MANAGED = 'PartiallyManaged'
+    EXTERNALLY_MANAGED = 'ExternallyManaged'

--- a/backend/dataall/core/environment/db/environment_enums.py
+++ b/backend/dataall/core/environment/db/environment_enums.py
@@ -1,7 +1,7 @@
 from dataall.base.api import GraphQLEnumMapper
 
 
-class ConsumptionRolePolicyManagementOptions(GraphQLEnumMapper):
+class PolicyManagementOptions(GraphQLEnumMapper):
     FULLY_MANAGED = 'FullyManaged'
     PARTIALLY_MANAGED = 'PartiallyManaged'
     EXTERNALLY_MANAGED = 'ExternallyManaged'

--- a/backend/dataall/core/environment/db/environment_enums.py
+++ b/backend/dataall/core/environment/db/environment_enums.py
@@ -2,6 +2,6 @@ from dataall.base.api import GraphQLEnumMapper
 
 
 class PolicyManagementOptions(GraphQLEnumMapper):
-    FULLY_MANAGED = 'FullyManaged'
-    PARTIALLY_MANAGED = 'PartiallyManaged'
-    EXTERNALLY_MANAGED = 'ExternallyManaged'
+    FULLY_MANAGED = 'Fully-Managed'
+    PARTIALLY_MANAGED = 'Partially-Managed'
+    EXTERNALLY_MANAGED = 'Externally-Managed'

--- a/backend/dataall/core/environment/db/environment_models.py
+++ b/backend/dataall/core/environment/db/environment_models.py
@@ -85,7 +85,7 @@ class ConsumptionRole(Base):
     groupUri = Column(String, nullable=False)
     IAMRoleName = Column(String, nullable=False)
     IAMRoleArn = Column(String, nullable=False)
-    dataallManaged = Column(Boolean, nullable=False, default=True)
+    dataallManaged = Column(String, nullable=False)
     created = Column(DateTime, default=datetime.datetime.now)
     updated = Column(DateTime, onupdate=datetime.datetime.now)
     deleted = Column(DateTime)

--- a/backend/dataall/core/environment/db/environment_models.py
+++ b/backend/dataall/core/environment/db/environment_models.py
@@ -2,11 +2,12 @@
 
 import datetime
 
-from sqlalchemy import Boolean, Column, DateTime, String, ForeignKey
+from sqlalchemy import Boolean, Column, DateTime, String, ForeignKey, Enum
 from sqlalchemy.orm import query_expression
 from dataall.base.db import Resource, Base, utils
 
 from dataall.core.environment.api.enums import EnvironmentPermission, EnvironmentType
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
 
 
 class Environment(Resource, Base):

--- a/backend/dataall/core/environment/db/environment_repositories.py
+++ b/backend/dataall/core/environment/db/environment_repositories.py
@@ -160,7 +160,6 @@ class EnvironmentRepository:
                 )
             )
         if filter and filter.get('groupUri'):
-            print('filter group')
             group = filter['groupUri']
             query = query.filter(
                 or_(

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -1142,8 +1142,3 @@ class EnvironmentService:
                 role_name=IAMRoleName,
             ).get_all_policies()
 
-    @staticmethod
-    @ResourcePolicyService.has_resource_permission(environment_permissions.GET_ENVIRONMENT)
-    def get_consumption_role_by_name(uri, IAMRoleName):
-        with get_context().db_engine.scoped_session() as session:
-            return EnvironmentRepository.get_environment_consumption_role_by_name(session, uri, IAMRoleName)

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -692,7 +692,9 @@ class EnvironmentService:
                         role_name=consumption_role.IAMRoleName,
                     )
                     for policy_manager in [
-                        Policy for Policy in share_policy_manager.initializedPolicies if Policy.policy_type == 'SharePolicy'
+                        Policy
+                        for Policy in share_policy_manager.initializedPolicies
+                        if Policy.policy_type == 'SharePolicy'
                     ]:
                         managed_policy_list = policy_manager.get_policies_unattached_to_role()
                         policy_manager.attach_policies(managed_policy_list)
@@ -1159,4 +1161,3 @@ class EnvironmentService:
                 resource_prefix=environment.resourcePrefix,
                 role_name=IAMRoleName,
             ).get_all_policies()
-

--- a/backend/dataall/core/environment/services/environment_service.py
+++ b/backend/dataall/core/environment/services/environment_service.py
@@ -125,8 +125,6 @@ class EnvironmentRequestValidationService:
             raise exceptions.RequiredParameter('groupUri')
         if not data.get('IAMRoleArn'):
             raise exceptions.RequiredParameter('IAMRoleArn')
-        if not data.get('dataallManaged'):
-            raise exceptions.RequiredParameter('dataallManaged')
 
     @staticmethod
     def validate_org_group(org_uri, group, session):

--- a/backend/dataall/core/environment/services/managed_iam_policies.py
+++ b/backend/dataall/core/environment/services/managed_iam_policies.py
@@ -198,8 +198,13 @@ class PolicyManager(object):
             # Check if the role_name is registered as a consumption role.
             # If its a consumption role with a "Externally Managed" policy management then 'attached' will be marked as 'N/A'
             externally_managed_role: bool = False
-            consumption_role_details = EnvironmentRepository.get_environment_consumption_role_by_name(self.session, self.environmentUri, self.role_name)
-            if consumption_role_details and consumption_role_details.dataallManaged == PolicyManagementOptions.EXTERNALLY_MANAGED.value:
+            consumption_role_details = EnvironmentRepository.get_environment_consumption_role_by_name(
+                self.session, self.environmentUri, self.role_name
+            )
+            if (
+                consumption_role_details
+                and consumption_role_details.dataallManaged == PolicyManagementOptions.EXTERNALLY_MANAGED.value
+            ):
                 externally_managed_role = True
 
             for policy_name in policy_name_list:
@@ -207,7 +212,9 @@ class PolicyManager(object):
                     'policy_name': policy_name,
                     'policy_type': policy_manager.policy_type,
                     'exists': policy_manager.check_if_policy_exists(policy_name=policy_name),
-                    'attached': 'N/A' if externally_managed_role else policy_manager.check_if_policy_attached(policy_name=policy_name),
+                    'attached': 'N/A'
+                    if externally_managed_role
+                    else policy_manager.check_if_policy_attached(policy_name=policy_name),
                 }
                 all_policies.append(policy_dict)
         logger.info(f'All policies currently added to role: {self.role_name} are: {str(all_policies)}')

--- a/backend/dataall/core/environment/services/managed_iam_policies.py
+++ b/backend/dataall/core/environment/services/managed_iam_policies.py
@@ -3,7 +3,8 @@ import logging
 import json
 from abc import ABC, abstractmethod
 from dataall.base.aws.iam import IAM
-from dataall.core.environment.db.environment_enums import ConsumptionRolePolicyManagementOptions
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
+from dataall.core.environment.db.environment_repositories import EnvironmentRepository
 
 logger = logging.getLogger(__name__)
 
@@ -94,14 +95,8 @@ class ManagedPolicy(ABC):
 
 
 class PolicyManager(object):
-    def __init__(
-        self,
-        role_name,
-        account,
-        region,
-        environmentUri,
-        resource_prefix,
-    ):
+    def __init__(self, session, account, region, environmentUri, resource_prefix, role_name):
+        self.session = session
         self.role_name = role_name
         self.account = account
         self.region = region
@@ -120,7 +115,7 @@ class PolicyManager(object):
             resource_prefix=self.resource_prefix,
         )
 
-    def create_all_policies(self, policy_management: ConsumptionRolePolicyManagementOptions) -> bool:
+    def create_all_policies(self, policy_management: str) -> bool:
         """
         Manager that registers and calls all policies created by data.all modules and that
         need to be created for consumption roles and team roles
@@ -137,7 +132,7 @@ class PolicyManager(object):
                     policy=json.dumps(empty_policy),
                 )
 
-                if policy_management == ConsumptionRolePolicyManagementOptions.FULLY_MANAGED:
+                if policy_management == PolicyManagementOptions.FULLY_MANAGED.value:
                     IAM.attach_role_policy(
                         account_id=self.account,
                         region=self.region,
@@ -200,12 +195,19 @@ class PolicyManager(object):
                 if policy_manager.check_if_policy_exists(policy_name=old_managed_policy_name):
                     policy_name_list.append(old_managed_policy_name)
 
+            # Check if the role_name is registered as a consumption role.
+            # If its a consumption role with a "Externally Managed" policy management then 'attached' will be marked as 'N/A'
+            externally_managed_role: bool = False
+            consumption_role_details = EnvironmentRepository.get_environment_consumption_role_by_name(self.session, self.environmentUri, self.role_name)
+            if consumption_role_details and consumption_role_details.dataallManaged == PolicyManagementOptions.EXTERNALLY_MANAGED.value:
+                externally_managed_role = True
+
             for policy_name in policy_name_list:
                 policy_dict = {
                     'policy_name': policy_name,
                     'policy_type': policy_manager.policy_type,
                     'exists': policy_manager.check_if_policy_exists(policy_name=policy_name),
-                    'attached': policy_manager.check_if_policy_attached(policy_name=policy_name),
+                    'attached': 'N/A' if externally_managed_role else policy_manager.check_if_policy_attached(policy_name=policy_name),
                 }
                 all_policies.append(policy_dict)
         logger.info(f'All policies currently added to role: {self.role_name} are: {str(all_policies)}')

--- a/backend/dataall/core/environment/services/managed_iam_policies.py
+++ b/backend/dataall/core/environment/services/managed_iam_policies.py
@@ -3,6 +3,7 @@ import logging
 import json
 from abc import ABC, abstractmethod
 from dataall.base.aws.iam import IAM
+from dataall.core.environment.db.environment_enums import ConsumptionRolePolicyManagementOptions
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +120,7 @@ class PolicyManager(object):
             resource_prefix=self.resource_prefix,
         )
 
-    def create_all_policies(self, managed) -> bool:
+    def create_all_policies(self, policy_management: ConsumptionRolePolicyManagementOptions) -> bool:
         """
         Manager that registers and calls all policies created by data.all modules and that
         need to be created for consumption roles and team roles
@@ -136,7 +137,7 @@ class PolicyManager(object):
                     policy=json.dumps(empty_policy),
                 )
 
-                if managed:
+                if policy_management == ConsumptionRolePolicyManagementOptions.FULLY_MANAGED:
                     IAM.attach_role_policy(
                         account_id=self.account,
                         region=self.region,

--- a/backend/dataall/core/environment/services/managed_iam_policies.py
+++ b/backend/dataall/core/environment/services/managed_iam_policies.py
@@ -198,8 +198,9 @@ class PolicyManager(object):
             # Check if the role_name is registered as a consumption role.
             # If its a consumption role with a "Externally Managed" policy management then 'attached' will be marked as 'N/A'
             externally_managed_role: bool = False
-            consumption_role_details = EnvironmentRepository.get_environment_consumption_role_by_name(
-                self.session, self.environmentUri, self.role_name
+            role_arn = f'arn:aws:iam::{self.account}:role/{self.role_name}'
+            consumption_role_details = EnvironmentRepository.find_consumption_roles_by_IAMArn(
+                session=self.session, uri=self.environmentUri, arn=role_arn
             )
             if (
                 consumption_role_details

--- a/backend/dataall/modules/s3_datasets_shares/services/s3_share_validator.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/s3_share_validator.py
@@ -1,5 +1,6 @@
 from dataall.base.db.exceptions import UnauthorizedOperation, InvalidInput
 from dataall.base.aws.iam import IAM
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
 from dataall.core.environment.services.environment_service import EnvironmentService
 from dataall.core.environment.db.environment_models import EnvironmentGroup, ConsumptionRole
 from dataall.core.environment.services.managed_iam_policies import PolicyManager
@@ -105,7 +106,7 @@ class S3ShareValidator(SharesValidatorInterface):
                 session, principal_id, environment.environmentUri
             )
             principal_role_name = consumption_role.IAMRoleName
-            managed = consumption_role.dataallManaged
+            managed = consumption_role.dataallManaged == PolicyManagementOptions.FULLY_MANAGED.value
 
         else:
             env_group: EnvironmentGroup = EnvironmentService.get_environment_group(
@@ -124,9 +125,14 @@ class S3ShareValidator(SharesValidatorInterface):
             )
 
         log.info('Verifying data.all managed share IAM policy is attached to IAM role...')
-        share_policy_manager = PolicyManager(session=session, account=environment.AwsAccountId, region=environment.region,
-                                             environmentUri=environment.environmentUri,
-                                             resource_prefix=environment.resourcePrefix, role_name=principal_role_name)
+        share_policy_manager = PolicyManager(
+            session=session,
+            account=environment.AwsAccountId,
+            region=environment.region,
+            environmentUri=environment.environmentUri,
+            resource_prefix=environment.resourcePrefix,
+            role_name=principal_role_name,
+        )
         for policy_manager in [
             Policy for Policy in share_policy_manager.initializedPolicies if Policy.policy_type == 'SharePolicy'
         ]:
@@ -152,10 +158,6 @@ class S3ShareValidator(SharesValidatorInterface):
             # End of backwards compatibility
 
             unattached = policy_manager.get_policies_unattached_to_role()
-            if unattached and not managed and not attachMissingPolicies:
-                raise Exception(
-                    f'Required customer managed policies {policy_manager.get_policies_unattached_to_role()} are not attached to role {principal_role_name}'
-                )
-            elif unattached:
+            if unattached and (managed or attachMissingPolicies):
                 managed_policy_list = policy_manager.get_policies_unattached_to_role()
                 policy_manager.attach_policies(managed_policy_list)

--- a/backend/dataall/modules/s3_datasets_shares/services/s3_share_validator.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/s3_share_validator.py
@@ -124,13 +124,9 @@ class S3ShareValidator(SharesValidatorInterface):
             )
 
         log.info('Verifying data.all managed share IAM policy is attached to IAM role...')
-        share_policy_manager = PolicyManager(
-            role_name=principal_role_name,
-            environmentUri=environment.environmentUri,
-            account=environment.AwsAccountId,
-            region=environment.region,
-            resource_prefix=environment.resourcePrefix,
-        )
+        share_policy_manager = PolicyManager(session=session, account=environment.AwsAccountId, region=environment.region,
+                                             environmentUri=environment.environmentUri,
+                                             resource_prefix=environment.resourcePrefix, role_name=principal_role_name)
         for policy_manager in [
             Policy for Policy in share_policy_manager.initializedPolicies if Policy.policy_type == 'SharePolicy'
         ]:

--- a/backend/dataall/modules/s3_datasets_shares/services/share_processors/s3_access_point_share_processor.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_processors/s3_access_point_share_processor.py
@@ -2,6 +2,9 @@ import logging
 from datetime import datetime
 from typing import List
 
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
+from dataall.core.environment.db.environment_models import ConsumptionRole
+from dataall.core.environment.db.environment_repositories import EnvironmentRepository
 from dataall.modules.shares_base.services.share_exceptions import PrincipalRoleNotFound
 from dataall.modules.s3_datasets_shares.services.share_managers import S3AccessPointShareManager
 from dataall.modules.s3_datasets_shares.services.s3_share_service import S3ShareService
@@ -11,6 +14,7 @@ from dataall.modules.shares_base.services.shares_enums import (
     ShareItemStatus,
     ShareObjectActions,
     ShareItemActions,
+    PrincipalType,
 )
 from dataall.modules.s3_datasets.db.dataset_models import DatasetStorageLocation
 from dataall.modules.shares_base.db.share_object_repositories import ShareObjectRepository

--- a/backend/dataall/modules/s3_datasets_shares/services/share_processors/s3_bucket_share_processor.py
+++ b/backend/dataall/modules/s3_datasets_shares/services/share_processors/s3_bucket_share_processor.py
@@ -1,8 +1,10 @@
 import logging
 from datetime import datetime
-from logging import exception
 from typing import List
 
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
+from dataall.core.environment.db.environment_models import ConsumptionRole
+from dataall.core.environment.db.environment_repositories import EnvironmentRepository
 from dataall.modules.shares_base.services.share_exceptions import PrincipalRoleNotFound
 from dataall.modules.s3_datasets_shares.services.share_managers import S3BucketShareManager
 from dataall.modules.s3_datasets_shares.services.s3_share_service import S3ShareService
@@ -11,6 +13,7 @@ from dataall.modules.shares_base.services.shares_enums import (
     ShareItemStatus,
     ShareObjectActions,
     ShareItemActions,
+    PrincipalType,
 )
 from dataall.modules.shares_base.db.share_object_repositories import ShareObjectRepository
 from dataall.modules.shares_base.db.share_state_machines_repositories import ShareStatusRepository

--- a/backend/dataall/modules/shares_base/api/resolvers.py
+++ b/backend/dataall/modules/shares_base/api/resolvers.py
@@ -288,6 +288,12 @@ def resolve_existing_shared_items(context: Context, source: ShareObject, **kwarg
     return ShareItemService.check_existing_shared_items(source)
 
 
+def resolve_role_policy_management(context, source: ShareObject):
+    if not source:
+        return 'Not Available'
+    return EnvironmentService.get_role_policy_management_type(source.principalType, source.principalId)
+
+
 def list_shareable_objects(context: Context, source: ShareObject, filter: dict = None):
     if not source:
         return None

--- a/backend/dataall/modules/shares_base/api/types.py
+++ b/backend/dataall/modules/shares_base/api/types.py
@@ -14,6 +14,7 @@ from dataall.modules.shares_base.api.resolvers import (
     list_shareable_objects,
     resolve_user_role,
     resolve_can_view_logs,
+    resolve_role_policy_management,
 )
 from dataall.core.environment.api.resolvers import resolve_environment
 
@@ -171,6 +172,11 @@ ShareObject = gql.ObjectType(
             resolver=resolve_user_role,
         ),
         gql.Field('permissions', gql.ArrayType(ShareObjectDataPermission.toGraphQLEnum())),
+        gql.Field(
+            name='policyManagement',
+            type=gql.String,
+            resolver=resolve_role_policy_management,
+        ),
     ],
 )
 

--- a/backend/dataall/modules/shares_base/api/types.py
+++ b/backend/dataall/modules/shares_base/api/types.py
@@ -1,4 +1,5 @@
 from dataall.base.api import gql
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
 from dataall.modules.shares_base.services.shares_enums import (
     ShareableType,
     PrincipalType,
@@ -174,7 +175,7 @@ ShareObject = gql.ObjectType(
         gql.Field('permissions', gql.ArrayType(ShareObjectDataPermission.toGraphQLEnum())),
         gql.Field(
             name='policyManagement',
-            type=gql.String,
+            type=gql.NonNullableType(PolicyManagementOptions.toGraphQLEnum()),
             resolver=resolve_role_policy_management,
         ),
     ],

--- a/backend/dataall/modules/shares_base/services/share_object_service.py
+++ b/backend/dataall/modules/shares_base/services/share_object_service.py
@@ -8,6 +8,7 @@ from typing import Dict, List
 from dataall.base.context import get_context
 from dataall.base.db.exceptions import UnauthorizedOperation, InvalidInput
 from dataall.core.activity.db.activity_models import Activity
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
 from dataall.core.environment.services.environment_service import EnvironmentService
 from dataall.core.permissions.services.resource_policy_service import ResourcePolicyService
 from dataall.core.permissions.services.tenant_policy_service import TenantPolicyService

--- a/backend/migrations/versions/77c3f1b2bec8_consumption_role_column_update.py
+++ b/backend/migrations/versions/77c3f1b2bec8_consumption_role_column_update.py
@@ -5,6 +5,7 @@ Revises: af2e1362d4cb
 Create Date: 2025-02-05 11:05:55.782419
 
 """
+
 from typing import List, Dict
 
 from alembic import op
@@ -12,13 +13,14 @@ import sqlalchemy as sa
 from sqlalchemy import orm
 
 from dataall.core.environment.db.environment_enums import PolicyManagementOptions
-from dataall.core.environment.db.environment_models import  ConsumptionRole
+from dataall.core.environment.db.environment_models import ConsumptionRole
 
 # revision identifiers, used by Alembic.
 revision = '77c3f1b2bec8'
 down_revision = 'af2e1362d4cb'
 branch_labels = None
 depends_on = None
+
 
 def get_session():
     bind = op.get_bind()
@@ -27,9 +29,15 @@ def get_session():
 
 
 def upgrade():
-
     # Update the column type to String and also remove the DEFAULT True
-    op.alter_column(table_name='consumptionrole', column_name='dataallManaged', nullable=False, existing_type=sa.Boolean(),type_=sa.String(), server_default=None)
+    op.alter_column(
+        table_name='consumptionrole',
+        column_name='dataallManaged',
+        nullable=False,
+        existing_type=sa.Boolean(),
+        type_=sa.String(),
+        server_default=None,
+    )
 
     session = get_session()
 
@@ -43,11 +51,17 @@ def upgrade():
     session.add_all(consumption_roles)
     session.commit()
 
+
 def downgrade():
     session = get_session()
     consumption_roles: List[ConsumptionRole] = session.query(ConsumptionRole).all()
     # For each consumption role, get the policy management options and set value to True if FullyManaged else False
-    consumption_role_policy_mgmt_map: Dict[str, str] = {consumption_role.consumptionRoleUri: True if consumption_role.dataallManaged == PolicyManagementOptions.FULLY_MANAGED.value else False for consumption_role in consumption_roles}
+    consumption_role_policy_mgmt_map: Dict[str, str] = {
+        consumption_role.consumptionRoleUri: True
+        if consumption_role.dataallManaged == PolicyManagementOptions.FULLY_MANAGED.value
+        else False
+        for consumption_role in consumption_roles
+    }
 
     op.drop_column(table_name='consumptionrole', column_name='dataallManaged')
     op.add_column(
@@ -58,6 +72,8 @@ def downgrade():
     # Update all the consumption.dataallManaged column with boolean values by using consumption_role_policy_mgmt_map map
     consumption_roles: List[ConsumptionRole] = session.query(ConsumptionRole).all()
     for consumption_role in consumption_roles:
-        consumption_role.dataallManaged = consumption_role_policy_mgmt_map.get(consumption_role.consumptionRoleUri, True)
+        consumption_role.dataallManaged = consumption_role_policy_mgmt_map.get(
+            consumption_role.consumptionRoleUri, True
+        )
     session.add_all(consumption_roles)
     session.commit()

--- a/backend/migrations/versions/77c3f1b2bec8_consumption_role_column_update.py
+++ b/backend/migrations/versions/77c3f1b2bec8_consumption_role_column_update.py
@@ -1,0 +1,63 @@
+"""Consumption role schema change and backfilling
+
+Revision ID: 77c3f1b2bec8
+Revises: af2e1362d4cb
+Create Date: 2025-02-05 11:05:55.782419
+
+"""
+from typing import List, Dict
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import orm
+
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
+from dataall.core.environment.db.environment_models import  ConsumptionRole
+
+# revision identifiers, used by Alembic.
+revision = '77c3f1b2bec8'
+down_revision = 'af2e1362d4cb'
+branch_labels = None
+depends_on = None
+
+def get_session():
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+    return session
+
+
+def upgrade():
+
+    # Update the column type to String and also remove the DEFAULT True
+    op.alter_column(table_name='consumptionrole', column_name='dataallManaged', nullable=False, existing_type=sa.Boolean(),type_=sa.String(), server_default=None)
+
+    session = get_session()
+
+    # For all consumption roles, set the dataallManaged column value with the PolicyManagementOptions types
+    consumption_roles: List[ConsumptionRole] = session.query(ConsumptionRole).all()
+    for consumption_role in consumption_roles:
+        if consumption_role.dataallManaged == 'true':
+            consumption_role.dataallManaged = PolicyManagementOptions.FULLY_MANAGED.value
+        else:
+            consumption_role.dataallManaged = PolicyManagementOptions.PARTIALLY_MANAGED.value
+    session.add_all(consumption_roles)
+    session.commit()
+
+def downgrade():
+    session = get_session()
+    consumption_roles: List[ConsumptionRole] = session.query(ConsumptionRole).all()
+    # For each consumption role, get the policy management options and set value to True if FullyManaged else False
+    consumption_role_policy_mgmt_map: Dict[str, str] = {consumption_role.consumptionRoleUri: True if consumption_role.dataallManaged == PolicyManagementOptions.FULLY_MANAGED.value else False for consumption_role in consumption_roles}
+
+    op.drop_column(table_name='consumptionrole', column_name='dataallManaged')
+    op.add_column(
+        'consumptionrole',
+        sa.Column('dataallManaged', sa.Boolean(), nullable=False, server_default=sa.sql.expression.true()),
+    )
+
+    # Update all the consumption.dataallManaged column with boolean values by using consumption_role_policy_mgmt_map map
+    consumption_roles: List[ConsumptionRole] = session.query(ConsumptionRole).all()
+    for consumption_role in consumption_roles:
+        consumption_role.dataallManaged = consumption_role_policy_mgmt_map.get(consumption_role.consumptionRoleUri, True)
+    session.add_all(consumption_roles)
+    session.commit()

--- a/frontend/src/design/components/InfoIconWithToolTip.js
+++ b/frontend/src/design/components/InfoIconWithToolTip.js
@@ -1,0 +1,25 @@
+import { Tooltip } from '@mui/material';
+import InfoIcon from '@mui/icons-material/Info';
+import PropTypes from 'prop-types';
+
+export const InfoIconWithToolTip = (props) => {
+  const { title, size, placement } = props;
+
+  return (
+    <Tooltip title={title} placement={placement}>
+      <InfoIcon sx={{ fontSize: `${size}rem` }}></InfoIcon>
+    </Tooltip>
+  );
+};
+
+InfoIconWithToolTip.propTypes = {
+  title: PropTypes.any,
+  size: PropTypes.number,
+  placement: PropTypes.string
+};
+
+InfoIconWithToolTip.defaultProps = {
+  title: '',
+  size: 1,
+  placement: 'bottom'
+};

--- a/frontend/src/design/components/index.js
+++ b/frontend/src/design/components/index.js
@@ -32,3 +32,4 @@ export * from './popovers';
 export * from './SanitizedHTML';
 export * from './NoAccessMaintenanceWindow';
 export * from './UserModal';
+export * from './InfoIconWithToolTip';

--- a/frontend/src/modules/Catalog/components/RequestAccessModal.js
+++ b/frontend/src/modules/Catalog/components/RequestAccessModal.js
@@ -720,7 +720,9 @@ export const RequestAccessModal = (props) => {
                       </Box>
                     )}
                     {!values.consumptionRole ||
-                    values.consumptionRole.dataallManaged ||
+                    values.consumptionRole.dataallManaged === 'Fully-Managed' ||
+                    values.consumptionRole.dataallManaged ===
+                      'Externally-Managed' ||
                     isSharePolicyAttached ? (
                       <Box />
                     ) : (
@@ -742,25 +744,24 @@ export const RequestAccessModal = (props) => {
                                 color="textSecondary"
                                 component="p"
                                 variant="caption"
-                              ></Typography>
-                              {values.consumptionRole &&
-                              !(
-                                values.consumptionRole.dataallManaged ||
-                                isSharePolicyAttached ||
-                                values.attachMissingPolicies
-                              ) ? (
-                                <FormHelperText error>
-                                  Selected consumption role is managed by
-                                  customer, but the share policy{' '}
-                                  <strong>{unAttachedPolicyNames}</strong> is
-                                  not attached.
-                                  <br />
-                                  Please attach it or let Data.all attach it for
-                                  you.
-                                </FormHelperText>
-                              ) : (
-                                ''
-                              )}
+                              >
+                                {values.consumptionRole &&
+                                values.consumptionRole.dataallManaged ===
+                                  'Partially-Managed' &&
+                                !isSharePolicyAttached ? (
+                                  <FormHelperText error>
+                                    Selected consumption role is partially
+                                    managed by customer and the share policy{' '}
+                                    <strong>{unAttachedPolicyNames}</strong> is
+                                    not attached.
+                                    <br />
+                                    Please attach it or let Data.all attach it
+                                    for you.
+                                  </FormHelperText>
+                                ) : (
+                                  ''
+                                )}
+                              </Typography>
                             </div>
                           }
                         />

--- a/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
@@ -7,10 +7,8 @@ import {
   CircularProgress,
   Dialog,
   TextField,
-  Tooltip,
   Typography
 } from '@mui/material';
-import InfoIcon from '@mui/icons-material/Info';
 import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import PropTypes from 'prop-types';
@@ -19,7 +17,8 @@ import * as Yup from 'yup';
 import { SET_ERROR, useDispatch } from 'globalErrors';
 import { fetchEnums, useClient, useFetchGroups } from 'services';
 import { addConsumptionRoleToEnvironment } from '../services';
-import {policyManagementInfoMap} from "../../constants";
+import { policyManagementInfoMap } from '../../constants';
+import { InfoIconWithToolTip } from '../../../design';
 
 export const EnvironmentRoleAddForm = (props) => {
   const { environment, onClose, open, reloadRoles, ...other } = props;
@@ -30,13 +29,14 @@ export const EnvironmentRoleAddForm = (props) => {
 
   useEffect(() => {
     const fetchPolicyManagementOptions = async () => {
-      const response = await fetchEnums(client, [
-        'PolicyManagementOptions'
-      ]);
+      const response = await fetchEnums(client, ['PolicyManagementOptions']);
       if (response['PolicyManagementOptions'].length > 0) {
         setPolicyManagementOptions(
           response['PolicyManagementOptions'].map((elem) => {
-            return { label: elem.value, key: elem.name };
+            return {
+              label: elem.value,
+              key: elem.name
+            };
           })
         );
       } else {
@@ -93,7 +93,6 @@ export const EnvironmentRoleAddForm = (props) => {
   }
 
   let { groupOptions, loadingGroups } = useFetchGroups(environment);
-
 
   if (!environment) {
     return null;
@@ -229,9 +228,8 @@ export const EnvironmentRoleAddForm = (props) => {
                       const { key, ...propOptions } = props;
                       return (
                         <Box key={key} {...propOptions}>
-                          {/*Display string 'FullyManaged' etc with a '-' in between*/}
-                          {option.label.match(/[A-Z][a-z]+/g).join('-')}
-                          <Tooltip
+                          {option.label}
+                          <InfoIconWithToolTip
                             title={
                               <span style={{ fontSize: 'small' }}>
                                 {policyManagementInfoMap[option.label] != null
@@ -239,10 +237,9 @@ export const EnvironmentRoleAddForm = (props) => {
                                   : 'Invalid Option for policy management.'}
                               </span>
                             }
-                            placement="right-start"
-                          >
-                            <InfoIcon sx={{ fontSize: '1rem' }} />
-                          </Tooltip>
+                            placement={'right-start'}
+                            size={1}
+                          />
                         </Box>
                       );
                     }}

--- a/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
@@ -136,7 +136,7 @@ export const EnvironmentRoleAddForm = (props) => {
                 .required(
                   'Policy Management option required. Please select a valid option'
                 )
-                .oneOf(policyManagementOptions.map((obj) => obj.label))
+                .oneOf(policyManagementOptions.map((obj) => obj.key))
             })}
             onSubmit={async (
               values,
@@ -218,8 +218,8 @@ export const EnvironmentRoleAddForm = (props) => {
                     disablePortal
                     options={policyManagementOptions}
                     onChange={(event, value) => {
-                      if (value && value.label) {
-                        setFieldValue('dataallManaged', value.label);
+                      if (value && value.key) {
+                        setFieldValue('dataallManaged', value.key);
                       } else {
                         setFieldValue('dataallManaged', '');
                       }
@@ -232,8 +232,8 @@ export const EnvironmentRoleAddForm = (props) => {
                           <InfoIconWithToolTip
                             title={
                               <span style={{ fontSize: 'small' }}>
-                                {policyManagementInfoMap[option.label] != null
-                                  ? policyManagementInfoMap[option.label]
+                                {policyManagementInfoMap[option.key] != null
+                                  ? policyManagementInfoMap[option.key]
                                   : 'Invalid Option for policy management.'}
                               </span>
                             }

--- a/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
@@ -1,6 +1,7 @@
 import { GroupAddOutlined } from '@mui/icons-material';
 import { LoadingButton } from '@mui/lab';
 import {
+  Alert,
   Autocomplete,
   Box,
   CardContent,
@@ -21,37 +22,17 @@ import { policyManagementInfoMap } from '../../constants';
 import { InfoIconWithToolTip } from '../../../design';
 
 export const EnvironmentRoleAddForm = (props) => {
-  const { environment, onClose, open, reloadRoles, ...other } = props;
+  const {
+    environment,
+    onClose,
+    open,
+    reloadRoles,
+    policyManagementOptions,
+    ...other
+  } = props;
   const { enqueueSnackbar } = useSnackbar();
   const dispatch = useDispatch();
   const client = useClient();
-  const [policyManagementOptions, setPolicyManagementOptions] = useState([]);
-
-  useEffect(() => {
-    const fetchPolicyManagementOptions = async () => {
-      const response = await fetchEnums(client, ['PolicyManagementOptions']);
-      if (response['PolicyManagementOptions'].length > 0) {
-        setPolicyManagementOptions(
-          response['PolicyManagementOptions'].map((elem) => {
-            return {
-              label: elem.value,
-              key: elem.name
-            };
-          })
-        );
-      } else {
-        dispatch({
-          type: SET_ERROR,
-          error: 'Could not fetch consumption role policy management options'
-        });
-      }
-    };
-
-    if (client)
-      fetchPolicyManagementOptions().catch((e) =>
-        dispatch({ type: SET_ERROR, e })
-      );
-  }, [client, dispatch]);
 
   async function submit(values, setStatus, setSubmitting, setErrors) {
     try {
@@ -261,6 +242,20 @@ export const EnvironmentRoleAddForm = (props) => {
                     )}
                   />
                 </CardContent>
+                {values.dataallManaged === 'EXTERNALLY_MANAGED' ? (
+                  <CardContent>
+                    <Alert severity="error" sx={{ mr: 1 }}>
+                      With "Externally-Managed" policy management, you are
+                      completely responsible for attaching / giving your
+                      consumption role appropriate permissions. Please select
+                      "Externally-Managed" if you know that your role has some
+                      super-user permissions or if you are completely managing
+                      the role and its policies.
+                    </Alert>
+                  </CardContent>
+                ) : (
+                  <div></div>
+                )}
                 <Box>
                   <CardContent>
                     <LoadingButton

--- a/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
@@ -13,10 +13,9 @@ import {
 import { Formik } from 'formik';
 import { useSnackbar } from 'notistack';
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
 import * as Yup from 'yup';
 import { SET_ERROR, useDispatch } from 'globalErrors';
-import { fetchEnums, useClient, useFetchGroups } from 'services';
+import { useClient, useFetchGroups } from 'services';
 import { addConsumptionRoleToEnvironment } from '../services';
 import { policyManagementInfoMap } from '../../constants';
 import { InfoIconWithToolTip } from '../../../design';

--- a/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
+++ b/frontend/src/modules/Environments/components/EnvironmentRoleAddForm.js
@@ -19,6 +19,7 @@ import * as Yup from 'yup';
 import { SET_ERROR, useDispatch } from 'globalErrors';
 import { fetchEnums, useClient, useFetchGroups } from 'services';
 import { addConsumptionRoleToEnvironment } from '../services';
+import {policyManagementInfoMap} from "../../constants";
 
 export const EnvironmentRoleAddForm = (props) => {
   const { environment, onClose, open, reloadRoles, ...other } = props;
@@ -30,11 +31,11 @@ export const EnvironmentRoleAddForm = (props) => {
   useEffect(() => {
     const fetchPolicyManagementOptions = async () => {
       const response = await fetchEnums(client, [
-        'ConsumptionRolePolicyManagementOptions'
+        'PolicyManagementOptions'
       ]);
-      if (response['ConsumptionRolePolicyManagementOptions'].length > 0) {
+      if (response['PolicyManagementOptions'].length > 0) {
         setPolicyManagementOptions(
-          response['ConsumptionRolePolicyManagementOptions'].map((elem) => {
+          response['PolicyManagementOptions'].map((elem) => {
             return { label: elem.value, key: elem.name };
           })
         );
@@ -93,14 +94,6 @@ export const EnvironmentRoleAddForm = (props) => {
 
   let { groupOptions, loadingGroups } = useFetchGroups(environment);
 
-  let policyManagementInfoMap = {
-    FULLY_MANAGED:
-      'Data.all manages creating, maintaining and also attaching the policy',
-    PARTIALLY_MANAGED:
-      "Data.all will create the IAM policy but won't attach policy to your consumption role. With this option, data.all will indicate share to be unhealthy if the data.all created policy is not attached.",
-    EXTERNALLY_MANAGED:
-      'Data.all will create the IAM policy required for any share but it will be incumbent on role owners to attach it or use their own policy. With this option, data.all will not indicate the share to be unhealthy even if the policy is not attached.'
-  };
 
   if (!environment) {
     return null;
@@ -241,8 +234,8 @@ export const EnvironmentRoleAddForm = (props) => {
                           <Tooltip
                             title={
                               <span style={{ fontSize: 'small' }}>
-                                {policyManagementInfoMap[option.key] != null
-                                  ? policyManagementInfoMap[option.key]
+                                {policyManagementInfoMap[option.label] != null
+                                  ? policyManagementInfoMap[option.label]
                                   : 'Invalid Option for policy management.'}
                               </span>
                             }

--- a/frontend/src/modules/Environments/components/EnvironmentTeams.js
+++ b/frontend/src/modules/Environments/components/EnvironmentTeams.js
@@ -822,11 +822,9 @@ export const EnvironmentTeams = ({ environment }) => {
                     field: 'dataallManaged',
                     headerName: 'Policy Management',
                     valueGetter: (params) => {
-                      return `${
-                        params.row.dataallManaged
-                          ? 'Data.all managed'
-                          : 'Customer managed'
-                      }`;
+                      return `${params.row.dataallManaged
+                        ?.match(/[A-Z][a-z]+/g)
+                        .join('-')}`;
                     },
                     flex: 0.6
                   },

--- a/frontend/src/modules/Environments/components/EnvironmentTeams.js
+++ b/frontend/src/modules/Environments/components/EnvironmentTeams.js
@@ -339,10 +339,14 @@ export const IAMRolePolicyDataGridCell = ({ environmentUri, IAMRoleName }) => {
   const getIAMPolicyTagColour = () => {
     if (policyAttachStatus === 'N/A') return 'warning';
     if (policyAttachStatus === 'Not Attached') return 'error';
+    if (policyAttachStatus === 'No Policies Present') return 'error';
     return 'success';
   };
 
   const getIAMPolicyAttachementStatus = (managedPolicyDetails) => {
+    if (managedPolicyDetails.length === 0) {
+      return 'No Policies Present';
+    }
     const is_policy_attach = managedPolicyDetails.map(
       (policy) => policy.attached
     );

--- a/frontend/src/modules/Environments/components/EnvironmentTeams.js
+++ b/frontend/src/modules/Environments/components/EnvironmentTeams.js
@@ -900,9 +900,7 @@ export const EnvironmentTeams = ({ environment }) => {
                     flex: 0.6,
                     editable: true,
                     type: 'singleSelect',
-                    valueOptions: policyManagementOptions.map(
-                      (obj) => obj.key
-                    ),
+                    valueOptions: policyManagementOptions.map((obj) => obj.key),
                     valueFormatter: (value) => {
                       return formattedName(value.value);
                     }

--- a/frontend/src/modules/Environments/components/EnvironmentTeams.js
+++ b/frontend/src/modules/Environments/components/EnvironmentTeams.js
@@ -18,8 +18,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  TextField,
-  Tooltip
+  TextField
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/DeleteOutlined';
@@ -36,6 +35,7 @@ import { VscChecklist } from 'react-icons/vsc';
 import {
   Defaults,
   DeleteObjectWithFrictionModal,
+  InfoIconWithToolTip,
   Label,
   Pager,
   RefreshTableMenu,
@@ -63,7 +63,6 @@ import { EnvironmentRoleAddForm } from './EnvironmentRoleAddForm';
 import { EnvironmentTeamInviteEditForm } from './EnvironmentTeamInviteEditForm';
 import { EnvironmentTeamInviteForm } from './EnvironmentTeamInviteForm';
 import { DataGrid, GridActionsCellItem, GridRowModes } from '@mui/x-data-grid';
-import InfoIcon from '@mui/icons-material/Info';
 import { policyManagementInfoMap } from '../../constants';
 
 function TeamRow({
@@ -839,10 +838,8 @@ export const EnvironmentTeams = ({ environment }) => {
                     renderCell: (params) => {
                       return (
                         <span>
-                          {params.row.dataallManaged
-                            ?.match(/[A-Z][a-z]+/g)
-                            .join('-')}
-                          <Tooltip
+                          {params.row.dataallManaged}
+                          <InfoIconWithToolTip
                             title={
                               <span style={{ fontSize: 'small' }}>
                                 {policyManagementInfoMap[
@@ -854,9 +851,9 @@ export const EnvironmentTeams = ({ environment }) => {
                                   : 'Invalid Option for policy management.'}
                               </span>
                             }
-                          >
-                            <InfoIcon sx={{ fontSize: '1rem' }} />
-                          </Tooltip>
+                            size={1}
+                            placement={'right-start'}
+                          />
                         </span>
                       );
                     },

--- a/frontend/src/modules/Environments/components/EnvironmentTeams.js
+++ b/frontend/src/modules/Environments/components/EnvironmentTeams.js
@@ -617,6 +617,16 @@ export const EnvironmentTeams = ({ environment }) => {
     return newRow;
   };
 
+  const formattedName = (unformattedPolicyMgmtName) => {
+    // Split name by "_"
+    return unformattedPolicyMgmtName
+      .split('_')
+      .map((word) => {
+        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+      })
+      .join('-');
+  };
+
   let { groupOptions } = useFetchGroups(environment);
 
   return (
@@ -838,7 +848,7 @@ export const EnvironmentTeams = ({ environment }) => {
                     renderCell: (params) => {
                       return (
                         <span>
-                          {params.row.dataallManaged}
+                          {formattedName(params.row.dataallManaged)}
                           <InfoIconWithToolTip
                             title={
                               <span style={{ fontSize: 'small' }}>

--- a/frontend/src/modules/Shares/services/getShareObject.js
+++ b/frontend/src/modules/Shares/services/getShareObject.js
@@ -31,6 +31,7 @@ export const getShareObject = ({ shareUri, filter }) => ({
           SamlGroupName
           environmentName
         }
+        policyManagement
         items(filter: $filter) {
           count
           page

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -1380,6 +1380,76 @@ const ShareView = () => {
                           </ListItem>
                           <ListItem
                             disableGutters
+                            sx={{
+                              paddingX: 2,
+                              paddingTop: 2,
+                              paddingBottom: 0
+                            }}
+                          >
+                            <Typography
+                              color="textSecondary"
+                              variant="subtitle2"
+                            >
+                              <Tooltip
+                                title={
+                                  <span>
+                                    IAM policy management indicates how much
+                                    control data.all has into creating and
+                                    attaching policies
+                                    <br />
+                                    <br />
+                                    1. Data.all fully managed - Data.all manages
+                                    creating, maintaining and also attaching the
+                                    policy <br />
+                                    <br />
+                                    2. Data.all partially managed - Data.all
+                                    will create the IAM policy but won't attach
+                                    policy to your consumption role. With this
+                                    option, data.all will indicate share to be
+                                    unhealthy if the data.all created policy is
+                                    not attached.
+                                    <br />
+                                    <br />
+                                    3. Externally Managed - Data.all will create
+                                    the IAM policy required for any share but it
+                                    will be incumbent on role owners to attach
+                                    it or use their own policy. With this
+                                    option, data.all will not indicate the share
+                                    to be unhealthy even if the policy is not
+                                    attached.
+                                  </span>
+                                }
+                              >
+                                Principal IAM Policy Management
+                              </Tooltip>
+                            </Typography>
+                          </ListItem>
+                          <ListItem
+                            disableGutters
+                            divider
+                            sx={{
+                              justifyContent: 'space-between',
+                              paddingX: 2,
+                              paddingTop: 1,
+                              paddingBottom: 2
+                            }}
+                          >
+                            <Typography
+                              color="textPrimary"
+                              variant="body2"
+                              sx={{
+                                whiteSpace: 'nowrap',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                WebkitBoxOrient: 'vertical',
+                                WebkitLineClamp: 2
+                              }}
+                            >
+                              <span>Data.all fully managed</span>
+                            </Typography>
+                          </ListItem>
+                          <ListItem
+                            disableGutters
                             divider
                             sx={{
                               justifyContent: 'space-between',

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -55,7 +55,8 @@ import {
   useSettings,
   Label,
   SanitizedHTML,
-  UserModal
+  UserModal,
+  InfoIconWithToolTip
 } from 'design';
 import { SET_ERROR, useDispatch } from 'globalErrors';
 import { useClient } from 'services';
@@ -88,6 +89,7 @@ import { ShareSubmitModal } from '../components/ShareSubmitModal';
 import { useTheme } from '@mui/styles';
 import { UpdateExtensionReason } from '../components/ShareUpdateExtension';
 import CancelIcon from '@mui/icons-material/Close';
+import { policyManagementInfoMap } from '../../constants';
 
 const isReadOnlyShare = (share) => share.permissions.every((p) => p === 'Read');
 
@@ -1380,10 +1382,10 @@ const ShareView = () => {
                           </ListItem>
                           <ListItem
                             disableGutters
+                            divider
                             sx={{
-                              paddingX: 2,
-                              paddingTop: 2,
-                              paddingBottom: 0
+                              justifyContent: 'space-between',
+                              padding: 2
                             }}
                           >
                             <Typography
@@ -1423,17 +1425,6 @@ const ShareView = () => {
                                 Principal IAM Policy Management
                               </Tooltip>
                             </Typography>
-                          </ListItem>
-                          <ListItem
-                            disableGutters
-                            divider
-                            sx={{
-                              justifyContent: 'space-between',
-                              paddingX: 2,
-                              paddingTop: 1,
-                              paddingBottom: 2
-                            }}
-                          >
                             <Typography
                               color="textPrimary"
                               variant="body2"
@@ -1445,7 +1436,15 @@ const ShareView = () => {
                                 WebkitLineClamp: 2
                               }}
                             >
-                              <span>Data.all fully managed</span>
+                              <span>{share.policyManagement} </span>
+                              <InfoIconWithToolTip
+                                title={
+                                  policyManagementInfoMap[
+                                    share.policyManagement
+                                  ]
+                                }
+                                size={1}
+                              />
                             </Typography>
                           </ListItem>
                           <ListItem

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -961,12 +961,11 @@ const ShareView = () => {
     return null;
   }
 
-  const formattedName = (unformattedPolicyMgmtName) => {
-    // Split name by "_"
+  const formatPolicyManagmentType = (unformattedPolicyMgmtName) => {
     return unformattedPolicyMgmtName
-      .split('_')
+      .split('_') // Split string "FULLY_MANAGED", etc on "_"
       .map((word) => {
-        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(); // Capitalize first word and lower case others
       })
       .join('-');
   };
@@ -1447,7 +1446,7 @@ const ShareView = () => {
                               }}
                             >
                               <span>
-                                {formattedName(share.policyManagement)}{' '}
+                                {formatPolicyManagmentType(share.policyManagement)}{' '}
                               </span>
                               <InfoIconWithToolTip
                                 title={

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -961,6 +961,16 @@ const ShareView = () => {
     return null;
   }
 
+  const formattedName = (unformattedPolicyMgmtName) => {
+    // Split name by "_"
+    return unformattedPolicyMgmtName
+      .split('_')
+      .map((word) => {
+        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+      })
+      .join('-');
+  };
+
   return (
     <>
       <Helmet>
@@ -1436,7 +1446,9 @@ const ShareView = () => {
                                 WebkitLineClamp: 2
                               }}
                             >
-                              <span>{share.policyManagement} </span>
+                              <span>
+                                {formattedName(share.policyManagement)}{' '}
+                              </span>
                               <InfoIconWithToolTip
                                 title={
                                   policyManagementInfoMap[

--- a/frontend/src/modules/Shares/views/ShareView.js
+++ b/frontend/src/modules/Shares/views/ShareView.js
@@ -1446,7 +1446,9 @@ const ShareView = () => {
                               }}
                             >
                               <span>
-                                {formatPolicyManagmentType(share.policyManagement)}{' '}
+                                {formatPolicyManagmentType(
+                                  share.policyManagement
+                                )}{' '}
                               </span>
                               <InfoIconWithToolTip
                                 title={

--- a/frontend/src/modules/constants.js
+++ b/frontend/src/modules/constants.js
@@ -16,10 +16,10 @@ export const Topics = [
 export const ConfidentialityList = ['Unclassified', 'Official', 'Secret'];
 
 export const policyManagementInfoMap = {
-  'Fully-Managed':
+  FULLY_MANAGED:
     'Data.all manages creating, maintaining and also attaching the policy',
-  'Partially-Managed':
+  PARTIALLY_MANAGED:
     "Data.all will create the IAM policy but won't attach policy to your consumption role. With this option, data.all will indicate share to be unhealthy if the data.all created policy is not attached.",
-  'Externally-Managed':
+  EXTERNALLY_MANAGED:
     'Data.all will create the IAM policy required for any share but it will be incumbent on role owners to attach it or use their own policy. With this option, data.all will not indicate the share to be unhealthy even if the policy is not attached.'
 };

--- a/frontend/src/modules/constants.js
+++ b/frontend/src/modules/constants.js
@@ -16,10 +16,10 @@ export const Topics = [
 export const ConfidentialityList = ['Unclassified', 'Official', 'Secret'];
 
 export const policyManagementInfoMap = {
-  FullyManaged:
+  'Fully-Managed':
     'Data.all manages creating, maintaining and also attaching the policy',
-  PartiallyManaged:
+  'Partially-Managed':
     "Data.all will create the IAM policy but won't attach policy to your consumption role. With this option, data.all will indicate share to be unhealthy if the data.all created policy is not attached.",
-  ExternallyManaged:
+  'Externally-Managed':
     'Data.all will create the IAM policy required for any share but it will be incumbent on role owners to attach it or use their own policy. With this option, data.all will not indicate the share to be unhealthy even if the policy is not attached.'
 };

--- a/frontend/src/modules/constants.js
+++ b/frontend/src/modules/constants.js
@@ -14,3 +14,12 @@ export const Topics = [
 ];
 
 export const ConfidentialityList = ['Unclassified', 'Official', 'Secret'];
+
+export const policyManagementInfoMap = {
+  FullyManaged:
+    'Data.all manages creating, maintaining and also attaching the policy',
+  PartiallyManaged:
+    "Data.all will create the IAM policy but won't attach policy to your consumption role. With this option, data.all will indicate share to be unhealthy if the data.all created policy is not attached.",
+  ExternallyManaged:
+    'Data.all will create the IAM policy required for any share but it will be incumbent on role owners to attach it or use their own policy. With this option, data.all will not indicate the share to be unhealthy even if the policy is not attached.'
+};

--- a/frontend/src/services/graphql/Shared/getEnumByName.js
+++ b/frontend/src/services/graphql/Shared/getEnumByName.js
@@ -26,8 +26,6 @@ export const fetchEnums = async (client, enum_names) => {
   const response = await client.query(
     getEnumByName({ enum_names: enum_names })
   );
-  console.log("Enums resp")
-  console.log(response)
   let enum_dict = {};
   if (!response.errors && response.data.queryEnums != null) {
     response.data.queryEnums.map((x) => {

--- a/frontend/src/services/graphql/Shared/getEnumByName.js
+++ b/frontend/src/services/graphql/Shared/getEnumByName.js
@@ -26,6 +26,8 @@ export const fetchEnums = async (client, enum_names) => {
   const response = await client.query(
     getEnumByName({ enum_names: enum_names })
   );
+  console.log("Enums resp")
+  console.log(response)
   let enum_dict = {};
   if (!response.errors && response.data.queryEnums != null) {
     response.data.queryEnums.map((x) => {

--- a/tests/core/environments/conftest.py
+++ b/tests/core/environments/conftest.py
@@ -1,5 +1,6 @@
 import uuid
 
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
 from tests.core.permissions.test_permission import *
 
 
@@ -33,7 +34,7 @@ def consumption_role(mock_aws_client, client, org_fixture, env_fixture, user, gr
             'groupUri': str(uuid.uuid4())[:8],
             'IAMRoleArn': test_arn,
             'environmentUri': env_fixture.environmentUri,
-            'dataallManaged': False,
+            'dataallManaged': 'FULLY_MANAGED',
         },
     )
     assert not response.errors

--- a/tests/core/environments/test_environment.py
+++ b/tests/core/environments/test_environment.py
@@ -749,6 +749,7 @@ def test_update_consumption_role(client, org_fixture, env_fixture, user, group, 
                 groupUri
                 IAMRoleName
                 IAMRoleArn
+                dataallManaged
             }
         }
     """
@@ -770,9 +771,15 @@ def test_update_consumption_role(client, org_fixture, env_fixture, user, group, 
         groups=[group.name],
         environmentUri=env_fixture.environmentUri,
         consumptionRoleUri=consumption_role_uri,
-        input={'consumptionRoleName': 'testRoleName', 'groupUri': 'testGroupUri'},
+        # Update consumptionRoleName, groupUri and also the policy management ( dataallManaged )
+        input={
+            'consumptionRoleName': 'testRoleName',
+            'groupUri': 'testGroupUri',
+            'dataallManaged': 'PARTIALLY_MANAGED',
+        },
     )
 
     assert not response.errors
     assert response.data.updateConsumptionRole.consumptionRoleName == 'testRoleName'
     assert response.data.updateConsumptionRole.groupUri == 'testGroupUri'
+    assert response.data.updateConsumptionRole.dataallManaged == 'PARTIALLY_MANAGED'

--- a/tests/modules/s3_datasets_shares/tasks/conftest.py
+++ b/tests/modules/s3_datasets_shares/tasks/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dataall.core.organizations.db.organization_models import Organization
-from dataall.core.environment.db.environment_models import Environment, EnvironmentGroup
+from dataall.core.environment.db.environment_models import Environment, EnvironmentGroup, ConsumptionRole
 from dataall.modules.shares_base.services.shares_enums import (
     ShareableType,
     ShareItemStatus,
@@ -128,15 +128,24 @@ def bucket(db):
 
 @pytest.fixture(scope='module')
 def share(db):
-    def factory(dataset: S3Dataset, environment: Environment, env_group: EnvironmentGroup) -> ShareObject:
+    def factory(
+        dataset: S3Dataset,
+        environment: Environment,
+        env_group: EnvironmentGroup,
+        consumption_role: ConsumptionRole = None,
+    ) -> ShareObject:
         with db.scoped_session() as session:
             share = ShareObject(
                 datasetUri=dataset.datasetUri,
                 environmentUri=environment.environmentUri,
                 owner='bob',
-                principalId=environment.SamlGroupName,
-                principalType=PrincipalType.Group.value,
-                principalRoleName=env_group.environmentIAMRoleName,
+                principalId=environment.SamlGroupName if not consumption_role else consumption_role.consumptionRoleUri,
+                principalType=PrincipalType.Group.value
+                if not consumption_role
+                else PrincipalType.ConsumptionRole.value,
+                principalRoleName=env_group.environmentIAMRoleName
+                if not consumption_role
+                else consumption_role.IAMRoleName,
                 status=ShareObjectStatus.Approved.value,
                 groupUri=env_group.groupUri,
                 permissions=[ShareObjectDataPermission.Read.value],

--- a/tests/modules/s3_datasets_shares/tasks/test_s3_bucket_share_manager.py
+++ b/tests/modules/s3_datasets_shares/tasks/test_s3_bucket_share_manager.py
@@ -4,8 +4,9 @@ from unittest.mock import MagicMock
 
 from typing import Callable
 
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
 from dataall.core.groups.db.group_models import Group
-from dataall.core.environment.db.environment_models import Environment, EnvironmentGroup
+from dataall.core.environment.db.environment_models import Environment, EnvironmentGroup, ConsumptionRole
 from dataall.core.organizations.db.organization_models import Organization
 from dataall.modules.shares_base.db.share_object_models import ShareObject
 from dataall.modules.s3_datasets_shares.services.share_managers import S3BucketShareManager
@@ -49,6 +50,16 @@ def source_environment(env: Callable, org_fixture: Organization, group: Group):
 def source_environment_group(environment_group: Callable, source_environment: Environment, group: Group):
     source_environment_group = environment_group(source_environment, group.name)
     yield source_environment_group
+
+
+@pytest.fixture(scope='module')
+def source_consumption_role(
+    consumption_role: Callable, source_environment_group, source_environment: Environment, group: Group
+):
+    source_consumption_role = consumption_role(
+        source_environment, group.name, 'test123', PolicyManagementOptions.FULLY_MANAGED.value
+    )
+    yield source_consumption_role
 
 
 @pytest.fixture(scope='module')
@@ -101,6 +112,18 @@ def share2(
 
 
 @pytest.fixture(scope='module')
+def share2_consumption_role(
+    share: Callable,
+    dataset2: S3Dataset,
+    target_environment: Environment,
+    target_environment_group: EnvironmentGroup,
+    source_consumption_role,
+) -> ShareObject:
+    share2_consumption_role = share(dataset2, target_environment, target_environment_group, source_consumption_role)
+    yield share2_consumption_role
+
+
+@pytest.fixture(scope='module')
 def share3(
     share: Callable,
     dataset_imported: S3Dataset,
@@ -117,6 +140,25 @@ def share_data2(
 ):
     yield ShareData(
         share=share2,
+        dataset=dataset2,
+        source_environment=source_environment,
+        target_environment=target_environment,
+        source_env_group=source_environment_group,
+        env_group=target_environment_group,
+    )
+
+
+@pytest.fixture(scope='module')
+def share_data2_consumption_role(
+    share2_consumption_role,
+    dataset2,
+    source_environment,
+    target_environment,
+    source_environment_group,
+    target_environment_group,
+):
+    yield ShareData(
+        share=share2_consumption_role,
         dataset=dataset2,
         source_environment=source_environment,
         target_environment=target_environment,
@@ -164,6 +206,17 @@ def share2_manager(
 ):
     with db.scoped_session() as session:
         manager = S3BucketShareManager(session, share_data2, bucket2)
+    yield manager
+
+
+@pytest.fixture(scope='function')
+def share2_consumption_role_manager(
+    db,
+    bucket2,
+    share_data2_consumption_role,
+):
+    with db.scoped_session() as session:
+        manager = S3BucketShareManager(session, share_data2_consumption_role, bucket2)
     yield manager
 
 
@@ -261,6 +314,14 @@ def mock_iam_client(mocker, account_id, role_name):
     mocker.patch('dataall.modules.s3_datasets_shares.services.share_managers.s3_bucket_share_manager.IAM', mock_client)
     mock_client.get_role_arn_by_name.return_value = f'arn:aws:iam::{account_id}:role/{role_name}'
     return mock_client
+
+
+def convert_role_management_to_type(db_engine, consumption_role: ConsumptionRole, policy_management_type: str):
+    with db_engine.scoped_session() as session:
+        consumption_role.dataallManaged = policy_management_type
+        session.add(consumption_role)
+        session.commit()
+    return consumption_role
 
 
 # For below test cases, dataset2, share2, src, target env and src group , env group remain the same
@@ -715,7 +776,7 @@ def test_grant_s3_iam_access_with_complete_policy_present(mocker, dataset2, shar
         return_value=['policy-0'],
     )
 
-    mocker.patch(
+    policy_attacher_mock = mocker.patch(
         'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.attach_policies',
         return_value=True,
     )
@@ -753,6 +814,153 @@ def test_grant_s3_iam_access_with_complete_policy_present(mocker, dataset2, shar
         policy['Statement'][kms_index]['Resource'] == created_iam_policy['Statement'][kms_index]['Resource']
         and policy['Statement'][kms_index]['Action'] == created_iam_policy['Statement'][kms_index]['Action']
     )
+
+    # Assert that the policy was attached at the end
+    # TODO
+    policy_attacher_mock.assert_called_once()
+
+
+def test_grant_s3_iam_access_with_fully_managed_consumption_role_complete_policy_but_unattached(
+    mocker, dataset2, share2_consumption_role_manager
+):
+    # Given
+    # The IAM Policy for sharing for the IAM role exists (check_if_policy_exists returns False but get_managed_policies returns ['policy-0'], indicating that indexed IAM policies exist)
+    # And the IAM Policy is NOT empty and already contains all target resources (get_managed_policy_default_version returns policy)
+    # Check if the IAM role ( i.e. the consumption role ) gets attached at the end
+
+    policy = {
+        'Version': '2012-10-17',
+        'Statement': [
+            {
+                'Sid': f'{IAM_S3_BUCKETS_STATEMENT_SID}S31',
+                'Effect': 'Allow',
+                'Action': S3_ALLOWED_ACTIONS,
+                'Resource': [
+                    f'arn:aws:s3:::{dataset2.S3BucketName}',
+                    f'arn:aws:s3:::{dataset2.S3BucketName}/*',
+                    f'arn:aws:s3:::S3Bucket',
+                    f'arn:aws:s3:::S3Bucket/*',
+                ],
+            },
+            {
+                'Sid': f'{IAM_S3_BUCKETS_STATEMENT_SID}KMS1',
+                'Effect': 'Allow',
+                'Action': ['kms:*'],
+                'Resource': [f'arn:aws:kms:{dataset2.region}:{dataset2.AwsAccountId}:key/kms-key'],
+            },
+        ],
+    }
+
+    mocker.patch('dataall.base.aws.iam.IAM.create_managed_policy', return_value=True)
+
+    mocker.patch('dataall.base.aws.iam.IAM.get_attached_managed_policies_to_role', return_value=['policy-0'])
+
+    mocker.patch('dataall.base.aws.iam.IAM.list_policy_names_by_policy_pattern', return_value=['policy-0'])
+
+    mocker.patch('dataall.base.aws.iam.IAM.delete_managed_policy_non_default_versions', return_value=True)
+
+    mocker.patch('dataall.base.aws.iam.IAM.delete_managed_policy_by_name', return_value=True)
+
+    mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService._get_managed_policy_quota',
+        return_value=10,
+    )
+    mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.check_if_policy_exists',
+        return_value=False,
+    )
+    mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.get_policies_unattached_to_role',
+        return_value=['policy-0'],
+    )
+
+    policy_attacher_mock = mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.attach_policies',
+        return_value=True,
+    )
+
+    kms_client = mock_kms_client(mocker)
+    kms_client().get_key_id.return_value = 'kms-key'
+
+    mocker.patch('dataall.base.aws.iam.IAM.get_managed_policy_default_version', return_value=('v1', policy))
+    mocker.patch('dataall.base.aws.iam.IAM.update_managed_policy_default_version', return_value=None)
+    share2_consumption_role_manager.grant_s3_iam_access()
+
+    policy_attacher_mock.assert_called_once()
+
+
+def test_grant_s3_iam_access_with_partially_managed_consumption_role_complete_policy_but_unattached(
+    db, mocker, dataset2, source_consumption_role, share2_consumption_role_manager
+):
+    # Given
+    # The IAM Policy for sharing for the IAM role exists (check_if_policy_exists returns False but get_managed_policies returns ['policy-0'], indicating that indexed IAM policies exist)
+    # And the IAM Policy is NOT empty and already contains all target resources (get_managed_policy_default_version returns policy)
+    # The consumption role is partially-managed consumption role
+    # Check if the IAM role ( i.e. the consumption role ) gets attached at the end
+    with db.scoped_session() as session:
+        source_consumption_role.dataallManaged = PolicyManagementOptions.PARTIALLY_MANAGED.value
+        session.add(source_consumption_role)
+        session.commit()
+
+    policy = {
+        'Version': '2012-10-17',
+        'Statement': [
+            {
+                'Sid': f'{IAM_S3_BUCKETS_STATEMENT_SID}S31',
+                'Effect': 'Allow',
+                'Action': S3_ALLOWED_ACTIONS,
+                'Resource': [
+                    f'arn:aws:s3:::{dataset2.S3BucketName}',
+                    f'arn:aws:s3:::{dataset2.S3BucketName}/*',
+                    f'arn:aws:s3:::S3Bucket',
+                    f'arn:aws:s3:::S3Bucket/*',
+                ],
+            },
+            {
+                'Sid': f'{IAM_S3_BUCKETS_STATEMENT_SID}KMS1',
+                'Effect': 'Allow',
+                'Action': ['kms:*'],
+                'Resource': [f'arn:aws:kms:{dataset2.region}:{dataset2.AwsAccountId}:key/kms-key'],
+            },
+        ],
+    }
+
+    mocker.patch('dataall.base.aws.iam.IAM.create_managed_policy', return_value=True)
+
+    mocker.patch('dataall.base.aws.iam.IAM.get_attached_managed_policies_to_role', return_value=['policy-0'])
+
+    mocker.patch('dataall.base.aws.iam.IAM.list_policy_names_by_policy_pattern', return_value=['policy-0'])
+
+    mocker.patch('dataall.base.aws.iam.IAM.delete_managed_policy_non_default_versions', return_value=True)
+
+    mocker.patch('dataall.base.aws.iam.IAM.delete_managed_policy_by_name', return_value=True)
+
+    mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService._get_managed_policy_quota',
+        return_value=10,
+    )
+    mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.check_if_policy_exists',
+        return_value=False,
+    )
+    mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.get_policies_unattached_to_role',
+        return_value=['policy-0'],
+    )
+
+    policy_attacher_mock = mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.attach_policies',
+        return_value=True,
+    )
+
+    kms_client = mock_kms_client(mocker)
+    kms_client().get_key_id.return_value = 'kms-key'
+
+    mocker.patch('dataall.base.aws.iam.IAM.get_managed_policy_default_version', return_value=('v1', policy))
+    mocker.patch('dataall.base.aws.iam.IAM.update_managed_policy_default_version', return_value=None)
+    share2_consumption_role_manager.grant_s3_iam_access()
+
+    policy_attacher_mock.assert_not_called()
 
 
 def test_grant_dataset_bucket_key_policy_with_complete_policy_present(
@@ -1667,8 +1875,8 @@ def test_check_s3_iam_access_no_policy(mocker, dataset2, share2_manager):
 
 def test_check_s3_iam_access_policy_not_attached(mocker, dataset2, share2_manager):
     # Given
-    # There is not existing IAM policy in the requesters account for the dataset's S3bucket
-    # Check if the update_role_policy func is called and policy statements are added
+    # a share is made on a role and the policy is not attached
+    # Check if IAM policy not attached errors are raised
 
     policy = {
         'Version': '2012-10-17',
@@ -1712,6 +1920,161 @@ def test_check_s3_iam_access_policy_not_attached(mocker, dataset2, share2_manage
     iam_update_role_policy_mock_1.assert_called_once()
     assert (len(share2_manager.bucket_errors)) == 1
     assert 'IAM Policy attached Target Resource' in share2_manager.bucket_errors[0]
+
+
+def test_check_s3_iam_access_policy_fully_managed_consumption_role_not_attached(
+    mocker, dataset2, share2_consumption_role_manager
+):
+    # Given
+    # a share is made on a fully managed  consumption role and the policy is not attached
+    # Check if IAM policy not attached errors are raised
+
+    policy = {
+        'Version': '2012-10-17',
+        'Statement': [
+            {
+                'Sid': f'{IAM_S3_BUCKETS_STATEMENT_SID}S31',
+                'Effect': 'Allow',
+                'Action': ['s3:*'],
+                'Resource': [f'arn:aws:s3:::{dataset2.S3BucketName}', f'arn:aws:s3:::{dataset2.S3BucketName}/*'],
+            },
+            {
+                'Sid': f'{IAM_S3_BUCKETS_STATEMENT_SID}KMS1',
+                'Effect': 'Allow',
+                'Action': ['kms:*'],
+                'Resource': [f'arn:aws:kms:{dataset2.region}:{dataset2.AwsAccountId}:key/kms-key'],
+            },
+        ],
+    }
+
+    mocker.patch('dataall.base.aws.iam.IAM.get_managed_policy_default_version', return_value=('v1', policy))
+
+    # When policy does not exist
+    mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.check_if_policy_exists',
+        return_value=True,
+    )
+
+    iam_update_role_policy_mock_1 = mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.get_policies_unattached_to_role',
+        return_value=['policy-0'],
+    )
+    mocker.patch('dataall.base.aws.iam.IAM.list_policy_names_by_policy_pattern', return_value=['policy-0'])
+
+    mocker.patch('dataall.base.aws.iam.IAM.get_attached_managed_policies_to_role', return_value=[])
+
+    kms_client = mock_kms_client(mocker)
+    kms_client().get_key_id.return_value = 'kms-key'
+    # When
+    share2_consumption_role_manager.check_s3_iam_access()
+    # Then
+    iam_update_role_policy_mock_1.assert_called_once()
+    assert (len(share2_consumption_role_manager.bucket_errors)) == 1
+    assert 'IAM Policy attached Target Resource' in share2_consumption_role_manager.bucket_errors[0]
+
+
+def test_check_s3_iam_access_policy_externally_managed_consumption_role_not_attached(
+    db, mocker, dataset2, source_consumption_role, share2_consumption_role_manager
+):
+    # Given
+    # a share is made on a externally managed  consumption role and the policy is not attached
+    # Check if IAM policy not attached errors are not raised
+
+    convert_role_management_to_type(db, source_consumption_role, PolicyManagementOptions.EXTERNALLY_MANAGED.value)
+
+    policy = {
+        'Version': '2012-10-17',
+        'Statement': [
+            {
+                'Sid': f'{IAM_S3_BUCKETS_STATEMENT_SID}S31',
+                'Effect': 'Allow',
+                'Action': ['s3:List*', 's3:GetObject', 's3:Describe*'],
+                'Resource': [f'arn:aws:s3:::{dataset2.S3BucketName}', f'arn:aws:s3:::{dataset2.S3BucketName}/*'],
+            },
+            {
+                'Sid': f'{IAM_S3_BUCKETS_STATEMENT_SID}KMS1',
+                'Effect': 'Allow',
+                'Action': ['kms:*'],
+                'Resource': [f'arn:aws:kms:{dataset2.region}:{dataset2.AwsAccountId}:key/kms-key'],
+            },
+        ],
+    }
+
+    mocker.patch('dataall.base.aws.iam.IAM.get_managed_policy_default_version', return_value=('v1', policy))
+
+    # When policy does not exist
+    mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.check_if_policy_exists',
+        return_value=True,
+    )
+
+    iam_update_role_policy_mock_1 = mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.get_policies_unattached_to_role',
+        return_value=['policy-0'],
+    )
+    mocker.patch('dataall.base.aws.iam.IAM.list_policy_names_by_policy_pattern', return_value=['policy-0'])
+
+    mocker.patch('dataall.base.aws.iam.IAM.get_attached_managed_policies_to_role', return_value=[])
+
+    kms_client = mock_kms_client(mocker)
+    kms_client().get_key_id.return_value = 'kms-key'
+    # When
+    share2_consumption_role_manager.check_s3_iam_access()
+    # Then
+    iam_update_role_policy_mock_1.assert_not_called()
+
+
+def test_check_s3_iam_access_policy_partially_managed_consumption_role_not_attached(
+    db, mocker, dataset2, source_consumption_role, share2_consumption_role_manager
+):
+    # Given
+    # a share is made on a fully managed  consumption role and the policy is not attached
+    # Check if IAM policy not attached errors are raised
+
+    convert_role_management_to_type(db, source_consumption_role, PolicyManagementOptions.PARTIALLY_MANAGED.value)
+
+    policy = {
+        'Version': '2012-10-17',
+        'Statement': [
+            {
+                'Sid': f'{IAM_S3_BUCKETS_STATEMENT_SID}S31',
+                'Effect': 'Allow',
+                'Action': ['s3:List*', 's3:GetObject', 's3:Describe*'],
+                'Resource': [f'arn:aws:s3:::{dataset2.S3BucketName}', f'arn:aws:s3:::{dataset2.S3BucketName}/*'],
+            },
+            {
+                'Sid': f'{IAM_S3_BUCKETS_STATEMENT_SID}KMS1',
+                'Effect': 'Allow',
+                'Action': ['kms:*'],
+                'Resource': [f'arn:aws:kms:{dataset2.region}:{dataset2.AwsAccountId}:key/kms-key'],
+            },
+        ],
+    }
+
+    mocker.patch('dataall.base.aws.iam.IAM.get_managed_policy_default_version', return_value=('v1', policy))
+
+    # When policy does not exist
+    mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.check_if_policy_exists',
+        return_value=True,
+    )
+
+    iam_update_role_policy_mock_1 = mocker.patch(
+        'dataall.modules.s3_datasets_shares.services.s3_share_managed_policy_service.S3SharePolicyService.get_policies_unattached_to_role',
+        return_value=['policy-0'],
+    )
+    mocker.patch('dataall.base.aws.iam.IAM.list_policy_names_by_policy_pattern', return_value=['policy-0'])
+
+    mocker.patch('dataall.base.aws.iam.IAM.get_attached_managed_policies_to_role', return_value=[])
+
+    kms_client = mock_kms_client(mocker)
+    kms_client().get_key_id.return_value = 'kms-key'
+    # When
+    share2_consumption_role_manager.check_s3_iam_access()
+    # Then
+    iam_update_role_policy_mock_1.assert_called_once()
+    assert (len(share2_consumption_role_manager.bucket_errors)) == 1
+    assert 'IAM Policy attached Target Resource' in share2_consumption_role_manager.bucket_errors[0]
 
 
 def test_check_s3_iam_access_missing_policy_statement(mocker, dataset2, share2_manager):

--- a/tests/permissions.py
+++ b/tests/permissions.py
@@ -1103,6 +1103,9 @@ EXPECTED_RESOLVERS: Mapping[str, TestData] = {
     field_id('ShareObject', 'userRoleForShareObject'): TestData(
         resource_ignore=IgnoreReason.USERROLEINRESOURCE, tenant_ignore=IgnoreReason.NOTREQUIRED
     ),
+    field_id('ShareObject', 'policyManagement'): TestData(
+        resource_ignore=IgnoreReason.USERLIMITED, tenant_ignore=IgnoreReason.NOTREQUIRED
+    ),
     field_id('SharedDatabaseTableItem', 'sharedGlueDatabaseName'): TestData(
         resource_ignore=IgnoreReason.INTRAMODULE, tenant_ignore=IgnoreReason.NOTREQUIRED
     ),

--- a/tests_new/integration_tests/core/environment/queries.py
+++ b/tests_new/integration_tests/core/environment/queries.py
@@ -1,3 +1,5 @@
+from dataall.core.environment.db.environment_enums import PolicyManagementOptions
+
 ENV_TYPE = """
 environmentUri
 created
@@ -210,7 +212,9 @@ def remove_group_from_env(client, env_uri, group_uri):
     return response.data.removeGroupFromEnvironment
 
 
-def add_consumption_role(client, env_uri, group_uri, consumption_role_name, iam_role_arn, is_managed=True):
+def add_consumption_role(
+    client, env_uri, group_uri, consumption_role_name, iam_role_arn, is_managed=PolicyManagementOptions.FULLY_MANAGED
+):
     query = {
         'operationName': 'addConsumptionRoleToEnvironment',
         'variables': {

--- a/tests_new/integration_tests/modules/shares/s3_datasets_shares/global_conftest.py
+++ b/tests_new/integration_tests/modules/shares/s3_datasets_shares/global_conftest.py
@@ -50,13 +50,7 @@ def create_consumption_role(client, group, environment, environment_client, iam_
         iam_role_name,
         f'dataall-integration-tests-role-{environment.region}',
     )
-    return add_consumption_role(
-        client,
-        environment.environmentUri,
-        group,
-        cons_role_name,
-        role['Role']['Arn'],
-    )
+    return add_consumption_role(client, environment.environmentUri, group, cons_role_name, role['Role']['Arn'])
 
 
 # --------------SESSION PARAM FIXTURES----------------------------


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail

- Introduces the new policy management options as described in this GH issue ( https://github.com/data-dot-all/dataall/issues/1613 )

### Relates
- https://github.com/data-dot-all/dataall/issues/1613

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? Yes
  - Is the input sanitized? Yes
  - What precautions are you taking before deserializing the data you consume? Using gql wrapper defined in data.all
  - Is injection prevented by parametrizing queries? yes
  - Have you ensured no `eval` or similar functions are used? Yes
- Does this PR introduce any functionality or component that requires authorization? N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?  No
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
