### PR TITLE
create a new access logs bucket instead of importing

### DIFF
--- a/.checkov.baseline
+++ b/.checkov.baseline
@@ -374,6 +374,12 @@
                         "CKV_AWS_116",
                         "CKV_AWS_117"
                     ]
+                },
+                {
+                    "resource": "AWS::S3::Bucket.dataalldevcloudfrontaccesslogsCAF85B96",
+                    "check_ids": [
+                        "CKV_AWS_18"
+                    ]
                 }
             ]
         },

--- a/deploy/stacks/cloudfront.py
+++ b/deploy/stacks/cloudfront.py
@@ -42,10 +42,15 @@ class CloudfrontDistro(pyNestedClass):
     ):
         super().__init__(scope, id, **kwargs)
 
-        self.server_access_logs_bucket = s3.Bucket.from_bucket_name(
+        self.server_access_logs_bucket = s3.Bucket(
             self,
-            'AccessLogsBucket',
-            Fn.import_value(f'{resource_prefix}-{envname}-access-logs-bucket'),
+            f'{resource_prefix}-{envname}-cloudfront-access-logs',
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            enforce_ssl=True,
+            removal_policy=RemovalPolicy.DESTROY,
+            versioned=True,
+            auto_delete_objects=True,
         )
 
         """


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
`Fn.import_value` can only import exports from the same region hence if frontend and backend are in different regions the deployments are failing

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
