### PR TITLE
allow customization of waf rate limits and api gateway throttling limits

### DIFF
--- a/deploy/stacks/backend_stack.py
+++ b/deploy/stacks/backend_stack.py
@@ -62,6 +62,7 @@ class BackendStack(Stack):
         with_approval_tests=False,
         allowed_origins='*',
         log_retention_duration=None,
+        throttling_config=None,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -208,6 +209,7 @@ class BackendStack(Stack):
             custom_waf_rules=custom_waf_rules,
             allowed_origins=allowed_origins,
             log_retention_duration=log_retention_duration,
+            throttling_config=throttling_config,
             **kwargs,
         )
 

--- a/deploy/stacks/backend_stage.py
+++ b/deploy/stacks/backend_stage.py
@@ -39,6 +39,7 @@ class BackendStage(Stage):
         with_approval_tests=False,
         allowed_origins='*',
         log_retention_duration=None,
+        throttling_config=None,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -75,6 +76,7 @@ class BackendStage(Stage):
             with_approval_tests=with_approval_tests,
             allowed_origins=allowed_origins,
             log_retention_duration=log_retention_duration,
+            throttling_config=throttling_config,
             **kwargs,
         )
 

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -66,6 +66,7 @@ class LambdaApiStack(pyNestedClass):
         custom_auth=None,
         allowed_origins='*',
         log_retention_duration=None,
+        throttling_config=None,
         **kwargs,
     ):
         super().__init__(scope, id, **kwargs)
@@ -355,6 +356,7 @@ class LambdaApiStack(pyNestedClass):
             vpc,
             user_pool,
             custom_auth,
+            throttling_config,
         )
 
         self.create_sns_topic(
@@ -526,10 +528,11 @@ class LambdaApiStack(pyNestedClass):
         vpc,
         user_pool,
         custom_auth,
+        throttling_config,
     ):
         api_deploy_options = apigw.StageOptions(
-            throttling_rate_limit=10000,
-            throttling_burst_limit=5000,
+            throttling_rate_limit=throttling_config.get('global_rate_limit', 10000),
+            throttling_burst_limit=throttling_config.get('global_burst_limit', 5000),
             logging_level=apigw.MethodLoggingLevel.INFO,
             tracing_enabled=True,
             data_trace_enabled=False,

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -36,6 +36,9 @@ from .pyNestedStack import pyNestedClass
 from .solution_bundling import SolutionBundling
 from .waf_rules import get_waf_rules
 
+DEFAULT_API_RATE_LIMIT = 10000
+DEFAULT_API_BURST_LIMIT = 5000
+
 
 class LambdaApiStack(pyNestedClass):
     def __init__(
@@ -531,8 +534,8 @@ class LambdaApiStack(pyNestedClass):
         throttling_config,
     ):
         api_deploy_options = apigw.StageOptions(
-            throttling_rate_limit=throttling_config.get('global_rate_limit', 10000),
-            throttling_burst_limit=throttling_config.get('global_burst_limit', 5000),
+            throttling_rate_limit=throttling_config.get('global_rate_limit', DEFAULT_API_RATE_LIMIT),
+            throttling_burst_limit=throttling_config.get('global_burst_limit', DEFAULT_API_BURST_LIMIT),
             logging_level=apigw.MethodLoggingLevel.INFO,
             tracing_enabled=True,
             data_trace_enabled=False,

--- a/deploy/stacks/pipeline.py
+++ b/deploy/stacks/pipeline.py
@@ -681,6 +681,7 @@ class PipelineStack(Stack):
                 with_approval_tests=target_env.get('with_approval_tests', False),
                 allowed_origins=target_env.get('allowed_origins', '*'),
                 log_retention_duration=self.log_retention_duration,
+                throttling_config=target_env.get('throttling', {}),
             )
         )
         return backend_stage

