### PR TITLE
[Gh-1863] Support for editing KMS keys 

### DIFF
--- a/backend/dataall/modules/s3_datasets/db/dataset_bucket_repositories.py
+++ b/backend/dataall/modules/s3_datasets/db/dataset_bucket_repositories.py
@@ -35,3 +35,7 @@ class DatasetBucketRepository:
     @staticmethod
     def get_dataset_bucket_by_name(session, bucket_name) -> DatasetBucket:
         return session.query(DatasetBucket).filter(DatasetBucket.S3BucketName == bucket_name).first()
+
+    @staticmethod
+    def get_dataset_bucket_for_dataset(session, datasetUri) -> DatasetBucket:
+        return session.query(DatasetBucket).filter(DatasetBucket.datasetUri == datasetUri).first()

--- a/backend/dataall/modules/s3_datasets/services/dataset_service.py
+++ b/backend/dataall/modules/s3_datasets/services/dataset_service.py
@@ -311,10 +311,11 @@ class DatasetService:
                     DatasetService.validate_kms_key(dataset, data.get('KmsAlias'))
                     new_kms_alias = 'SSE-S3' if (data.get('KmsAlias') == '' or data.get('KmsAlias') == 'SSE-S3') else data.get('KmsAlias')
                     dataset.KmsAlias = new_kms_alias
-                    dataset.importedKmsKey = False if data.get('KmsAlias') == '' else True
+                    dataset.importedKmsKey = False if ( data.get('KmsAlias') == '' or data.get('KmsAlias') == 'SSE-S3' ) else True
                     # Update the dataset bucket as well
                     dataset_bucket = DatasetBucketRepository.get_dataset_bucket_for_dataset(session, dataset.datasetUri)
                     dataset_bucket.KmsAlias = new_kms_alias
+                    dataset_bucket.importedKmsKey = False if ( data.get('KmsAlias') == '' or data.get('KmsAlias') == 'SSE-S3' ) else True
 
                 if data.get('stewards') and data.get('stewards') != dataset.stewards:
                     if data.get('stewards') != dataset.SamlAdminGroupName:

--- a/backend/dataall/modules/s3_datasets/services/dataset_service.py
+++ b/backend/dataall/modules/s3_datasets/services/dataset_service.py
@@ -130,51 +130,54 @@ class DatasetService:
                     action=IMPORT_DATASET,
                     message=f'Dataset with bucket {dataset.S3BucketName} already exists',
                 )
-
         kms_alias = dataset.KmsAlias
+        DatasetService.validate_kms_key(dataset, kms_alias)
+
+        return True
+
+    @staticmethod
+    def validate_kms_key(dataset, kms_alias_for_validation):
 
         s3_encryption, kms_id_type, kms_id = S3DatasetClient(dataset).get_bucket_encryption()
-        if kms_alias not in [None, 'Undefined', '', 'SSE-S3']:  # user-defined KMS encryption
+        if kms_alias_for_validation not in [None, 'Undefined', '', 'SSE-S3']:  # user-defined KMS encryption
             if s3_encryption == 'AES256':
                 raise exceptions.InvalidInput(
                     param_name='KmsAlias',
-                    param_value=dataset.KmsAlias,
-                    constraint=f'empty, Bucket {dataset.S3BucketName} is encrypted with AWS managed key (SSE-S3). KmsAlias {kms_alias} should NOT be provided as input parameter.',
+                    param_value=kms_alias_for_validation,
+                    constraint=f'empty, Bucket {dataset.S3BucketName} is encrypted with AWS managed key (SSE-S3). KmsAlias {kms_alias_for_validation} should NOT be provided as input parameter.',
                 )
             NamingConventionService(
                 target_uri=dataset.datasetUri,
-                target_label=kms_alias,
+                target_label=kms_alias_for_validation,
                 pattern=NamingConventionPattern.KMS,
             ).validate_imported_name()
 
             key_exists = KmsClient(account_id=dataset.AwsAccountId, region=dataset.region).check_key_exists(
-                key_alias=f'alias/{kms_alias}'
+                key_alias=f'alias/{kms_alias_for_validation}'
             )
             if not key_exists:
                 raise exceptions.AWSResourceNotFound(
                     action=IMPORT_DATASET,
-                    message=f'KMS key with alias={kms_alias} cannot be found - Please check if KMS Key Alias exists in account {dataset.AwsAccountId}',
+                    message=f'KMS key with alias={kms_alias_for_validation} cannot be found - Please check if KMS Key Alias exists in account {dataset.AwsAccountId}',
                 )
 
