### PR TITLE
fix pivot role ram policy

### DIFF
--- a/backend/dataall/modules/s3_datasets_shares/cdk/pivot_role_data_sharing_policy.py
+++ b/backend/dataall/modules/s3_datasets_shares/cdk/pivot_role_data_sharing_policy.py
@@ -103,9 +103,8 @@ class DataSharingPivotRole(PivotRoleStatementSet):
                     'ram:AcceptResourceShareInvitation',
                     'ram:RejectResourceShareInvitation',
                 ],
-                resources=[f'arn:aws:ram:*:{self.account}:resource-share-invitation/*'],  # Scoped
+                resources=['arn:aws:ram:*:*:resource-share-invitation/*'],  # Scoped
                 conditions={
-                    'StringEquals': {'aws:ResourceAccount': [f'{self.account}']},
                     'ForAllValues:StringLike': {
                         'ram:ResourceShareName': ['LakeFormation*', f'{self.env_resource_prefix}*']
                     },


### PR DESCRIPTION
### Feature or Bugfix
- Bugfix

### Detail
In #1853 the permission was restricted only to the requester account which is incorrect as we need the target account.
Given that pivotRole must support multiple target data sources this cannot be tied specifically to an account.

For the record this was causing integration tests to fail with the root cause...
```
[ERROR] Failed to accept RAM invitation arn:aws:ram:eu-central-1:DATASET_ACCOUNT:resource-share-invitation/*** due to An error occurred (AccessDeniedException) when calling the AcceptResourceShareInvitation operation: User: arn:aws:sts::CONSUMER_ACCOUNT:assumed-role/dataallPivotRole-cdk-eu-central-1/dataallPivotRole-cdk-eu-central-1 is not authorized to perform: ram:AcceptResourceShareInvitation on resource: arn:aws:ram:eu-central-1:DATASET_ACCOUNT:resource-share-invitation/*** because no identity-based policy allows the ram:AcceptResourceShareInvitation action
```