### PR TITLE
Fix/custom auth 500

### DIFF
--- a/deploy/custom_resources/custom_authorizer/auth_services.py
+++ b/deploy/custom_resources/custom_authorizer/auth_services.py
@@ -24,7 +24,9 @@ class AuthServices:
 
     @staticmethod
     def generate_deny_policy(incoming_resource_str: str):
-        return AuthServices.generate_policy({'sub': None, EMAIL_CLAIM: None}, 'Deny', incoming_resource_str)
+        return AuthServices.generate_policy(
+            {'sub': None, EMAIL_CLAIM: None, USER_ID_CLAIM: None}, 'Deny', incoming_resource_str
+        )
 
     # Generates Policy document containing policy to allow the API invocation for allowed API Endpoints
     # Also attaches the claims which are present in the token

--- a/deploy/custom_resources/custom_authorizer/auth_services.py
+++ b/deploy/custom_resources/custom_authorizer/auth_services.py
@@ -1,7 +1,14 @@
 import json
+import logging
 import os
 
+EMAIL_CLAIM = os.getenv('email')
+USER_ID_CLAIM = os.getenv('user_id')
+
 ALLOWED_API_RESOURCE_NAMES = ['graphql', 'search']
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
 
 
 class AuthServices:
@@ -15,6 +22,10 @@ class AuthServices:
         resource_list[5] = '/'.join(api_gateway_arn)
         return ':'.join(resource_list)
 
+    @staticmethod
+    def generate_deny_policy(incoming_resource_str: str):
+        return AuthServices.generate_policy({'sub': None, EMAIL_CLAIM: None}, 'Deny', incoming_resource_str)
+
     # Generates Policy document containing policy to allow the API invocation for allowed API Endpoints
     # Also attaches the claims which are present in the token
     # Policy document and principal_id are two required items when using custom authorizer lamda in API gateway
@@ -24,7 +35,7 @@ class AuthServices:
         principal_id = verified_claims['sub']
 
         # Attach a claim called 'email'. This is needed by Api Handler
-        verified_claims['email'] = verified_claims[os.getenv('email')]
+        verified_claims['email'] = verified_claims[EMAIL_CLAIM]
 
         for claim_name, claim_value in verified_claims.items():
             if isinstance(claim_value, list):
@@ -34,7 +45,7 @@ class AuthServices:
 
         context.update(
             {
-                'user_id': verified_claims[os.getenv('user_id')],
+                'user_id': verified_claims[USER_ID_CLAIM],
                 'custom_authorizer': 'true',
             }
         )
@@ -55,5 +66,7 @@ class AuthServices:
             'policyDocument': {'Version': '2012-10-17', 'Statement': policy_statement},
             'context': context,
         }
+
+        logger.debug(f'Generated policy is {json.dumps(policy)}')
 
         return policy


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
Currently when access is denied we raise exceptions which have 2 side effects
* APIGW returns 500 Internal Server Error to the user which is confusing
* Deny cache is not populated hence increasing the traffic that IdP is receiving

In this change we return an explicit Deny policy for all known scenarios and raise an exception otherwise.
The known scenarios include
* We receive 401 from Cognito which means invalid access token (unauthorized access)
* We receive 403 from Cognito which means throttling
* We fail to validate the jwt token returned by Cognito

### Relates
- <URL or Ticket>

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