-            key_matches = kms_id == kms_alias
+            key_matches = kms_id == kms_alias_for_validation
             if kms_id_type == 'key':
                 key_id = KmsClient(account_id=dataset.AwsAccountId, region=dataset.region).get_key_id(
-                    key_alias=f'alias/{kms_alias}'
+                    key_alias=f'alias/{kms_alias_for_validation}'
                 )
                 key_matches = key_id == kms_id
 
             if not key_matches:
                 raise exceptions.InvalidInput(
                     param_name='KmsAlias',
-                    param_value=dataset.KmsAlias,
+                    param_value=kms_alias_for_validation,
                     constraint=f'the KMS Alias of the KMS key used to encrypt the Bucket {dataset.S3BucketName}. Provide the correct KMS Alias as input parameter.',
                 )
 
         else:  # user-defined S3 encryption
             if s3_encryption != 'AES256':
                 raise exceptions.RequiredParameter(param_name='KmsAlias')
-
-        return True
 
     @staticmethod
     @TenantPolicyService.has_tenant_permission(MANAGE_DATASETS)
@@ -304,8 +307,14 @@ class DatasetService:
                 )
 
                 if data.get('KmsAlias') not in ['Undefined'] and data.get('KmsAlias') != dataset.KmsAlias:
-                    dataset.KmsAlias = 'SSE-S3' if data.get('KmsAlias') == '' else data.get('KmsAlias')
+                    log.info(f"Validating the kms key with alias: {data.get('KmsAlias')}")
+                    DatasetService.validate_kms_key(dataset, data.get('KmsAlias'))
+                    new_kms_alias = 'SSE-S3' if (data.get('KmsAlias') == '' or data.get('KmsAlias') == 'SSE-S3') else data.get('KmsAlias')
+                    dataset.KmsAlias = new_kms_alias
                     dataset.importedKmsKey = False if data.get('KmsAlias') == '' else True
+                    # Update the dataset bucket as well
+                    dataset_bucket = DatasetBucketRepository.get_dataset_bucket_for_dataset(session, dataset.datasetUri)
+                    dataset_bucket.KmsAlias = new_kms_alias
 
                 if data.get('stewards') and data.get('stewards') != dataset.stewards:
                     if data.get('stewards') != dataset.SamlAdminGroupName:

--- a/frontend/src/modules/S3_Datasets/views/DatasetEditForm.js
+++ b/frontend/src/modules/S3_Datasets/views/DatasetEditForm.js
@@ -737,6 +737,34 @@ const DatasetEditForm = (props) => {
                             </CardContent>
                           )}
                       </Card>
+                      {dataset.imported && (
+                        <Card sx={{ mb: 3 }}>
+                          <CardHeader title="KMS Configuration" />
+                          <CardContent>
+                            <TextField
+                              error={Boolean(
+                                touched.KmsAlias && errors.KmsAlias
+                              )}
+                              fullWidth
+                              helperText={touched.KmsAlias && errors.KmsAlias}
+                              label="Amazon KMS key Alias"
+                              name="KmsAlias"
+                              onBlur={handleBlur}
+                              onChange={handleChange}
+                              value={values.KmsAlias}
+                              variant="outlined"
+                              placeholder="Enter KMS key alias (if SSE-KMS encryption is used)"
+                            />
+                            <Box sx={{ mt: 2 }}>
+                              <Typography variant="body2" color="textSecondary">
+                                <strong>Note:</strong> If S3 bucket doesn't have
+                                a KMS key associated then put 'SSE-S3',
+                                otherwise put the appropriate KMS alias.
+                              </Typography>
+                            </Box>
+                          </CardContent>
+                        </Card>
+                      )}
                       <Card>
                         <CardHeader title="Governance" />
                         <CardContent>

--- a/tests/modules/s3_datasets/test_dataset.py
+++ b/tests/modules/s3_datasets/test_dataset.py
@@ -114,6 +114,9 @@ def test_list_datasets(client, dataset1, group):
 
 
 def test_update_dataset(dataset1, client, group, group2, module_mocker):
