### PR TITLE
pytest early exit and integ test consumption role improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test:
 
 integration-tests: upgrade-pip install-integration-tests
 	export PYTHONPATH=./backend:/./tests_new && \
-	python -m pytest -v -ra tests_new/integration_tests/ \
+	python -m pytest -x -v -ra tests_new/integration_tests/ \
 		--junitxml=reports/integration_tests.xml
 
 coverage: upgrade-pip install-backend install-cdkproxy install-tests

--- a/tests_new/integration_tests/aws_clients/iam.py
+++ b/tests_new/integration_tests/aws_clients/iam.py
@@ -27,16 +27,7 @@ class IAMClient:
         self._client.delete_role(RoleName=role_name)
 
     def create_role(self, account_id, role_name, test_role_name):
-        policy_doc = {
-            'Version': '2012-10-17',
-            'Statement': [
-                {
-                    'Effect': 'Allow',
-                    'Principal': {'AWS': [f'arn:aws:iam::{account_id}:role/{test_role_name}']},
-                    'Action': 'sts:AssumeRole',
-                }
-            ],
-        }
+        policy_doc = self._get_assume_role_policy_doc(account_id, test_role_name)
         role = self._client.create_role(
             RoleName=role_name,
             AssumeRolePolicyDocument=json.dumps(policy_doc),
@@ -46,9 +37,15 @@ class IAMClient:
 
     def get_consumption_role(self, account_id, role_name, test_role_name):
         role = self.get_role(role_name)
-        if role is None:
+        if role:  # if role exists make sure it is using the correct policies
+            policy_doc = self._get_assume_role_policy_doc(account_id, test_role_name)
+            self._client.update_assume_role_policy(
+                RoleName=role_name,
+                PolicyDocument=json.dumps(policy_doc),
+            )
+        else:
             role = self.create_role(account_id, role_name, test_role_name)
-            self.put_consumption_role_policy(role_name)
+        self.put_consumption_role_policy(role_name)
         return role
 
     def delete_policy(self, role_name, policy_name):
@@ -79,3 +76,16 @@ class IAMClient:
                                         ]
                                     }""",
         )
+
+    def _get_assume_role_policy_doc(self, account_id, principal_role_name):
+        policy_doc = {
+            'Version': '2012-10-17',
+            'Statement': [
+                {
+                    'Effect': 'Allow',
+                    'Principal': {'AWS': [f'arn:aws:iam::{account_id}:role/{principal_role_name}']},
+                    'Action': 'sts:AssumeRole',
+                }
+            ],
+        }
+        return policy_doc


### PR DESCRIPTION
### Feature or Bugfix
- Feature

### Detail
-  pytest early exit, it will make manually deleting resources easier
-  override integ tests consumption role policies in case it exists to make sure it's always in a good state (mainly useful for persistent environments) 