### PR TITLE
must be able to assume the default pivotRole which is prefixed with d…

### DIFF
--- a/deploy/cdk_exec_policy/cdkExecPolicy.yaml
+++ b/deploy/cdk_exec_policy/cdkExecPolicy.yaml
@@ -107,8 +107,8 @@ Resources:
               - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${EnvironmentResourcePrefix}*'
               - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-*'
               - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/cdk-*'
-              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/dataall-*'
-              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/dataall-*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/dataall*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/dataall*'
 
           - Sid: IAMTwo
             Effect: Allow


### PR DESCRIPTION
Fixing the below error, the default pivotRole doesn't have a dash
```
Failed to assume role arn:aws:iam::*:role/dataallPivotRole-cdk-eu-central-1 due to: An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::*:assumed-role/dataall-dev-graphql-role/dataall-dev-graphql is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::*:role/dataallPivotRole-cdk-eu-central-1
```

### Feature or Bugfix
- Bugfix