+    # Mock the validate_kms_key function to return True
+    module_mocker.patch('dataall.modules.s3_datasets.services.dataset_service.DatasetService.validate_kms_key', return_value=True)
+    
     response = client.query(
         """
         mutation UpdateDataset($datasetUri:String!,$input:ModifyDatasetInput){
@@ -587,7 +590,11 @@ def test_create_dataset_with_expiration_setting(client, env_fixture, org_fixture
     assert response.data.createDataset.expiryMaxDuration == 3
 
 
-def test_update_dataset_with_expiration_setting_changes(dataset2, client, user, group, group2):
+def test_update_dataset_with_expiration_setting_changes(dataset2, client, user, group, group2, module_mocker):
+    # Mock the validate_kms_key function to return True
+    module_mocker.patch('dataall.modules.s3_datasets.services.dataset_service.DatasetService.validate_kms_key',
+                        return_value=True)
+
     assert dataset2.enableExpiration == False
     assert dataset2.expirySetting == None
     assert dataset2.expiryMinDuration == None

--- a/tests/modules/s3_datasets/test_dataset.py
+++ b/tests/modules/s3_datasets/test_dataset.py
@@ -7,10 +7,11 @@ from dataall.base.config import config
 from dataall.core.environment.db.environment_models import Environment
 from dataall.core.organizations.db.organization_models import Organization
 from dataall.modules.s3_datasets.db.dataset_repositories import DatasetRepository
-from dataall.modules.s3_datasets.db.dataset_models import DatasetStorageLocation, DatasetTable, S3Dataset
+from dataall.modules.s3_datasets.db.dataset_models import DatasetStorageLocation, DatasetTable, S3Dataset, DatasetBucket
 from dataall.modules.datasets_base.db.dataset_models import DatasetBase
 from dataall.core.resource_lock.db.resource_lock_models import ResourceLock
 from tests.core.stacks.test_stack import update_stack_query
+from dataall.modules.s3_datasets.db.dataset_bucket_repositories import DatasetBucketRepository
 
 from dataall.modules.datasets_base.services.datasets_enums import ConfidentialityClassification
 
@@ -44,6 +45,22 @@ def dataset1(
     print(d)
     yield d
 
+@pytest.fixture(scope='function')
+def dataset3(
+    module_mocker,
+    org_fixture: Organization,
+    env_fixture: Environment,
+    dataset: typing.Callable,
+    group,
+) -> S3Dataset:
+    kms_client = MagicMock()
+    module_mocker.patch('dataall.modules.s3_datasets.services.dataset_service.KmsClient', kms_client)
+
+    kms_client().get_key_id.return_value = mocked_key_id
+
+    d = dataset(org=org_fixture, env=env_fixture, name='dataset1', owner=env_fixture.owner, group=group.name)
+    print(d)
+    yield d
 
 @pytest.fixture(scope='module')
 def dataset2(
@@ -746,3 +763,120 @@ def test_import_dataset_with_expiration_setting(org_fixture, env_fixture, datase
     assert response.data.importDataset.expirySetting == 'Monthly'
     assert response.data.importDataset.expiryMinDuration == 1
     assert response.data.importDataset.expiryMaxDuration == 3
+
+
+def test_update_dataset_kms_key_change_to_new_key(db, dataset3, client, group, module_mocker):
+    """Test updating a dataset's KMS key to a new key alias"""
+    # Mock the validate_kms_key function to return True
+    module_mocker.patch('dataall.modules.s3_datasets.services.dataset_service.DatasetService.validate_kms_key', return_value=True)
+    
+    # First, set an initial KMS alias for the dataset
+    with db.scoped_session() as session:
+        dataset = DatasetRepository.get_dataset_by_uri(session, dataset3.datasetUri)
+        initial_kms = 'initial-kms-key'
+        dataset.KmsAlias = initial_kms
+        dataset.importedKmsKey = True
+        session.commit()
+        
+        # Also update the bucket
+        dataset_bucket = DatasetBucketRepository.get_dataset_bucket_for_dataset(session, dataset3.datasetUri)
+        if dataset_bucket:
+            dataset_bucket.KmsAlias = initial_kms
+            session.commit()
+    
+    # Update dataset with new KMS alias
+    new_kms_key = 'new-key'
+    response = client.query(
+        """
+        mutation UpdateDataset($datasetUri:String!,$input:ModifyDatasetInput){
+            updateDataset(datasetUri:$datasetUri,input:$input){
+                datasetUri
+                label
+                restricted {
+                    KmsAlias
+                }
+            }
+        }
+        """,
+        username=dataset3.owner,
+        datasetUri=dataset3.datasetUri,
+        input={
+            'label': dataset3.label,
+            'KmsAlias': new_kms_key,
+        },
+        groups=[group.name],
+    )
+    
+    # Verify the GraphQL response
+    assert response.data.updateDataset.datasetUri == dataset3.datasetUri
+    assert response.data.updateDataset.restricted.KmsAlias == new_kms_key
+    
+    # Verify the dataset was updated in the database
+    with db.scoped_session() as session:
+        updated_dataset = DatasetRepository.get_dataset_by_uri(session, dataset3.datasetUri)
+        assert updated_dataset.KmsAlias == new_kms_key
+        assert updated_dataset.importedKmsKey == True  # Should be True for custom KMS key
+        
+        # Verify the dataset bucket was also updated
+        dataset_bucket = DatasetBucketRepository.get_dataset_bucket_for_dataset(session, dataset3.datasetUri)
+        assert dataset_bucket is not None
+        assert dataset_bucket.KmsAlias == new_kms_key
+        assert dataset_bucket.importedKmsKey == True
+
+
+def test_update_dataset_kms_key_change_to_sse_s3(db, dataset3, client, group, module_mocker):
+    """Test updating a dataset's KMS key to SSE-S3 (server-side encryption with S3 managed keys)"""
+    # Mock the validate_kms_key function to return True
+    module_mocker.patch('dataall.modules.s3_datasets.services.dataset_service.DatasetService.validate_kms_key', return_value=True)
+    
+    # First, set an initial KMS alias for the dataset
+    with db.scoped_session() as session:
+        dataset = DatasetRepository.get_dataset_by_uri(session, dataset3.datasetUri)
+        initial_kms = 'existing-kms-key'
+        dataset.KmsAlias = initial_kms
+        dataset.importedKmsKey = True
+        session.commit()
+        
+        # Also update the bucket
+        dataset_bucket = DatasetBucketRepository.get_dataset_bucket_for_dataset(session, dataset3.datasetUri)
+        if dataset_bucket:
+            dataset_bucket.KmsAlias = initial_kms
+            session.commit()
+    
+    # Update dataset to use SSE-S3 (by passing 'SSE-S3' as the alias)
+    response = client.query(
+        """
+        mutation UpdateDataset($datasetUri:String!,$input:ModifyDatasetInput){
+            updateDataset(datasetUri:$datasetUri,input:$input){
+                datasetUri
+                label
+                restricted {
+                    KmsAlias
+                }
+            }
+        }
+        """,
+        username=dataset3.owner,
+        datasetUri=dataset3.datasetUri,
+        input={
+            'label': dataset3.label,
+            'KmsAlias': 'SSE-S3',  # This should trigger SSE-S3 mode
+        },
+        groups=[group.name],
+    )
+    
+    # Verify the GraphQL response
+    assert response.data.updateDataset.datasetUri == dataset3.datasetUri
+    assert response.data.updateDataset.restricted.KmsAlias == 'SSE-S3'
+    
+    # Verify the dataset was updated in the database
+    with db.scoped_session() as session:
+        updated_dataset = DatasetRepository.get_dataset_by_uri(session, dataset3.datasetUri)
+        assert updated_dataset.KmsAlias == 'SSE-S3'
+        assert updated_dataset.importedKmsKey == False  # Should be False for SSE-S3
+        
+        # Verify the dataset bucket was also updated
+        dataset_bucket = DatasetBucketRepository.get_dataset_bucket_for_dataset(session, dataset3.datasetUri)
+        assert dataset_bucket is not None
+        assert dataset_bucket.KmsAlias == 'SSE-S3'
+        assert dataset_bucket.importedKmsKey == False  # Should be False for SSE-S3

--- a/tests/modules/s3_datasets/test_dataset_glossary.py
+++ b/tests/modules/s3_datasets/test_dataset_glossary.py
@@ -26,7 +26,11 @@ def _columns(db, dataset_fixture, table_fixture) -> List[DatasetTableColumn]:
     yield cols
 
 
-def test_dataset_term_link_approval(db, client, t1, dataset_fixture, user, group):
+def test_dataset_term_link_approval(db, client, t1, dataset_fixture, user, group, module_mocker):
+    # Mock the validate_kms_key function to return True
+    module_mocker.patch('dataall.modules.s3_datasets.services.dataset_service.DatasetService.validate_kms_key',
+                        return_value=True)
+
     response = client.query(
         """
         mutation UpdateDataset($datasetUri:String!,$input:ModifyDatasetInput){


### PR DESCRIPTION
### Feature or Bugfix
- Feature


### Detail

- Added enhancement feature for editing the KMS keys

### Relates
- https://github.com/data-dot-all/dataall/issues/1863

### Security
Please answer the questions below briefly where applicable, or write `N/A`. Based on
[OWASP 10](https://owasp.org/Top10/en/).

- Does this PR introduce or modify any input fields or queries - this includes
fetching data from storage outside the application (e.g. a database, an S3 bucket)?
  - Is the input sanitized?
  - What precautions are you taking before deserializing the data you consume?
  - Is injection prevented by parametrizing queries?
  - Have you ensured no `eval` or similar functions are used?
- Does this PR introduce any functionality or component that requires authorization?
  - How have you ensured it respects the existing AuthN/AuthZ mechanisms?
  - Are you logging failed auth attempts?
- Are you using or adding any cryptographic features?
  - Do you use a standard proven implementations?
  - Are the used keys controlled by the customer? Where are they stored?
- Are you introducing any new policies/roles/users?
  - Have you used the least-privilege principle? How?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
