### PR TITLE
Fix: Scope CDK execution policy IAM permissions to prevent privilege escalation (#1614)

### DIFF
--- a/deploy/cdk_exec_policy/cdkExecPolicy.yaml
+++ b/deploy/cdk_exec_policy/cdkExecPolicy.yaml
@@ -103,8 +103,12 @@ Resources:
               - 'iam:UpdateAssumeRolePolicy'
               - 'iam:PutRolePolicy'
             Resource:
-              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*'
-              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${EnvironmentResourcePrefix}*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${EnvironmentResourcePrefix}*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/cdk-*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/dataall-*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/dataall-*'
 
           - Sid: IAMTwo
             Effect: Allow


### PR DESCRIPTION
## Summary
Enhanced the data.all CDK execution policy to prevent privilege escalation attacks by scoping IAM permissions to specific resource patterns instead of using wildcard access.

## Problem
The original policy allowed access to any role or policy in the account using wildcard resources (`arn:aws:iam::account:policy/*` and `arn:aws:iam::account:role/*`). This meant that anyone with CloudFormation deployment access could potentially create roles like `AttackerAdminRole` and attach powerful policies such as `AdministratorAccess` to escalate privileges.

## Solution
IAM permissions are now restricted to specific resource prefixes:
- Environment-specific resources (`${EnvironmentResourcePrefix}*`)
- CDK resources (`cdk-*`) 
- data.all application resources (`dataall-*`)

## Impact
- Blocks malicious CloudFormation templates from creating unauthorized administrative resources
- Preserves all existing data.all functionality (environment creation, dataset operations, service deployments)
- Implements least privilege access principles
- Provides defense-in-depth protection against infrastructure-based privilege escalation
- Zero operational impact

## Testing
- [ ] Verified existing data.all operations continue to work
- [ ] Confirmed restricted IAM permissions block unauthorized resource creation

Fixes #1614
