### PR TITLE
change all lambdas to structured logging

### DIFF
--- a/deploy/stacks/cloudfront.py
+++ b/deploy/stacks/cloudfront.py
@@ -336,6 +336,7 @@ class CloudfrontDistro(pyNestedClass):
                 ),
             ),
             runtime=_lambda.Runtime.NODEJS_18_X,
+            logging_format=_lambda.LoggingFormat.JSON,
         )
 
         http_header_func_version = http_header_func.current_version

--- a/deploy/stacks/cognito.py
+++ b/deploy/stacks/cognito.py
@@ -414,6 +414,7 @@ class IdpStack(pyNestedClass):
             handler='cognito_users.handler',
             execute_after=[self.client],
             execute_on_handler_change=True,
+            logging_format=_lambda.LoggingFormat.JSON,
         )
 
         CfnOutput(

--- a/deploy/stacks/frontend_cognito_config.py
+++ b/deploy/stacks/frontend_cognito_config.py
@@ -116,4 +116,5 @@ class FrontendCognitoConfig(pyNestedClass):
             handler='cognito_urls.handler',
             execute_after=execute_after,
             execute_on_handler_change=True,
+            logging_format=_lambda.LoggingFormat.JSON,
         )

--- a/deploy/stacks/lambda_api.py
+++ b/deploy/stacks/lambda_api.py
@@ -136,6 +136,8 @@ class LambdaApiStack(pyNestedClass):
             dead_letter_queue=self.esproxy_dlq,
             on_failure=lambda_destination.SqsDestination(self.esproxy_dlq),
             tracing=_lambda.Tracing.ACTIVE,
+            logging_format=_lambda.LoggingFormat.JSON,
+            application_log_level_v2=getattr(_lambda.ApplicationLogLevel, log_level),
         )
 
         self.api_handler_dlq = self.set_dlq(f'{resource_prefix}-{envname}-graphql-dlq')
@@ -177,6 +179,8 @@ class LambdaApiStack(pyNestedClass):
             dead_letter_queue=self.api_handler_dlq,
             on_failure=lambda_destination.SqsDestination(self.api_handler_dlq),
             tracing=_lambda.Tracing.ACTIVE,
+            logging_format=_lambda.LoggingFormat.JSON,
+            application_log_level_v2=getattr(_lambda.ApplicationLogLevel, log_level),
         )
 
         self.aws_handler_dlq = self.set_dlq(f'{resource_prefix}-{envname}-awsworker-dlq')
@@ -211,6 +215,8 @@ class LambdaApiStack(pyNestedClass):
             dead_letter_queue=self.aws_handler_dlq,
             on_failure=lambda_destination.SqsDestination(self.aws_handler_dlq),
             tracing=_lambda.Tracing.ACTIVE,
+            logging_format=_lambda.LoggingFormat.JSON,
+            application_log_level_v2=getattr(_lambda.ApplicationLogLevel, log_level),
         )
         self.aws_handler.add_event_source(
             lambda_event_sources.SqsEventSource(
@@ -306,6 +312,8 @@ class LambdaApiStack(pyNestedClass):
             security_groups=[authorizer_fn_sg],
             runtime=runtime,
             layers=[cryptography_layer],
+            logging_format=_lambda.LoggingFormat.JSON,
+            application_log_level_v2=getattr(_lambda.ApplicationLogLevel, log_level),
         )
 
         # Add NAT Connectivity For Custom Authorizer Lambda

--- a/deploy/stacks/trigger_function_stack.py
+++ b/deploy/stacks/trigger_function_stack.py
@@ -61,6 +61,7 @@ class TriggerFunctionStack(pyNestedClass):
             handler=_lambda.Handler.FROM_IMAGE,
             execute_after=execute_after,
             execute_on_handler_change=True,
+            logging_format=_lambda.LoggingFormat.JSON,
         )
 
         for connectable in connectables:


### PR DESCRIPTION
### Feature or Bugfix
Feature

### Detail
Currently when strings that contain `\n` are logged they appear as multiple entries in CloudWatch. This is a restriction arising from using a Docker runtime which is [by design and not going to change](https://github.com/aws/aws-lambda-dotnet/issues/1662).

Additionally structured logs are easier to discover and query via AWS's native tools.

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