--- a/deploy/stacks/waf_rules.py
+++ b/deploy/stacks/waf_rules.py
@@ -163,7 +163,11 @@ def get_waf_rules(envname, name, custom_waf_rules=None, ip_set_regional=None):
             wafv2.CfnWebACL.RuleProperty(
                 name=f'{name}RateLimit',
                 statement=wafv2.CfnWebACL.StatementProperty(
-                    rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(aggregate_key_type='IP', limit=1000)
+                    rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(
+                        aggregate_key_type='IP',
+                        limit=(custom_waf_rules or {}).get('rate_limit', 1000),
+                        evaluation_window_sec=(custom_waf_rules or {}).get('rate_limit_window'),
+                    )
                 ),
                 action=wafv2.CfnWebACL.RuleActionProperty(block={}),
                 visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(

--- a/deploy/stacks/waf_rules.py
+++ b/deploy/stacks/waf_rules.py
@@ -1,5 +1,7 @@
 from aws_cdk import aws_wafv2 as wafv2
 
+DEFAULT_WAF_RATE_LIMIT = 1000
+
 
 def get_waf_rules(envname, name, custom_waf_rules=None, ip_set_regional=None):
     waf_rules = []
@@ -165,7 +167,7 @@ def get_waf_rules(envname, name, custom_waf_rules=None, ip_set_regional=None):
                 statement=wafv2.CfnWebACL.StatementProperty(
                     rate_based_statement=wafv2.CfnWebACL.RateBasedStatementProperty(
                         aggregate_key_type='IP',
-                        limit=(custom_waf_rules or {}).get('rate_limit', 1000),
+                        limit=(custom_waf_rules or {}).get('rate_limit', DEFAULT_WAF_RATE_LIMIT),
                         evaluation_window_sec=(custom_waf_rules or {}).get('rate_limit_window'),
                     )
                 ),

--- a/documentation/userguide/docs/security.md
+++ b/documentation/userguide/docs/security.md
@@ -38,13 +38,20 @@ existing SAML 2.0–based SSO authentication systems.
 
 ### **AWS Web Application Firewall (WAF)**
 Data.all supports the opportunity to add custom rules to AWS WAF. These rules are set in `cdk.json` at the root level of the repository.
-As a custom rules (property `custom_waf_rules`) customer can set two allow lists:
+As a custom rules (property `custom_waf_rules`) customer can the following:
 * The Geo match allow-list (property `allowed_geo_list`) is an array of two-character country codes that you want to match against. 
 If this property is specified, WAF will block web requests from all other countries, otherwise requests from all countries will be allowed.
 * The IP match allow-list (property `allowed_ip_list`) is used to specify zero or more IP addresses or blocks of IP addresses. 
 If this property is specified, WAF will block web requests from all other IP addresses, otherwise requests from all IP addresses will be allowed.
+* The IP based rate limit (`rate_limit`, default 1000) and the rate limit evaluation window (`rate_limit_window`, default 300) in seconds with valid values 60,120,300 
 
-Example of custom WAF rules setting:
+### **ApiGateway Global Throttling**
+
+Data.all supports setting custom global throttling limits (using the token bucket algorithm) in ApiGateway via `cdk.json` with the following parameters
+* `global_rate_limit` (default 10000)  the target maximum number of requests per second that API Gateway will fulfill before returning `429 Too Many Requests`
+* `global_burst_limit` (default 5000) the target maximum number of concurrent request submissions that API Gateway will fulfill before returning `429 Too Many Requests`
+
+Example of `cdk.json` which is setting custom WAF rules and global throttling:
 ```json
 {
   "app": "python ./deploy/app.py",
@@ -55,22 +62,28 @@ Example of custom WAF rules setting:
     "@aws-cdk/core:stackRelativeExports": false,
     "tooling_region": "eu-west-1",
     "DeploymentEnvironments": [
-        {
-            "envname": "dev",
-            "account": "000000000000",
-            "region": "eu-west-1",
-            "custom_waf_rules": {
-                "allowed_geo_list": [
-                  "US",
-                  "CN"
-                ],
-                "allowed_ip_list": [
-                  "192.0.2.44/32",
-                  "192.0.2.0/24",
-                  "192.0.0.0/16"
-                ]
-              }
+      {
+        "envname": "dev",
+        "account": "000000000000",
+        "region": "eu-west-1",
+        "custom_waf_rules": {
+          "allowed_geo_list": [
+            "US",
+            "CN"
+          ],
+          "allowed_ip_list": [
+            "192.0.2.44/32",
+            "192.0.2.0/24",
+            "192.0.0.0/16"
+          ],
+          "rate_limit": 1000,
+          "rate_limit_window": 500
+        },
+        "throttling": {
+          "global_rate_limit": 10000,
+          "global_burst_limit": 5000
         }
+      }
     ]
   }
 }


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
Due to the diverse nature of data.all deployments it is hard to come up with rate limites that will fit everyone. As such we are providing configuration parameters that customers can tweak to make their deployments more secure.


### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
