### PR TITLE
[Bugfix ] GH-1770 bug fix in v2.6.2

### DIFF
--- a/backend/dataall/modules/s3_datasets/cdk/assets/glueprofilingjob/glue_script.py
+++ b/backend/dataall/modules/s3_datasets/cdk/assets/glueprofilingjob/glue_script.py
@@ -100,7 +100,7 @@ def run_table_profiling(
         logger.debug('Profiling table for %s %s ', database, table)
         logger.debug('using %s', database)
         spark.sql('use `{}`'.format(database))
-        df = spark.sql('select * from {}'.format(table))
+        df = spark.sql('select * from `{}`'.format(table))
         total = df.count()
         logger.debug('Retrieved count for %s %s', table, total)
 

--- a/backend/dataall/modules/s3_datasets_shares/api/resolvers.py
+++ b/backend/dataall/modules/s3_datasets_shares/api/resolvers.py
@@ -68,4 +68,4 @@ def list_shared_databases_tables_with_env_group(context: Context, source, enviro
 
 
 def resolve_shared_db_name(context: Context, source, **kwargs):
-    return S3ShareService.resolve_shared_db_name(source.GlueDatabaseName, source.shareUri)
+    return S3ShareService.resolve_shared_db_name(source.GlueDatabaseName, source.shareUri, source.targetEnvAwsAccountId, source.targetEnvRegion)

--- a/frontend/src/modules/Tables/services/getDatasetTable.js
+++ b/frontend/src/modules/Tables/services/getDatasetTable.js
@@ -13,17 +13,9 @@ export const getDatasetTable = (tableUri) => ({
           userRoleForDataset
           SamlAdminGroupName
           owner
-          organization {
-            label
-          }
           environment {
             label
             region
-            subscriptionsEnabled
-            subscriptionsProducersTopicImported
-            subscriptionsConsumersTopicImported
-            subscriptionsConsumersTopicName
-            subscriptionsProducersTopicName
           }
         }
         datasetUri


### PR DESCRIPTION
### Feature or Bugfix

-Bugfix

### Detail

- Updated glue script to include \`\` in  glue_script.py
- Removed query items which are not present in the output type definition and corrected resolvers 

### Relates
- https://github.com/data-dot-all/dataall/issues/1770

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)? N/A
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization? N/A
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features? N/A
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users? N/A
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
